### PR TITLE
Move 3 container images off Docker Hub to avoid rate limits

### DIFF
--- a/roles/jukebox/defaults/main.yml
+++ b/roles/jukebox/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Container images
-jukebox_server_image: "docker.io/lmscommunity/lyrionmusicserver"
+jukebox_server_image: "ghcr.io/lmscommunity/lyrionmusicserver"
 jukebox_player_image: "docker.io/giof71/squeezelite"
 
 # Squeezelite preset selecting the audio output device. The

--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Container images
-paperless_postgres_image: "docker.io/library/postgres:16"
-paperless_redis_image: "docker.io/library/redis:7-alpine"
+paperless_postgres_image: "public.ecr.aws/docker/library/postgres:16"
+paperless_redis_image: "public.ecr.aws/docker/library/redis:7-alpine"
 paperless_app_image: "ghcr.io/paperless-ngx/paperless-ngx:latest"
 paperless_gotenberg_image: "docker.io/gotenberg/gotenberg:8"
 


### PR DESCRIPTION
## Summary

Switch three images from Docker Hub to registries without anonymous pull rate limits:

| Image | Before | After |
|-------|--------|-------|
| lyrionmusicserver | `docker.io/lmscommunity/lyrionmusicserver` | `ghcr.io/lmscommunity/lyrionmusicserver` |
| postgres (paperless) | `docker.io/library/postgres:16` | `public.ecr.aws/docker/library/postgres:16` |
| redis (paperless) | `docker.io/library/redis:7-alpine` | `public.ecr.aws/docker/library/redis:7-alpine` |

Three images remain on Docker Hub (no alternative registry available):
- `docker.io/mikebrady/shairport-sync`
- `docker.io/giof71/squeezelite`
- `docker.io/gotenberg/gotenberg:8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)