### PR TITLE
Add configurable URL variables for entephoto reverse proxy

### DIFF
--- a/roles/entephoto/README.md
+++ b/roles/entephoto/README.md
@@ -20,10 +20,14 @@ containers: PostgreSQL, MinIO (S3-compatible object storage), Museum
 
 ## Variables
 
-| Variable                    | Default     | Purpose                                                                                          |
-|-----------------------------|-------------|--------------------------------------------------------------------------------------------------|
-| `entephoto_minio_root_user` | `enteadmin` | MinIO admin username (paired with `entephoto_minio_password`).                                   |
-| `entephoto_admin_user_ids`  | `[]`        | Ente user IDs granted admin rights. Populate after first signup (see "Bootstrapping an admin").  |
+| Variable                    | Default                            | Purpose                                                                                          |
+|-----------------------------|-------------------------------------|--------------------------------------------------------------------------------------------------|
+| `entephoto_minio_root_user` | `enteadmin`                         | MinIO admin username (paired with `entephoto_minio_password`).                                   |
+| `entephoto_admin_user_ids`  | `[]`                                | Ente user IDs granted admin rights. Populate after first signup (see "Bootstrapping an admin").  |
+| `entephoto_api_url`         | `http://<server-ip>:8080`           | Museum API URL served to the browser. Override for reverse proxy.                                |
+| `entephoto_photos_url`      | `http://<server-ip>:3000`           | Photos web app URL served to the browser.                                                        |
+| `entephoto_albums_url`      | `http://<server-ip>:3002`           | Albums/public-albums URL served to the browser.                                                  |
+| `entephoto_s3_endpoint`     | `<server-ip>:3200`                  | MinIO S3 endpoint for presigned upload URLs. Override when proxying MinIO.                       |
 
 ## Secrets
 
@@ -77,6 +81,32 @@ ansible -i inventory/hosts.yml homeserver -m debug -a "var=entephoto_jwt_secret"
 - `entephoto-minio-data` — MinIO buckets.
 - `entephoto-museum-config` — staged `museum.yaml` (rendered from
   template with vaulted secrets).
+
+## Reverse proxy
+
+By default, all URLs use the server's IP address with direct port
+access. When serving Ente through a reverse proxy (e.g. Caddy with
+HTTPS subdomains), override the URL variables in your host_vars:
+
+```yaml
+entephoto_api_url: "https://entephoto-api.example.com"
+entephoto_photos_url: "https://entephoto.example.com"
+entephoto_albums_url: "https://entephoto-albums.example.com"
+entephoto_s3_endpoint: "entephoto-s3.example.com"
+```
+
+The reverse proxy must forward each subdomain to the corresponding
+local port:
+
+| Subdomain              | Backend              |
+|------------------------|----------------------|
+| `entephoto-api`        | `localhost:8080`     |
+| `entephoto`            | `localhost:3000`     |
+| `entephoto-albums`     | `localhost:3002`     |
+| `entephoto-s3`         | `localhost:3200`     |
+
+When using the `caddy` role, add matching entries to
+`caddy_reverse_proxy_services` in your host_vars.
 
 ## Deployment
 

--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -5,6 +5,15 @@ entephoto_minio_image: "quay.io/minio/minio:latest"
 entephoto_server_image: "ghcr.io/ente-io/server:latest"
 entephoto_web_image: "ghcr.io/ente-io/web:latest"
 
+# URLs served to the browser. Override in host_vars when using a reverse proxy.
+entephoto_api_url: "http://{{ ansible_facts['default_ipv4']['address'] }}:8080"
+entephoto_photos_url: "http://{{ ansible_facts['default_ipv4']['address'] }}:3000"
+entephoto_albums_url: "http://{{ ansible_facts['default_ipv4']['address'] }}:3002"
+
+# MinIO S3 endpoint used for presigned upload URLs sent to browsers.
+# Override when proxying MinIO through a reverse proxy.
+entephoto_s3_endpoint: "{{ ansible_facts['default_ipv4']['address'] }}:3200"
+
 # MinIO admin username (password comes from vault: entephoto_minio_password)
 entephoto_minio_root_user: enteadmin
 

--- a/roles/entephoto/templates/quadlets/entephoto-web.container.j2
+++ b/roles/entephoto/templates/quadlets/entephoto-web.container.j2
@@ -10,6 +10,6 @@ AutoUpdate=registry
 
 Pod=entephoto.pod
 
-Environment=ENTE_API_ORIGIN=http://{{ ansible_facts['default_ipv4']['address'] }}:8080
-Environment=ENTE_ALBUMS_ORIGIN=http://{{ ansible_facts['default_ipv4']['address'] }}:3002
-Environment=ENTE_PHOTOS_ORIGIN=http://{{ ansible_facts['default_ipv4']['address'] }}:3000
+Environment=ENTE_API_ORIGIN={{ entephoto_api_url }}
+Environment=ENTE_ALBUMS_ORIGIN={{ entephoto_albums_url }}
+Environment=ENTE_PHOTOS_ORIGIN={{ entephoto_photos_url }}

--- a/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
+++ b/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
@@ -11,20 +11,20 @@ s3:
     b2-eu-cen:
         key: enteadmin
         secret: {{ entephoto_minio_password }}
-        endpoint: {{ ansible_facts['default_ipv4']['address'] }}:3200
+        endpoint: {{ entephoto_s3_endpoint }}
         region: eu-central-2
         bucket: b2-eu-cen
     wasabi-eu-central-2-v3:
         key: enteadmin
         secret: {{ entephoto_minio_password }}
-        endpoint: {{ ansible_facts['default_ipv4']['address'] }}:3200
+        endpoint: {{ entephoto_s3_endpoint }}
         region: eu-central-2
         bucket: wasabi-eu-central-2-v3
         compliance: false
     scw-eu-fr-v3:
         key: enteadmin
         secret: {{ entephoto_minio_password }}
-        endpoint: {{ ansible_facts['default_ipv4']['address'] }}:3200
+        endpoint: {{ entephoto_s3_endpoint }}
         region: eu-central-2
         bucket: scw-eu-fr-v3
 
@@ -36,7 +36,7 @@ jwt:
     secret: {{ entephoto_jwt_secret }}
 
 apps:
-    public-albums: http://{{ ansible_facts['default_ipv4']['address'] }}:3002
+    public-albums: {{ entephoto_albums_url }}
     cast: http://{{ ansible_facts['default_ipv4']['address'] }}:3004
     accounts: http://{{ ansible_facts['default_ipv4']['address'] }}:3001
 


### PR DESCRIPTION
## Summary

- Add `entephoto_api_url`, `entephoto_photos_url`, `entephoto_albums_url`, and `entephoto_s3_endpoint` defaults that preserve current direct IP:port behavior
- Replace hardcoded IP:port references in `entephoto-web.container.j2` and `museum.yaml.j2` with the new variables
- Document reverse proxy setup and variable overrides in README

## Test plan

- [x] Deploy to test host with defaults — verify URLs still use direct IP:port
- [x] Override variables in host_vars for reverse proxy — verify templates render with proxy URLs

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)