### PR TITLE
Refactor backup/restore: declarative per-role manifests

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -1,5 +1,10 @@
 ---
-# Restore all service volumes from NAS backup.
+# Restore service volumes from NAS backup.
+#
+# Uses backup_manifest declarations from each role's defaults/main.yml
+# as the single source of truth for volume names, methods, and NAS shares.
+# Special post-restore logic (pihole listsCache, entephoto DB restore) is
+# handled by per-role hooks in roles/<service>/tasks/restore.yml.
 #
 # Usage:
 #   ansible-playbook playbooks/restore.yml --limit homeserver
@@ -11,25 +16,15 @@
 #   ansible-playbook playbooks/restore.yml --limit homeserver --tags samba
 #   ansible-playbook playbooks/restore.yml --limit homeserver --tags entephoto
 #
+# Restore jukebox music (128 GB, opt-in):
+#   ansible-playbook playbooks/restore.yml --limit homeserver --tags jukebox-music
+#
 # Prerequisites:
 #   - Services must be deployed first (playbooks/site.yml) so users,
 #     volumes, and quadlets exist.
 #   - NAS must be reachable (backup_nas_hostname / backup_nas_ip from
 #     host_vars).
 #   - Backup tarballs / rsync mirrors must exist on the NAS.
-#
-# What it does per service:
-#   1. Mounts NAS backup shares (read-only).
-#   2. Finds the latest backup snapshot.
-#   3. Stops the service.
-#   4. Removes and recreates volumes.
-#   5. Imports tar backups / rsyncs data / restores pg_dump.
-#   6. Starts the service.
-#   7. Unmounts NAS shares.
-#
-# IMPORTANT for Ente Photos:
-#   The Postgres restore requires stopping museum + web while keeping
-#   postgres up, then DROP + CREATE database before loading the dump.
 
 - name: Restore service volumes from NAS backup
   hosts: homeservers
@@ -39,17 +34,37 @@
   vars:
     nas_host: "{{ backup_nas_hostname }}"
     nas_volume: "{{ backup_nas_volume }}"
-    nas_tar_mount: /mnt/restore/tar
-    nas_xchange_mount: /mnt/restore/xchange
-    nas_syncthing_mount: /mnt/restore/syncthing
-    nas_music_mount: /mnt/restore/music
-    nas_photos_mount: /mnt/restore/photos
+    restore_root: /mnt/restore
     nfs_opts: "ro,noatime,vers=4"
+    # Services that have backup manifests. Must match role directory names.
+    _restorable_services:
+      - pihole
+      - samba
+      - syncthing
+      - jukebox
+      - entephoto
 
-  tasks:
-    # ==================================================================
-    # NAS mount/unmount helpers
-    # ==================================================================
+  pre_tasks:
+    # Load each role's defaults so backup_manifest vars are available.
+    # The restore playbook runs standalone (not via site.yml), so role
+    # defaults are not automatically in scope.
+    - name: Load role defaults for restorable services
+      ansible.builtin.include_vars:
+        dir: "{{ playbook_dir }}/../roles/{{ item }}/defaults"
+        name: "_role_defaults_{{ item }}"
+      loop: "{{ _restorable_services }}"
+      tags: [always]
+
+    - name: Build restore manifests list
+      ansible.builtin.set_fact:
+        _restore_manifests: >-
+          {{ _restore_manifests | default([]) +
+             [lookup('vars', '_role_defaults_' + item).backup_manifest
+              | combine({'_role_name': item})] }}
+      loop: "{{ _restorable_services }}"
+      when: lookup('vars', '_role_defaults_' + item, default={}).backup_manifest is defined
+      tags: [always]
+
     - name: Ensure NAS hostname resolves
       ansible.builtin.lineinfile:
         path: /etc/hosts
@@ -58,269 +73,65 @@
         state: present
       tags: [always]
 
-    # ------------------------------------------------------------------
-    # Pi-hole
-    # ------------------------------------------------------------------
-    - name: "PIHOLE: restore"
+  tasks:
+    # ==================================================================
+    # Per-service restore — each block uses the generic task file
+    # parameterised by the service's manifest. Static tags allow
+    # --tags filtering.
+    # ==================================================================
+
+    - name: Restore pihole
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'pihole') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'pihole') | list | length > 0
       tags: [pihole]
-      block:
-        - name: "PIHOLE: mount NAS tar share"
-          ansible.builtin.file:
-            path: "{{ nas_tar_mount }}"
-            state: directory
-        - ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
 
-        - name: "PIHOLE: find latest backup"
-          ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/systemd-pihole-etc/*.tar.gz | head -1
-          register: pihole_etc_latest
-          changed_when: false
-        - ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/systemd-pihole-dnsmasq/*.tar.gz | head -1
-          register: pihole_dnsmasq_latest
-          changed_when: false
-
-        - name: "PIHOLE: stop container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u pihole XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.pihole.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.pihole.uid }}/bus
-              systemctl --user stop pihole
-          changed_when: false
-          failed_when: false
-
-        - name: "PIHOLE: restore systemd-pihole-etc"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u pihole podman volume rm systemd-pihole-etc || true
-            sudo -u pihole podman volume create systemd-pihole-etc
-            gunzip -c "{{ pihole_etc_latest.stdout }}" | sudo -u pihole podman volume import systemd-pihole-etc -
-
-        - name: "PIHOLE: restore systemd-pihole-dnsmasq"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u pihole podman volume rm systemd-pihole-dnsmasq || true
-            sudo -u pihole podman volume create systemd-pihole-dnsmasq
-            gunzip -c "{{ pihole_dnsmasq_latest.stdout }}" | sudo -u pihole podman volume import systemd-pihole-dnsmasq -
-
-        - name: "PIHOLE: fix listsCache ownership (tar export preserves root UIDs for etag files)"
-          ansible.builtin.shell: |
-            cd /tmp
-            su - pihole -c 'podman unshare rm -rf \
-                $(podman volume inspect systemd-pihole-etc --format={% raw %}{{.Mountpoint}}{% endraw %})/listsCache'
-          changed_when: false
-          failed_when: false
-
-        - name: "PIHOLE: start container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u pihole XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.pihole.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.pihole.uid }}/bus
-              systemctl --user start pihole
-          changed_when: false
-
-        - name: "PIHOLE: unmount NAS"
-          ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            state: unmounted
-
-    # ------------------------------------------------------------------
-    # Samba
-    # ------------------------------------------------------------------
-    - name: "SAMBA: restore"
+    - name: Restore samba
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'samba') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'samba') | list | length > 0
       tags: [samba]
-      block:
-        - name: "SAMBA: mount NAS xchange share"
-          ansible.builtin.file:
-            path: "{{ nas_xchange_mount }}"
-            state: directory
-        - ansible.posix.mount:
-            path: "{{ nas_xchange_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-xchange"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
 
-        - name: "SAMBA: stop container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u samba XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.samba.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.samba.uid }}/bus
-              systemctl --user stop samba
-          changed_when: false
-          failed_when: false
-
-        - name: "SAMBA: rsync from NAS mirror"
-          ansible.builtin.shell: |
-            cd /tmp
-            MP=$(sudo -u samba podman volume inspect systemd-samba-data --format='{{ '{{' }}.Mountpoint{{ '}}' }}')
-            sudo -u samba podman unshare rsync -a --no-owner --no-group --numeric-ids \
-                "{{ nas_xchange_mount }}/" "$MP/"
-
-        - name: "SAMBA: start container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u samba XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.samba.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.samba.uid }}/bus
-              systemctl --user start samba
-          changed_when: false
-
-        - name: "SAMBA: unmount NAS"
-          ansible.posix.mount:
-            path: "{{ nas_xchange_mount }}"
-            state: unmounted
-
-    # ------------------------------------------------------------------
-    # Syncthing
-    # ------------------------------------------------------------------
-    - name: "SYNCTHING: restore"
+    - name: Restore syncthing
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'syncthing') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'syncthing') | list | length > 0
       tags: [syncthing]
-      block:
-        - name: "SYNCTHING: mount NAS shares"
-          ansible.builtin.file:
-            path: "{{ item }}"
-            state: directory
-          loop:
-            - "{{ nas_tar_mount }}"
-            - "{{ nas_syncthing_mount }}"
-        - ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
-        - ansible.posix.mount:
-            path: "{{ nas_syncthing_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-syncthing"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
 
-        - name: "SYNCTHING: find latest config backup"
-          ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/systemd-syncthing-config/*.tar.gz | head -1
-          register: syncthing_config_latest
-          changed_when: false
-
-        - name: "SYNCTHING: stop container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u syncthg XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.syncthg.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.syncthg.uid }}/bus
-              systemctl --user stop syncthing
-          changed_when: false
-          failed_when: false
-
-        - name: "SYNCTHING: restore config volume"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u syncthg podman volume rm systemd-syncthing-config || true
-            sudo -u syncthg podman volume create systemd-syncthing-config
-            gunzip -c "{{ syncthing_config_latest.stdout }}" | sudo -u syncthg podman volume import systemd-syncthing-config -
-
-        - name: "SYNCTHING: rsync data from NAS mirror"
-          ansible.builtin.shell: |
-            cd /tmp
-            MP=$(sudo -u syncthg podman volume inspect systemd-syncthing-data --format='{{ '{{' }}.Mountpoint{{ '}}' }}')
-            sudo -u syncthg podman unshare rsync -a --delete --no-owner --no-group --numeric-ids \
-                "{{ nas_syncthing_mount }}/" "$MP/"
-
-        - name: "SYNCTHING: start container"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u syncthg XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.syncthg.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.syncthg.uid }}/bus
-              systemctl --user start syncthing
-          changed_when: false
-
-        - name: "SYNCTHING: unmount NAS"
-          ansible.posix.mount:
-            path: "{{ item }}"
-            state: unmounted
-          loop:
-            - "{{ nas_syncthing_mount }}"
-            - "{{ nas_tar_mount }}"
-
-    # ------------------------------------------------------------------
-    # Jukebox (config + playlist only; music via --tags jukebox-music)
-    # ------------------------------------------------------------------
-    - name: "JUKEBOX: restore config + playlist"
+    - name: Restore jukebox
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'jukebox') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'jukebox') | list | length > 0
       tags: [jukebox]
-      block:
-        - name: "JUKEBOX: mount NAS tar share"
-          ansible.builtin.file:
-            path: "{{ nas_tar_mount }}"
-            state: directory
-        - ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
 
-        - name: "JUKEBOX: find latest backups"
-          ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/jukebox-server-config/*.tar.gz | head -1
-          register: jukebox_config_latest
-          changed_when: false
-        - ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/jukebox-server-playlist/*.tar.gz | head -1
-          register: jukebox_playlist_latest
-          changed_when: false
+    - name: Restore entephoto
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | list | length > 0
+      tags: [entephoto]
 
-        - name: "JUKEBOX: stop pod"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u jukebox XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.jukebox.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.jukebox.uid }}/bus
-              systemctl --user stop jukebox-pod
-          changed_when: false
-          failed_when: false
-
-        - name: "JUKEBOX: restore config volume"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u jukebox podman volume rm jukebox-server-config || true
-            sudo -u jukebox podman volume create jukebox-server-config
-            gunzip -c "{{ jukebox_config_latest.stdout }}" | sudo -u jukebox podman volume import jukebox-server-config -
-
-        - name: "JUKEBOX: restore playlist volume"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u jukebox podman volume rm jukebox-server-playlist || true
-            sudo -u jukebox podman volume create jukebox-server-playlist
-            gunzip -c "{{ jukebox_playlist_latest.stdout }}" | sudo -u jukebox podman volume import jukebox-server-playlist -
-
-        - name: "JUKEBOX: start pod"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u jukebox XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.jukebox.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.jukebox.uid }}/bus
-              systemctl --user start jukebox-pod
-          changed_when: false
-
-        - name: "JUKEBOX: unmount NAS"
-          ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            state: unmounted
-
-    # ------------------------------------------------------------------
-    # Jukebox music (large rsync — separate tag so you can skip it)
-    # ------------------------------------------------------------------
-    - name: "JUKEBOX-MUSIC: restore music library from NAS mirror"
+    # ==================================================================
+    # Opt-in: jukebox music (128 GB rsync — tagged [never])
+    # ==================================================================
+    - name: Restore jukebox music library
       tags: [jukebox-music, never]
       block:
         - name: "JUKEBOX-MUSIC: mount NAS music share"
           ansible.builtin.file:
-            path: "{{ nas_music_mount }}"
+            path: "{{ restore_root }}/music"
             state: directory
         - ansible.posix.mount:
-            path: "{{ nas_music_mount }}"
+            path: "{{ restore_root }}/music"
             src: "{{ nas_host }}:{{ nas_volume }}/backup-music"
             fstype: nfs
             opts: "{{ nfs_opts }}"
@@ -329,134 +140,12 @@
         - name: "JUKEBOX-MUSIC: rsync music into volume"
           ansible.builtin.shell: |
             cd /tmp
-            MP=$(sudo -u jukebox podman volume inspect jukebox-server-music --format='{{ '{{' }}.Mountpoint{{ '}}' }}')
-            sudo -u jukebox podman unshare rsync -a --no-owner --no-group --numeric-ids \
-                "{{ nas_music_mount }}/" "$MP/"
+            MP=$(sudo -u jukebox podman volume inspect jukebox-server-music \
+                --format='{% raw %}{{.Mountpoint}}{% endraw %}')
+            sudo -u jukebox podman unshare rsync -a --no-owner --no-group \
+                --numeric-ids "{{ restore_root }}/music/" "$MP/"
 
         - name: "JUKEBOX-MUSIC: unmount NAS"
           ansible.posix.mount:
-            path: "{{ nas_music_mount }}"
+            path: "{{ restore_root }}/music"
             state: unmounted
-
-    # ------------------------------------------------------------------
-    # Ente Photos (three-part restore)
-    # ------------------------------------------------------------------
-    - name: "ENTEPHOTO: restore"
-      tags: [entephoto]
-      block:
-        - name: "ENTEPHOTO: mount NAS shares"
-          ansible.builtin.file:
-            path: "{{ item }}"
-            state: directory
-          loop:
-            - "{{ nas_tar_mount }}"
-            - "{{ nas_photos_mount }}"
-        - ansible.posix.mount:
-            path: "{{ nas_tar_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
-        - ansible.posix.mount:
-            path: "{{ nas_photos_mount }}"
-            src: "{{ nas_host }}:{{ nas_volume }}/backup-photos"
-            fstype: nfs
-            opts: "{{ nfs_opts }}"
-            state: ephemeral
-
-        - name: "ENTEPHOTO: find latest backups"
-          ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/entephoto-museum-config/*.tar.gz | head -1
-          register: entephoto_config_latest
-          changed_when: false
-        - ansible.builtin.shell: >
-            ls -t {{ nas_tar_mount }}/pgdump-entephoto-postgres/*.sql.gz | head -1
-          register: entephoto_pgdump_latest
-          changed_when: false
-
-        - name: "ENTEPHOTO: stop pod"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
-              systemctl --user stop entephoto-pod
-          changed_when: false
-          failed_when: false
-
-        - name: "ENTEPHOTO: restore museum-config volume"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u entephoto podman volume rm entephoto-museum-config || true
-            sudo -u entephoto podman volume create entephoto-museum-config
-            gunzip -c "{{ entephoto_config_latest.stdout }}" | sudo -u entephoto podman volume import entephoto-museum-config -
-
-        - name: "ENTEPHOTO: rsync minio-data from NAS mirror"
-          ansible.builtin.shell: |
-            cd /tmp
-            MP=$(sudo -u entephoto podman volume inspect entephoto-minio-data --format='{{ '{{' }}.Mountpoint{{ '}}' }}')
-            sudo -u entephoto podman unshare rsync -a --delete --no-owner --no-group --numeric-ids \
-                "{{ nas_photos_mount }}/" "$MP/"
-
-        - name: "ENTEPHOTO: start pod (postgres needs to be up for DB restore)"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
-              systemctl --user start entephoto-pod
-          changed_when: false
-
-        - name: "ENTEPHOTO: wait for postgres to be ready"
-          ansible.builtin.shell: >
-            cd /tmp && sudo -u entephoto podman exec entephoto-postgres
-            pg_isready -U pguser -d ente_db
-          register: pg_ready
-          until: pg_ready.rc == 0
-          retries: 30
-          delay: 2
-          changed_when: false
-
-        - name: "ENTEPHOTO: stop museum + web (they hold DB connections)"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
-              systemctl --user stop {{ item }}
-          loop:
-            - entephoto-museum
-            - entephoto-web
-          changed_when: false
-          failed_when: false
-
-        - name: "ENTEPHOTO: drop and recreate database"
-          ansible.builtin.shell: |
-            cd /tmp
-            sudo -u entephoto podman exec entephoto-postgres \
-                psql -U pguser -d postgres -c "DROP DATABASE IF EXISTS ente_db;"
-            sudo -u entephoto podman exec entephoto-postgres \
-                psql -U pguser -d postgres -c "CREATE DATABASE ente_db OWNER pguser;"
-
-        - name: "ENTEPHOTO: restore pg_dump"
-          ansible.builtin.shell: |
-            cd /tmp
-            gunzip -c "{{ entephoto_pgdump_latest.stdout }}" | \
-                sudo -u entephoto podman exec -i entephoto-postgres \
-                psql -U pguser -d ente_db
-
-        - name: "ENTEPHOTO: start museum + web"
-          ansible.builtin.command:
-            cmd: >
-              sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
-              DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
-              systemctl --user start {{ item }}
-          loop:
-            - entephoto-museum
-            - entephoto-web
-          changed_when: false
-
-        - name: "ENTEPHOTO: unmount NAS"
-          ansible.posix.mount:
-            path: "{{ item }}"
-            state: unmounted
-          loop:
-            - "{{ nas_photos_mount }}"
-            - "{{ nas_tar_mount }}"

--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -1,0 +1,133 @@
+---
+# Generic restore for one service, parameterised by {{ svc }}.
+#
+# Expected svc keys:
+#   service_user   — Linux username (key into my_linux_users for UID)
+#   service_unit   — systemd --user unit to stop/start
+#   volumes[]      — list of {name, method, nas_share?, restore_opt_in?}
+#   databases[]    — optional list of {container, db_user, db_name, method}
+#   post_restore_tasks — optional role-relative path for post-restore hook
+#   _role_name     — injected by the aggregation set_fact
+
+# --- Mount NAS shares ---
+- name: "{{ svc._role_name | upper }}: mount NAS tar share"
+  block:
+    - ansible.builtin.file:
+        path: "{{ restore_root }}/tar"
+        state: directory
+    - ansible.posix.mount:
+        path: "{{ restore_root }}/tar"
+        src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
+        fstype: nfs
+        opts: "{{ nfs_opts }}"
+        state: ephemeral
+
+- name: "{{ svc._role_name | upper }}: mount NAS rsync shares"
+  block:
+    - ansible.builtin.file:
+        path: "{{ restore_root }}/{{ item.nas_share }}"
+        state: directory
+      loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
+      loop_control:
+        label: "{{ item.nas_share }}"
+    - ansible.posix.mount:
+        path: "{{ restore_root }}/{{ item.nas_share }}"
+        src: "{{ nas_host }}:{{ nas_volume }}/backup-{{ item.nas_share }}"
+        fstype: nfs
+        opts: "{{ nfs_opts }}"
+        state: ephemeral
+      loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
+      loop_control:
+        label: "{{ item.nas_share }}"
+  when: svc.volumes | selectattr('method', 'equalto', 'rsync') | list | length > 0
+
+# --- Find latest tar backups ---
+- name: "{{ svc._role_name | upper }}: find latest tar backups"
+  ansible.builtin.shell: >
+    ls -t {{ restore_root }}/tar/{{ item.name }}/*.tar.gz | head -1
+  register: _tar_latest
+  loop: "{{ svc.volumes | selectattr('method', 'equalto', 'tar') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  changed_when: false
+
+# --- Find latest pgdump backups ---
+- name: "{{ svc._role_name | upper }}: find latest pgdump backups"
+  ansible.builtin.shell: >
+    ls -t {{ restore_root }}/tar/pgdump-{{ item.container }}/*.sql.gz | head -1
+  register: _pgdump_latest
+  loop: "{{ svc.databases | default([]) }}"
+  loop_control:
+    label: "{{ item.container }}"
+  changed_when: false
+
+# --- Stop the service ---
+- name: "{{ svc._role_name | upper }}: stop service"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u {{ svc.service_user }}
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users[svc.service_user].uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users[svc.service_user].uid }}/bus
+      systemctl --user stop {{ svc.service_unit }}
+  changed_when: false
+  failed_when: false
+
+# --- Restore tar volumes ---
+- name: "{{ svc._role_name | upper }}: restore tar volume {{ item.item.name }}"
+  ansible.builtin.shell: |
+    cd /tmp
+    sudo -u {{ svc.service_user }} podman volume rm {{ item.item.name }} || true
+    sudo -u {{ svc.service_user }} podman volume create {{ item.item.name }}
+    gunzip -c "{{ item.stdout }}" | \
+        sudo -u {{ svc.service_user }} podman volume import {{ item.item.name }} -
+  loop: "{{ _tar_latest.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+
+# --- Restore rsync volumes (skip opt-in ones) ---
+- name: "{{ svc._role_name | upper }}: rsync restore {{ item.name }}"
+  ansible.builtin.shell: |
+    cd /tmp
+    MP=$(sudo -u {{ svc.service_user }} podman volume inspect {{ item.name }} \
+        --format='{% raw %}{{.Mountpoint}}{% endraw %}')
+    sudo -u {{ svc.service_user }} podman unshare rsync -a --delete \
+        --no-owner --no-group --numeric-ids \
+        "{{ restore_root }}/{{ item.nas_share }}/" "$MP/"
+  loop: >-
+    {{ svc.volumes
+       | selectattr('method', 'equalto', 'rsync')
+       | rejectattr('restore_opt_in', 'defined')
+       | list }}
+  loop_control:
+    label: "{{ item.name }}"
+
+# --- Start the service ---
+- name: "{{ svc._role_name | upper }}: start service"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u {{ svc.service_user }}
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users[svc.service_user].uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users[svc.service_user].uid }}/bus
+      systemctl --user start {{ svc.service_unit }}
+  changed_when: false
+
+# --- Run post-restore hook if defined ---
+- name: "{{ svc._role_name | upper }}: run post-restore tasks"
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/{{ svc._role_name }}/tasks/{{ svc.post_restore_tasks }}"
+  when: svc.post_restore_tasks is defined
+
+# --- Unmount NAS shares ---
+- name: "{{ svc._role_name | upper }}: unmount NAS rsync shares"
+  ansible.posix.mount:
+    path: "{{ restore_root }}/{{ item.nas_share }}"
+    state: unmounted
+  loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
+  loop_control:
+    label: "{{ item.nas_share }}"
+  when: svc.volumes | selectattr('method', 'equalto', 'rsync') | list | length > 0
+
+- name: "{{ svc._role_name | upper }}: unmount NAS tar share"
+  ansible.posix.mount:
+    path: "{{ restore_root }}/tar"
+    state: unmounted

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -22,13 +22,13 @@ set -euo pipefail
 BACKUP_ROOT="/mnt/backup"
 NAS_HOST="{{ backup_nas_hostname }}"
 NAS_VOLUME="{{ backup_nas_volume }}"
-# Local mount name → Synology shared folder name
+# Local mount name → Synology shared folder name.
+# Derived from backup_manifest declarations in each role's defaults.
 declare -A NFS_SHARES=(
   [tar]=backup-tar
-  [photos]=backup-photos
-  [syncthing]=backup-syncthing
-  [xchange]=backup-xchange
-  [music]=backup-music
+{% for share in _backup_manifests | map(attribute='volumes') | flatten | selectattr('method', 'equalto', 'rsync') | map(attribute='nas_share') | unique | sort %}
+  [{{ share }}]=backup-{{ share }}
+{% endfor %}
 )
 MOUNT_OPTS="noatime,hard,_netdev,vers=4"
 RETENTION_DAYS=7
@@ -139,45 +139,28 @@ backup_pgdump() {
 
 # =======================================================================
 # Backup definitions per service
+# Generated from backup_manifest declarations in each role's defaults.
 # =======================================================================
+{% for svc in _backup_manifests %}
 
-# === Pi-hole ===
-log "--- Pi-hole ---"
-stop_service pihole {{ my_linux_users.pihole.uid }} pihole
-backup_tar_volume pihole {{ my_linux_users.pihole.uid }} systemd-pihole-etc
-backup_tar_volume pihole {{ my_linux_users.pihole.uid }} systemd-pihole-dnsmasq
-start_service pihole {{ my_linux_users.pihole.uid }} pihole
-
-# === Samba ===
-log "--- Samba ---"
-stop_service samba {{ my_linux_users.samba.uid }} samba
-backup_rsync_volume samba {{ my_linux_users.samba.uid }} systemd-samba-data xchange
-start_service samba {{ my_linux_users.samba.uid }} samba
-
-# === Syncthing ===
-log "--- Syncthing ---"
-stop_service syncthg {{ my_linux_users.syncthg.uid }} syncthing
-backup_tar_volume syncthg {{ my_linux_users.syncthg.uid }} systemd-syncthing-config
-backup_rsync_volume syncthg {{ my_linux_users.syncthg.uid }} systemd-syncthing-data syncthing
-start_service syncthg {{ my_linux_users.syncthg.uid }} syncthing
-
-# === Jukebox ===
-log "--- Jukebox ---"
-stop_service jukebox {{ my_linux_users.jukebox.uid }} jukebox-pod
-backup_tar_volume jukebox {{ my_linux_users.jukebox.uid }} jukebox-server-config
-backup_tar_volume jukebox {{ my_linux_users.jukebox.uid }} jukebox-server-playlist
-backup_rsync_volume jukebox {{ my_linux_users.jukebox.uid }} jukebox-server-music music
-start_service jukebox {{ my_linux_users.jukebox.uid }} jukebox-pod
-
-# === Ente Photos ===
-log "--- Ente Photos ---"
+# === {{ svc._role_name | capitalize }} ===
+log "--- {{ svc._role_name | capitalize }} ---"
+{% if svc.databases is defined %}
+{% for db in svc.databases %}
 # pg_dump runs while service is up (consistent logical snapshot)
-backup_pgdump entephoto entephoto-postgres pguser ente_db
-# Stop pod for volume backups
-stop_service entephoto {{ my_linux_users.entephoto.uid }} entephoto-pod
-backup_tar_volume entephoto {{ my_linux_users.entephoto.uid }} entephoto-museum-config
-backup_rsync_volume entephoto {{ my_linux_users.entephoto.uid }} entephoto-minio-data photos
-start_service entephoto {{ my_linux_users.entephoto.uid }} entephoto-pod
+backup_pgdump {{ svc.service_user }} {{ db.container }} {{ db.db_user }} {{ db.db_name }}
+{% endfor %}
+{% endif %}
+stop_service {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ svc.service_unit }}
+{% for vol in svc.volumes %}
+{% if vol.method == 'tar' %}
+backup_tar_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }}
+{% elif vol.method == 'rsync' %}
+backup_rsync_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }} {{ vol.nas_share }}
+{% endif %}
+{% endfor %}
+start_service {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ svc.service_unit }}
+{% endfor %}
 
 # =======================================================================
 log "=== Backup finished ($ERRORS errors) ==="

--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -6,3 +6,14 @@ entephoto_minio_root_user: enteadmin
 #   podman exec entephoto-postgres psql -U pguser ente_db -c "SELECT user_id FROM users;")
 # Admins can manage subscriptions and storage for all users.
 entephoto_admin_user_ids: []
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: entephoto
+  service_unit: entephoto-pod
+  volumes:
+    - { name: entephoto-museum-config, method: tar }
+    - { name: entephoto-minio-data, method: rsync, nas_share: photos }
+  databases:
+    - { container: entephoto-postgres, db_user: pguser, db_name: ente_db, method: pgdump }
+  post_restore_tasks: restore.yml

--- a/roles/entephoto/tasks/main.yml
+++ b/roles/entephoto/tasks/main.yml
@@ -89,3 +89,10 @@
         "'
   register: entephoto_bucket_create
   changed_when: "'Bucket created successfully' in entephoto_bucket_create.stdout"
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/entephoto/tasks/restore.yml
+++ b/roles/entephoto/tasks/restore.yml
@@ -1,0 +1,63 @@
+---
+# Ente Photos post-restore hook: three-phase Postgres restore.
+#
+# At this point the generic flow has already:
+#   - restored museum-config (tar) and minio-data (rsync)
+#   - started entephoto-pod (all containers in the pod are up)
+#
+# We now need to:
+#   1. Wait for Postgres to become ready
+#   2. Stop museum + web (they hold DB connections that block DROP)
+#   3. DROP + CREATE the database
+#   4. Load the pg_dump
+#   5. Restart museum + web
+
+- name: "ENTEPHOTO: wait for postgres to be ready"
+  ansible.builtin.shell: >
+    cd /tmp && sudo -u entephoto podman exec entephoto-postgres
+    pg_isready -U pguser -d ente_db
+  register: pg_ready
+  until: pg_ready.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
+
+- name: "ENTEPHOTO: stop museum + web (they hold DB connections)"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u entephoto
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
+      systemctl --user stop {{ item }}
+  loop:
+    - entephoto-museum
+    - entephoto-web
+  changed_when: false
+  failed_when: false
+
+- name: "ENTEPHOTO: drop and recreate database"
+  ansible.builtin.shell: |
+    cd /tmp
+    sudo -u entephoto podman exec entephoto-postgres \
+        psql -U pguser -d postgres -c "DROP DATABASE IF EXISTS ente_db;"
+    sudo -u entephoto podman exec entephoto-postgres \
+        psql -U pguser -d postgres -c "CREATE DATABASE ente_db OWNER pguser;"
+
+- name: "ENTEPHOTO: restore pg_dump"
+  ansible.builtin.shell: |
+    cd /tmp
+    gunzip -c "{{ _pgdump_latest.results[0].stdout }}" | \
+        sudo -u entephoto podman exec -i entephoto-postgres \
+        psql -U pguser -d ente_db
+
+- name: "ENTEPHOTO: start museum + web"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u entephoto
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
+      systemctl --user start {{ item }}
+  loop:
+    - entephoto-museum
+    - entephoto-web
+  changed_when: false

--- a/roles/jukebox/defaults/main.yml
+++ b/roles/jukebox/defaults/main.yml
@@ -18,3 +18,12 @@ jukebox_squeezelite_name: "LMS-Player-{{ ansible_facts['hostname'] }}"
 # by setup.sh and stored in host_vars. Empty string leaves it up to
 # the container entrypoint (random MAC, new identity on every start).
 jukebox_squeezelite_mac: ""
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: jukebox
+  service_unit: jukebox-pod
+  volumes:
+    - { name: jukebox-server-config, method: tar }
+    - { name: jukebox-server-playlist, method: tar }
+    - { name: jukebox-server-music, method: rsync, nas_share: music, restore_opt_in: true }

--- a/roles/jukebox/tasks/main.yml
+++ b/roles/jukebox/tasks/main.yml
@@ -100,3 +100,10 @@
       # - "9090/tcp" # only required for external clients (e.g. smart phone)
       # - "3483/tcp" # player and server communicate over
       # - "3483/udp" # pod related network
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -32,3 +32,12 @@ pihole_adlists:
 # Stored in pihole.toml under dns.hosts via `pihole-FTL --config`.
 # Format: list of {ip, hostname} dicts. Override per-host in inventory.
 pihole_local_dns_records: []
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: pihole
+  service_unit: pihole
+  volumes:
+    - { name: systemd-pihole-etc, method: tar }
+    - { name: systemd-pihole-dnsmasq, method: tar }
+  post_restore_tasks: restore.yml

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -90,3 +90,10 @@
 
 - name: Run post-install configuration
   ansible.builtin.import_tasks: postinstall.yml
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/pihole/tasks/restore.yml
+++ b/roles/pihole/tasks/restore.yml
@@ -1,0 +1,14 @@
+---
+# Pi-hole post-restore hook.
+# The backup tarball preserves root-owned .etag files in listsCache.
+# After import into a rootless container, pihole -g can't overwrite
+# them, causing "List download failed: using previously cached list".
+# Wipe the whole listsCache dir so pihole -g recreates it fresh.
+
+- name: "PIHOLE: fix listsCache ownership after restore"
+  ansible.builtin.shell: |
+    cd /tmp
+    su - pihole -c 'podman unshare rm -rf \
+        $(podman volume inspect systemd-pihole-etc --format={% raw %}{{.Mountpoint}}{% endraw %})/listsCache'
+  changed_when: false
+  failed_when: false

--- a/roles/samba/defaults/main.yml
+++ b/roles/samba/defaults/main.yml
@@ -7,3 +7,10 @@ samba_timezone: "UTC"
 samba_workgroup: "WORKGROUP"
 samba_server_string: "Samba Server"
 samba_netbios_name: "HOMESERVER"
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: samba
+  service_unit: samba
+  volumes:
+    - { name: systemd-samba-data, method: rsync, nas_share: xchange }

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -47,3 +47,10 @@
       - port: 139
         proto: tcp
         toport: "{{ samba_netbios_port }}"
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/syncthing/defaults/main.yml
+++ b/roles/syncthing/defaults/main.yml
@@ -1,3 +1,11 @@
 syncthing_gui_port: 8384
 syncthing_listen_port: 22000
 syncthing_discovery_port: 21027
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: syncthg
+  service_unit: syncthing
+  volumes:
+    - { name: systemd-syncthing-config, method: tar }
+    - { name: systemd-syncthing-data, method: rsync, nas_share: syncthing }

--- a/roles/syncthing/tasks/main.yml
+++ b/roles/syncthing/tasks/main.yml
@@ -53,3 +53,10 @@
       - "{{ syncthing_listen_port }}/tcp"
       - "{{ syncthing_listen_port }}/udp"
       - "{{ syncthing_discovery_port }}/udp"
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined


### PR DESCRIPTION
## Summary

- Each backed-up role now declares a `backup_manifest` in its `defaults/main.yml` specifying volume names, backup methods (tar/rsync/pgdump), NAS share names, and optional post-restore hooks
- Both the backup script template and the restore playbook consume this manifest — single source of truth, eliminating duplication
- Special post-restore logic handled by per-role hooks (`roles/pihole/tasks/restore.yml`, `roles/entephoto/tasks/restore.yml`)
- Net -39 lines despite adding the new generic restore infrastructure

## Test plan

- [x] Deploy to eddie via `site.yml` — `ok=474, changed=6, failed=0`
- [x] Verify rendered backup script has correct NFS_SHARES, volume names, methods, UIDs
- [x] Nightly backup ran successfully: `Backup finished (0 errors)` (21:00 timer run)
- [x] Restore dry-run (`--check --tags pihole`) — manifests load, generic task file included
- [ ] Full restore test on one service (pihole recommended — smallest, fastest)

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)