### PR TITLE
Fix Unbound container not restarting after clean stop

### DIFF
--- a/roles/pihole/templates/quadlets/pihole.container.j2
+++ b/roles/pihole/templates/quadlets/pihole.container.j2
@@ -3,6 +3,9 @@ Description=Pi-hole
 After=network-online.target
 After=local-fs.target
 Wants=network-online.target
+{% if pihole_enable_unbound | default(false) | bool %}
+Wants=unbound.service
+{% endif %}
 
 [Container]
 Image={{ pihole_image }}

--- a/roles/pihole/templates/quadlets/unbound.container.j2
+++ b/roles/pihole/templates/quadlets/unbound.container.j2
@@ -2,7 +2,7 @@
 Description=Unbound recursive DNS resolver (Pi-hole upstream)
 After=network-online.target pihole.service
 Wants=network-online.target
-Requires=pihole.service
+BindsTo=pihole.service
 
 [Container]
 ContainerName=%N
@@ -24,7 +24,7 @@ Entrypoint=unbound
 Exec=-d -c /etc/unbound/pihole.conf
 
 [Service]
-Restart=on-failure
+Restart=always
 TimeoutStartSec=300
 
 [Install]


### PR DESCRIPTION
## Summary

- Change `Restart=on-failure` to `Restart=always` so Unbound restarts regardless of exit code
- Replace `Requires=` with `BindsTo=pihole.service` so Unbound's lifecycle is fully tied to Pi-hole (restart propagates both directions)

See #26 for root cause analysis.

## Test plan

- [x] Deploy to test host and verify Unbound starts with Pi-hole
- [x] Stop Pi-hole manually, confirm both stop, then start Pi-hole and confirm Unbound also comes back
- [ ] Trigger `systemctl --user daemon-reload` and verify both containers recover

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)