### PR TITLE
Bump podman_quadlet Galaxy role to v1.1.0 (pre-pull images)

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,4 +1,5 @@
 ---
 roles:
   - name: luckynrslevin.podman_quadlet
-    version: v1.0.0
+    src: https://github.com/luckynrslevin/ansible-role-podman-quadlet.git
+    version: v1.1.0


### PR DESCRIPTION
## Summary

- Bump `luckynrslevin.podman_quadlet` from v1.0.0 to v1.1.0
- Adds automatic pre-pull of container images before systemd restart
- Install source changed to direct GitHub URL

v1.1.0 release: https://github.com/luckynrslevin/ansible-role-podman-quadlet/releases/tag/v1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)