### PR TITLE
Fix listsCache write failure caused by SELinux MCS label mismatch

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -125,9 +125,8 @@ so the host points at `127.0.0.1:1053` for DNS.
 2. Inserts each entry from `pihole_adlists` into the SQLite `adlist`
    table via `INSERT OR IGNORE` (Pi-hole v6 stopped reading the
    legacy `/etc/pihole/adlists.list` flat file).
-3. Clears `listsCache` so the rootless user can write to it.
-4. Runs `pihole -g` to download lists into `gravity`.
-5. If `pihole_local_dns_records` is set, writes them via
+3. Runs `pihole -g` to download lists into `gravity`.
+4. If `pihole_local_dns_records` is set, writes them via
    `pihole-FTL --config dns.hosts <json>`.
 
 ### Why `pihole_adlists` doesn't include StevenBlack

--- a/roles/pihole/tasks/postinstall.yml
+++ b/roles/pihole/tasks/postinstall.yml
@@ -54,14 +54,6 @@
   loop: "{{ pihole_adlists }}"
   changed_when: false
 
-- name: Fix listsCache permissions for rootless container
-  become: true
-  ansible.builtin.shell: >
-    su - pihole -c 'podman unshare rm -rf
-    $(podman volume inspect systemd-pihole-etc --format={% raw %}{{.Mountpoint}}{% endraw %})/listsCache'
-  changed_when: false
-  failed_when: false
-
 - name: Update Pi-hole gravity # noqa: command-instead-of-shell
   become: true
   ansible.builtin.shell: su - pihole -c 'podman exec pihole pihole -g'

--- a/roles/pihole/tasks/postinstall.yml
+++ b/roles/pihole/tasks/postinstall.yml
@@ -56,7 +56,7 @@
 
 - name: Update Pi-hole gravity # noqa: command-instead-of-shell
   become: true
-  ansible.builtin.shell: su - pihole -c 'podman exec pihole pihole -g'
+  ansible.builtin.shell: su - pihole -c 'podman exec --user pihole pihole pihole -g'
   changed_when: false
 
 # Local DNS records: write the full list via pihole-FTL --config dns.hosts.

--- a/roles/pihole/tasks/restore.yml
+++ b/roles/pihole/tasks/restore.yml
@@ -1,14 +1,4 @@
 ---
 # Pi-hole post-restore hook.
-# The backup tarball preserves root-owned .etag files in listsCache.
-# After import into a rootless container, pihole -g can't overwrite
-# them, causing "List download failed: using previously cached list".
-# Wipe the whole listsCache dir so pihole -g recreates it fresh.
-
-- name: "PIHOLE: fix listsCache ownership after restore"
-  ansible.builtin.shell: |
-    cd /tmp
-    su - pihole -c 'podman unshare rm -rf \
-        $(podman volume inspect systemd-pihole-etc --format={% raw %}{{.Mountpoint}}{% endraw %})/listsCache'
-  changed_when: false
-  failed_when: false
+# SecurityLabelDisable=true in the Quadlet prevents SELinux MCS label
+# mismatches (#31), so no listsCache cleanup is needed after restore.

--- a/roles/pihole/templates/quadlets/pihole.container.j2
+++ b/roles/pihole/templates/quadlets/pihole.container.j2
@@ -30,7 +30,9 @@ PublishPort=8443:443/tcp
 
 DNS={{ pihole_container_dns }}
 
-#SecurityLabelDisable=true
+# SELinux MCS labels change on every container recreation, blocking
+# writes to volume files labeled by the previous instance (#31).
+SecurityLabelDisable=true
 
 HostName={{ pihole_hostname }}
 


### PR DESCRIPTION
## Summary

- Enable `SecurityLabelDisable=true` in `pihole.container` — SELinux assigns random MCS categories on each container creation, blocking writes to volume files labeled by the previous instance
- Remove the `listsCache` rm -rf workarounds from `postinstall.yml` and `restore.yml` (no longer needed)
- Update README post-install steps

Root cause analysis in #31.

## Test plan

- [ ] Deploy to eddie and run `pihole -g` — verify gravity downloads all lists successfully
- [ ] Restart the pihole container and run `pihole -g` again — verify it still works (no MCS mismatch)
- [ ] Confirm ad blocking works via [adblock.turtlecute.org](https://adblock.turtlecute.org/)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)