### PR TITLE
pihole: add Hagezi Multi Pro blocklist

### DIFF
--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -25,6 +25,8 @@ pihole_local_router: "192.168.x.1"
 # built-in default (StevenBlack unified hosts — auto-added by the
 # container on first run). Override per host in inventory.
 pihole_adlists:
+  - address: "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/pro.txt"
+    comment: "Hagezi Multi Pro — ads, trackers, malware, phishing (~300K domains)"
   - address: "https://raw.githubusercontent.com/Turtlecute33/Toolz/master/src/d3host.txt"
     comment: "https://adblock.turtlecute.org/"
 


### PR DESCRIPTION
## Summary

Adds the [Hagezi Multi Pro](https://github.com/hagezi/dns-blocklists) blocklist (~300K domains) to Pi-hole's default adlists. Covers ads, trackers, malware, and phishing.

## Why

With Unbound (#5) replacing Quad9 as the upstream resolver, the malware/phishing filtering that Quad9 provided at the resolver level is gone. This list restores that security layer at the Pi-hole level.

## Changes

One-line addition to `roles/pihole/defaults/main.yml` — adds the Hagezi list before the existing Turtlecute list.

## After merge

Run `ansible-playbook playbooks/pihole.yml --limit homeserver` to deploy, then gravity will pick up the new list on the next `pihole -g` run (or trigger manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)