### PR TITLE
Add paperless-ngx role (document management)

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -354,3 +354,4 @@ ports, deployment notes, and troubleshooting:
 - [samba](../roles/samba/README.md) — SMB file share
 - [shairportsync](../roles/shairportsync/README.md) — AirPlay receiver (incl. audio debugging)
 - [syncthing](../roles/syncthing/README.md) — file sync
+- [paperless-ngx](../roles/paperless-ngx/README.md) — document management (OCR + search)

--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -80,3 +80,16 @@ entephoto_hash_key: !vault |
 entephoto_jwt_secret: !vault |
           <your vault-encrypted secret here>
 ##################################################################################################
+
+##################################################################################################
+### Paperless-NGX configuration
+### Generate: openssl rand -hex 32 | ansible-vault encrypt_string --stdin-name 'paperless_secret_key'
+### Generate: openssl rand -base64 24 | ansible-vault encrypt_string --stdin-name 'paperless_db_password'
+### Generate: openssl rand -base64 24 | ansible-vault encrypt_string --stdin-name 'paperless_admin_password'
+paperless_secret_key: !vault |
+          <your vault-encrypted key here>
+paperless_db_password: !vault |
+          <your vault-encrypted password here>
+paperless_admin_password: !vault |
+          <your vault-encrypted password here>
+##################################################################################################

--- a/playbooks/paperless-ngx.yml
+++ b/playbooks/paperless-ngx.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Paperless-NGX document management
+  hosts: homeservers
+  become: true
+  gather_facts: true
+
+  roles:
+    - paperless-ngx

--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -43,6 +43,7 @@
       - syncthing
       - jukebox
       - entephoto
+      - paperless-ngx
 
   pre_tasks:
     # Load each role's defaults so backup_manifest vars are available.
@@ -119,6 +120,14 @@
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | list | length > 0
       tags: [entephoto]
+
+    - name: Restore paperless-ngx
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'paperless-ngx') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'paperless-ngx') | list | length > 0
+      tags: [paperless-ngx]
 
     # ==================================================================
     # Opt-in: jukebox music (128 GB rsync — tagged [never])

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -25,4 +25,5 @@
     - { role: shairportsync, when: "'shairportsync' in (deploy_services | default([]))" }
     - { role: jukebox,       when: "'jukebox' in (deploy_services | default([]))" }
     - { role: entephoto,     when: "'entephoto' in (deploy_services | default([]))" }
+    - { role: paperless-ngx, when: "'paperless-ngx' in (deploy_services | default([]))" }
     - { role: backup,        when: "'backup' in (deploy_services | default([]))" }

--- a/roles/paperless-ngx/README.md
+++ b/roles/paperless-ngx/README.md
@@ -1,0 +1,106 @@
+# paperless-ngx
+
+[Paperless-ngx](https://docs.paperless-ngx.com) — document management
+system with OCR, full-text search, tagging, and a web UI. Deployed as
+a rootless Podman pod with Postgres, Redis, the Paperless-ngx app, and
+Gotenberg (document conversion).
+
+## Container images
+
+| Container | Image |
+|-----------|-------|
+| paperless-db | `docker.io/library/postgres:16` |
+| paperless-redis | `docker.io/library/redis:7-alpine` |
+| paperless-ngx | `ghcr.io/paperless-ngx/paperless-ngx:latest` |
+| paperless-gotenberg | `docker.io/gotenberg/gotenberg:8` |
+
+## Service user
+
+`paperless` (UID/GID 1007) — rootless.
+
+## Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `paperless_admin_user` | `admin` | Admin account created on first startup. |
+| `paperless_time_zone` | `Europe/Berlin` | Timezone for timestamps and scheduler. |
+| `paperless_ocr_language` | `deu+eng` | OCR languages (ISO 639-2, `+` separated). |
+| `paperless_enable_gotenberg` | `true` | Enable Gotenberg for Office doc conversion. |
+
+## Secrets
+
+All three must be vaulted in your host_vars:
+
+```bash
+openssl rand -hex 32 | ansible-vault encrypt_string \
+  --encrypt-vault-id default --stdin-name 'paperless_secret_key'
+
+openssl rand -base64 24 | ansible-vault encrypt_string \
+  --encrypt-vault-id default --stdin-name 'paperless_db_password'
+
+openssl rand -base64 24 | ansible-vault encrypt_string \
+  --encrypt-vault-id default --stdin-name 'paperless_admin_password'
+```
+
+Inspect a stored secret:
+
+```bash
+ansible -i inventory/hosts.yml homeserver -m debug -a "var=paperless_secret_key"
+```
+
+## Firewall ports
+
+- **8000/tcp** — Web UI and API.
+
+## Endpoints
+
+- Web UI: `http://<server-ip>:8000`
+
+## Volumes
+
+- `paperless-db-data` — PostgreSQL data files.
+- `paperless-redis-data` — Redis persistence.
+- `paperless-media` — uploaded/processed documents (originals + archive).
+- `paperless-data` — search index, thumbnails, classification model.
+- `paperless-export` — document exports.
+- `paperless-consume` — incoming documents (drop files here for auto-import).
+
+## Deployment
+
+```bash
+ansible-playbook playbooks/paperless-ngx.yml --limit homeserver
+```
+
+After deployment, open `http://<server-ip>:8000` and log in with the
+admin credentials from your host_vars. The admin account is only
+created on first startup — subsequent deploys don't overwrite it.
+
+## Document ingestion
+
+Drop files into the consume volume for automatic import:
+
+```bash
+# Find the consume volume's host path
+sudo -u paperless podman volume inspect paperless-consume \
+    --format '{{.Mountpoint}}'
+
+# Copy a document into it
+sudo cp invoice.pdf <mountpoint>/
+```
+
+Or upload via the web UI (drag-and-drop).
+
+## Tips and troubleshooting
+
+### OCR not working for a language
+
+Install additional Tesseract language packs by setting
+`paperless_ocr_language` to include the desired language codes.
+Common: `deu` (German), `eng` (English), `fra` (French),
+`ita` (Italian). The container downloads language data on first use.
+
+### Gotenberg disabled
+
+If you don't need Office document conversion, set
+`paperless_enable_gotenberg: false` in your host_vars. The Gotenberg
+container won't be started, saving ~200 MB of RAM.

--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Paperless-ngx admin account created on first startup.
+# After initial setup, change the password via the web UI.
+paperless_admin_user: "admin"
+
+# Timezone for document timestamps and scheduler.
+paperless_time_zone: "Europe/Berlin"
+
+# OCR language(s). Use ISO 639-2 3-letter codes, '+' separated.
+# Common: deu (German), eng (English), fra (French).
+paperless_ocr_language: "deu+eng"
+
+# Enable Gotenberg for Office document conversion (docx, xlsx, pptx → PDF).
+paperless_enable_gotenberg: true
+
+# Backup manifest — consumed by the backup role and restore playbook.
+backup_manifest:
+  service_user: paperless
+  service_unit: paperless-ngx-pod
+  volumes:
+    - { name: paperless-redis-data, method: tar }
+    - { name: paperless-data, method: tar }
+    - { name: paperless-export, method: tar }
+    - { name: paperless-media, method: rsync, nas_share: paperless-media }
+  databases:
+    - { container: paperless-db, db_user: paperless, db_name: paperless, method: pgdump }
+  post_restore_tasks: restore.yml

--- a/roles/paperless-ngx/files/quadlets/paperless-consume.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-consume.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-consume

--- a/roles/paperless-ngx/files/quadlets/paperless-data.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-data

--- a/roles/paperless-ngx/files/quadlets/paperless-db-data.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-db-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-db-data

--- a/roles/paperless-ngx/files/quadlets/paperless-export.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-export.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-export

--- a/roles/paperless-ngx/files/quadlets/paperless-gotenberg.container
+++ b/roles/paperless-ngx/files/quadlets/paperless-gotenberg.container
@@ -1,0 +1,13 @@
+[Unit]
+Description=paperless-ngx gotenberg document converter
+PartOf=paperless-ngx-pod.service
+
+[Container]
+ContainerName=%N
+Image=docker.io/gotenberg/gotenberg:8
+AutoUpdate=registry
+
+Pod=paperless-ngx.pod
+
+# Disable Chromium routes (not needed for paperless-ngx, saves memory)
+Exec=gotenberg --chromium-disable-javascript=true --chromium-allow-list=file:///tmp/.*

--- a/roles/paperless-ngx/files/quadlets/paperless-media.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-media.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-media

--- a/roles/paperless-ngx/files/quadlets/paperless-ngx.network
+++ b/roles/paperless-ngx/files/quadlets/paperless-ngx.network
@@ -1,0 +1,5 @@
+[Unit]
+Description=paperless-ngx pod network
+
+[Network]
+NetworkName=paperless-ngx

--- a/roles/paperless-ngx/files/quadlets/paperless-ngx.pod
+++ b/roles/paperless-ngx/files/quadlets/paperless-ngx.pod
@@ -1,0 +1,13 @@
+[Unit]
+Description=paperless-ngx document management
+After=network-online.target
+Wants=network-online.target
+
+[Pod]
+PodName=paperless-ngx
+Network=paperless-ngx.network
+
+PublishPort=8000:8000/tcp
+
+[Install]
+WantedBy=default.target

--- a/roles/paperless-ngx/files/quadlets/paperless-redis-data.volume
+++ b/roles/paperless-ngx/files/quadlets/paperless-redis-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=paperless-redis-data

--- a/roles/paperless-ngx/files/quadlets/paperless-redis.container
+++ b/roles/paperless-ngx/files/quadlets/paperless-redis.container
@@ -1,0 +1,17 @@
+[Unit]
+Description=paperless-ngx redis message broker
+PartOf=paperless-ngx-pod.service
+
+[Container]
+ContainerName=%N
+Image=docker.io/library/redis:7-alpine
+AutoUpdate=registry
+
+Pod=paperless-ngx.pod
+
+Volume=paperless-redis-data.volume:/data
+
+HealthCmd=redis-cli ping
+HealthInterval=30s
+HealthStartPeriod=30s
+HealthRetries=3

--- a/roles/paperless-ngx/tasks/main.yml
+++ b/roles/paperless-ngx/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+
+- name: Ensure rootless user group exists
+  ansible.builtin.group:
+    name: paperless
+    gid: "{{ my_linux_users.paperless.gid }}"
+    state: present
+
+- name: Ensure rootless user exists
+  ansible.builtin.user:
+    name: paperless
+    state: present
+    uid: "{{ my_linux_users.paperless.uid }}"
+    group: paperless
+    create_home: true
+
+- name: Enable linger for rootless user
+  become: true
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger paperless"
+  changed_when: false
+
+- name: Enable podman auto-update timer for rootless user # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u paperless XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.paperless.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.paperless.uid }}/bus
+      systemctl --user enable --now podman-auto-update.timer
+  changed_when: false
+
+- name: Save current role path
+  ansible.builtin.set_fact:
+    paperless_role_path: "{{ role_path }}"
+
+# Pre-pull images to avoid systemd startup timeout on first deploy.
+# The paperless-ngx image is ~1.5 GB.
+- name: Pre-pull paperless-ngx container images # noqa: no-changed-when
+  become: true
+  ansible.builtin.shell: "su - paperless -c 'podman pull {{ item }}'"
+  loop:
+    - docker.io/library/postgres:16
+    - docker.io/library/redis:7-alpine
+    - ghcr.io/paperless-ngx/paperless-ngx:latest
+    - docker.io/gotenberg/gotenberg:8
+  changed_when: false
+
+- name: Deploy paperless-ngx pod using podman_quadlet
+  ansible.builtin.include_role:
+    name: luckynrslevin.podman_quadlet
+  vars:
+    podman_quadlet_app_name: "paperless-ngx-pod"
+    podman_quadlet_rootless_user_name: paperless
+    podman_quadlet_files_templates_src_path: "{{ paperless_role_path }}"
+    podman_quadlet_file_names:
+      - paperless-ngx.pod
+      - paperless-ngx.network
+      - paperless-db.container.j2
+      - paperless-redis.container
+      - paperless-ngx.container.j2
+      - paperless-gotenberg.container
+      - paperless-db-data.volume
+      - paperless-redis-data.volume
+      - paperless-media.volume
+      - paperless-data.volume
+      - paperless-export.volume
+      - paperless-consume.volume
+    podman_quadlet_firewall_ports:
+      - "8000/tcp"
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/paperless-ngx/tasks/restore.yml
+++ b/roles/paperless-ngx/tasks/restore.yml
@@ -1,0 +1,58 @@
+---
+# Paperless-ngx post-restore hook: Postgres database restore.
+#
+# At this point the generic flow has already:
+#   - restored redis-data, data, export volumes (tar)
+#   - restored media volume (rsync)
+#   - started paperless-ngx-pod (all containers in the pod are up)
+#
+# We now need to:
+#   1. Wait for Postgres to become ready
+#   2. Stop the paperless-ngx container (it holds DB connections)
+#   3. DROP + CREATE the database
+#   4. Load the pg_dump
+#   5. Restart the paperless-ngx container
+
+- name: "PAPERLESS-NGX: wait for postgres to be ready"
+  ansible.builtin.shell: >
+    cd /tmp && sudo -u paperless podman exec paperless-db
+    pg_isready -U paperless -d paperless
+  register: pg_ready
+  until: pg_ready.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
+
+- name: "PAPERLESS-NGX: stop app container (holds DB connections)"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u paperless
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.paperless.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.paperless.uid }}/bus
+      systemctl --user stop paperless-ngx
+  changed_when: false
+  failed_when: false
+
+- name: "PAPERLESS-NGX: drop and recreate database"
+  ansible.builtin.shell: |
+    cd /tmp
+    sudo -u paperless podman exec paperless-db \
+        psql -U paperless -d postgres -c "DROP DATABASE IF EXISTS paperless;"
+    sudo -u paperless podman exec paperless-db \
+        psql -U paperless -d postgres -c "CREATE DATABASE paperless OWNER paperless;"
+
+- name: "PAPERLESS-NGX: restore pg_dump"
+  ansible.builtin.shell: |
+    cd /tmp
+    gunzip -c "{{ _pgdump_latest.results[0].stdout }}" | \
+        sudo -u paperless podman exec -i paperless-db \
+        psql -U paperless -d paperless
+
+- name: "PAPERLESS-NGX: start app container"
+  ansible.builtin.command:
+    cmd: >
+      sudo -u paperless
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.paperless.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.paperless.uid }}/bus
+      systemctl --user start paperless-ngx
+  changed_when: false

--- a/roles/paperless-ngx/templates/quadlets/paperless-db.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-db.container.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=paperless-ngx postgres database
+PartOf=paperless-ngx-pod.service
+
+[Container]
+ContainerName=%N
+Image=docker.io/library/postgres:16
+AutoUpdate=registry
+
+Pod=paperless-ngx.pod
+
+Volume=paperless-db-data.volume:/var/lib/postgresql/data
+
+Environment=POSTGRES_DB=paperless
+Environment=POSTGRES_USER=paperless
+Environment=POSTGRES_PASSWORD={{ paperless_db_password }}
+
+HealthCmd=pg_isready -U paperless -d paperless
+HealthInterval=30s
+HealthStartPeriod=60s
+HealthRetries=5

--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -1,0 +1,58 @@
+[Unit]
+Description=paperless-ngx web application
+PartOf=paperless-ngx-pod.service
+After=paperless-db.service
+After=paperless-redis.service
+
+[Container]
+ContainerName=%N
+Image=ghcr.io/paperless-ngx/paperless-ngx:latest
+AutoUpdate=registry
+
+Pod=paperless-ngx.pod
+
+Volume=paperless-media.volume:/usr/src/paperless/media
+Volume=paperless-data.volume:/usr/src/paperless/data
+Volume=paperless-export.volume:/usr/src/paperless/export
+Volume=paperless-consume.volume:/usr/src/paperless/consume
+
+# Database
+Environment=PAPERLESS_DBHOST=localhost
+Environment=PAPERLESS_DBPORT=5432
+Environment=PAPERLESS_DBNAME=paperless
+Environment=PAPERLESS_DBUSER=paperless
+Environment=PAPERLESS_DBPASS={{ paperless_db_password }}
+
+# Redis
+Environment=PAPERLESS_REDIS=redis://localhost:6379
+
+# Security
+Environment=PAPERLESS_SECRET_KEY={{ paperless_secret_key }}
+
+# Admin account (created on first startup only)
+Environment=PAPERLESS_ADMIN_USER={{ paperless_admin_user }}
+Environment=PAPERLESS_ADMIN_PASSWORD={{ paperless_admin_password }}
+
+# Localisation
+Environment=PAPERLESS_TIME_ZONE={{ paperless_time_zone }}
+Environment=PAPERLESS_OCR_LANGUAGE={{ paperless_ocr_language }}
+
+# Gotenberg (document conversion)
+{% if paperless_enable_gotenberg %}
+Environment=PAPERLESS_TIKA_ENABLED=true
+Environment=PAPERLESS_TIKA_GOTENBERG_ENDPOINT=http://localhost:3000
+Environment=PAPERLESS_TIKA_ENDPOINT=http://localhost:3000
+{% endif %}
+
+# Misc
+Environment=PAPERLESS_URL={{ paperless_url | default('') }}
+Environment=USERMAP_UID=1000
+Environment=USERMAP_GID=1000
+
+HealthCmd=curl -fs http://localhost:8000 || exit 1
+HealthInterval=30s
+HealthStartPeriod=120s
+HealthRetries=5
+
+[Service]
+TimeoutStartSec=600

--- a/scripts/clean-host.sh
+++ b/scripts/clean-host.sh
@@ -11,7 +11,7 @@
 # This removes:
 #   - All rootless and rootful containers, volumes, images
 #   - Service users (shairport, syncthg, pihole, jukebox, entephoto,
-#     samba, webproxy)
+#     paperless, samba, webproxy)
 #   - Systemd units (dashboard, backup timers)
 #   - Deployed scripts and configs
 #   - Firewall rules added by the roles
@@ -37,7 +37,7 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
-SERVICE_USERS=(shairport syncthg pihole jukebox entephoto samba webproxy)
+SERVICE_USERS=(shairport syncthg pihole jukebox entephoto paperless samba webproxy)
 
 # ---- Stop and remove containers ----
 info "Stopping containers and cleaning podman state..."

--- a/setup.sh
+++ b/setup.sh
@@ -228,10 +228,11 @@ SERVICES=(
     [shairportsync]="Shairport-sync AirPlay audio receiver (needs audio device)"
     [jukebox]="Lyrion Music Server + Squeezelite player"
     [entephoto]="Ente Photos (self-hosted photo storage)"
+    [paperless-ngx]="Paperless-NGX document management (OCR + search)"
 )
 
 # Recommended order for deployment
-SERVICE_ORDER=(caddy dashboard pihole syncthing samba shairportsync jukebox entephoto)
+SERVICE_ORDER=(caddy dashboard pihole syncthing samba shairportsync jukebox entephoto paperless-ngx)
 SELECTED_SERVICES=()
 
 for svc in "${SERVICE_ORDER[@]}"; do
@@ -300,6 +301,9 @@ ENTEPHOTO_MINIO_PW=$(openssl rand -base64 24)
 ENTEPHOTO_ENC_KEY=$(openssl rand -base64 32)
 ENTEPHOTO_HASH_KEY=$(openssl rand -base64 64)
 ENTEPHOTO_JWT=$(openssl rand -hex 32)
+PAPERLESS_SECRET_KEY=$(openssl rand -hex 32)
+PAPERLESS_DB_PW=$(openssl rand -base64 24)
+PAPERLESS_ADMIN_PW=$(openssl rand -base64 24)
 
 # Generate a stable, locally-administered unicast MAC for the
 # squeezelite player. First octet 0x02 sets the locally-administered
@@ -343,6 +347,9 @@ my_linux_users:
   entephoto:
     uid: 1008
     gid: 1008
+  paperless:
+    uid: 1007
+    gid: 1007
   samba:
     uid: 1010
     gid: 1010
@@ -377,6 +384,13 @@ echo ""
 vault_encrypt "$ENTEPHOTO_JWT" "entephoto_jwt_secret"
 echo ""
 echo "entephoto_admin_user_ids: []"
+echo ""
+echo "### Paperless-NGX"
+vault_encrypt "$PAPERLESS_SECRET_KEY" "paperless_secret_key"
+echo ""
+vault_encrypt "$PAPERLESS_DB_PW" "paperless_db_password"
+echo ""
+vault_encrypt "$PAPERLESS_ADMIN_PW" "paperless_admin_password"
 echo "##################################################################################################"
 } > inventory/host_vars/homeserver/main.yml
 
@@ -483,6 +497,23 @@ cat << EOF
       - entephoto-postgres-data
       - entephoto-minio-data
       - entephoto-museum-config
+
+EOF
+fi
+
+if is_selected paperless-ngx; then
+cat << EOF
+  - name: Paperless-NGX
+    user: paperless
+    uid: 1007
+    service: paperless-ngx-pod
+    urls:
+      - label: Web UI
+        url: http://${SERVER_IP}:8000
+    volumes:
+      - paperless-db-data
+      - paperless-media
+      - paperless-data
 
 EOF
 fi


### PR DESCRIPTION
## Summary

- New role `paperless-ngx` deploying a complete document management system with OCR, full-text search, and web UI
- Rootless Podman pod with PostgreSQL 16, Redis 7, Paperless-ngx, and Gotenberg 8
- Follows the established multi-container pod pattern from entephoto
- Includes backup_manifest for declarative backup/restore + DB restore hook
- All integration points updated: site.yml, restore.yml, setup.sh, clean-host.sh, example host_vars, Quickstart.md

## Test plan

- [x] Deploy to eddie: `ok=62, changed=6, failed=0`
- [x] All 5 containers running and healthy
- [x] Web UI responds at `:8000` (HTTP 302 → login)
- [ ] Log in with admin credentials
- [ ] Upload a test document → OCR processes it
- [ ] Backup run includes paperless-ngx volumes

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)