### PR TITLE
pihole: fix Hagezi blocklist URL (domains format, not wildcard)

### DIFF
--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -25,7 +25,7 @@ pihole_local_router: "192.168.x.1"
 # built-in default (StevenBlack unified hosts — auto-added by the
 # container on first run). Override per host in inventory.
 pihole_adlists:
-  - address: "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/pro.txt"
+  - address: "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/pro.txt"
     comment: "Hagezi Multi Pro — ads, trackers, malware, phishing (~300K domains)"
   - address: "https://raw.githubusercontent.com/Turtlecute33/Toolz/master/src/d3host.txt"
     comment: "https://adblock.turtlecute.org/"


### PR DESCRIPTION
## Summary

Fixes the Hagezi Multi Pro blocklist URL from `wildcard/pro.txt` to `domains/pro.txt`.

The wildcard format (`*.doubleclick.net`) isn't supported by Pi-hole v6's gravity parser — all 193K entries were counted as invalid domains with 0 usable. The domains format has plain domain names that Pi-hole parses correctly.

One-line URL path fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)