### PR TITLE
jellyfin: switch to GHCR registry

### DIFF
--- a/roles/jellyfin/README.md
+++ b/roles/jellyfin/README.md
@@ -6,7 +6,7 @@ single rootless container with host networking (for DLNA discovery).
 
 ## Container image
 
-`docker.io/jellyfin/jellyfin:latest`
+`ghcr.io/jellyfin/jellyfin:latest`
 
 ## Service user
 

--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -36,7 +36,7 @@
 # Pre-pull the image to avoid systemd startup timeout on first deploy.
 - name: Pre-pull Jellyfin container image # noqa: no-changed-when
   become: true
-  ansible.builtin.shell: "su - jellyfin -c 'podman pull docker.io/jellyfin/jellyfin:latest'"
+  ansible.builtin.shell: "su - jellyfin -c 'podman pull ghcr.io/jellyfin/jellyfin:latest'"
   changed_when: false
 
 - name: Deploy jellyfin container using podman_quadlet

--- a/roles/jellyfin/templates/quadlets/jellyfin.container.j2
+++ b/roles/jellyfin/templates/quadlets/jellyfin.container.j2
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Container]
 ContainerName=%N
-Image=docker.io/jellyfin/jellyfin:latest
+Image=ghcr.io/jellyfin/jellyfin:latest
 AutoUpdate=registry
 Network=host
 


### PR DESCRIPTION
## Summary

Switch Jellyfin container image from `docker.io/jellyfin/jellyfin` to `ghcr.io/jellyfin/jellyfin` to avoid Docker Hub rate limits.

Updated in container template, pre-pull task, and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)