### PR TITLE
Support HTTPS presigned URLs for Ente Photos (closes #33)

### DIFF
--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -7,6 +7,12 @@ caddy_listen_port: 9080
 # Caddy HTTPS listen port (unprivileged, mapped via firewall from 443)
 caddy_listen_port_https: 9443
 
+# Host path where Caddy's internal root CA certificate is exported after
+# startup. Containers on the same host can mount this file and set
+# SSL_CERT_FILE so they trust Caddy's self-signed TLS. Only exported when
+# caddy_domain is set (i.e. Caddy is issuing internal certs).
+caddy_ca_cert_host_path: "/etc/pki/caddy-internal/root.crt"
+
 # Domain name for the server. Used for subdomain-based reverse proxy
 # routing and self-signed TLS certificates. If empty, Caddy only
 # serves the dashboard on :80 (no reverse proxy, no HTTPS).

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -62,6 +62,13 @@
       {{ [{'port': 80, 'proto': 'tcp', 'toport': caddy_listen_port}]
          + ([{'port': 443, 'proto': 'tcp', 'toport': caddy_listen_port_https}]
             if caddy_domain else []) }}
+    # Also open the HTTPS listen port directly (not only via 443→9443
+    # forward) so containers on this host can reach Caddy on
+    # <subdomain>.<caddy_domain>:{{ caddy_listen_port_https }} via the
+    # host-gateway. Firewall port-forwards only apply to external traffic,
+    # so pod-to-host traffic needs the port itself open.
+    podman_quadlet_firewall_ports: >-
+      {{ [caddy_listen_port_https ~ '/tcp'] if caddy_domain else [] }}
 
 - name: Reload Caddy configuration # noqa: no-changed-when
   become: true
@@ -69,3 +76,47 @@
     su - webproxy -c 'podman exec caddy caddy reload --config /etc/caddy/Caddyfile 2>&1'
   changed_when: false
   failed_when: false
+
+# --------------------------------------------------------------------------
+# Export Caddy's internal root CA certificate to a host path so other
+# containers (e.g. the Ente museum pod) can mount it and trust Caddy's
+# self-signed certs when talking to other services through Caddy.
+# --------------------------------------------------------------------------
+- name: Ensure Caddy CA cert host directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ caddy_ca_cert_host_path | dirname }}"
+    state: directory
+    mode: "0755"
+  when: caddy_domain | length > 0
+
+- name: Wait for Caddy's internal root CA to be generated # noqa: no-changed-when
+  become: true
+  ansible.builtin.shell: >
+    su - webproxy -c 'podman exec caddy
+    test -f /data/caddy/pki/authorities/local/root.crt'
+  register: caddy_ca_ready
+  retries: 30
+  delay: 2
+  until: caddy_ca_ready.rc == 0
+  changed_when: false
+  when: caddy_domain | length > 0
+
+- name: Export Caddy internal root CA to host # noqa: no-changed-when
+  become: true
+  ansible.builtin.shell: >
+    set -o pipefail;
+    su - webproxy -c 'podman exec caddy
+    cat /data/caddy/pki/authorities/local/root.crt'
+    > {{ caddy_ca_cert_host_path | quote }}
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: caddy_domain | length > 0
+
+- name: Set permissions on exported Caddy CA cert
+  become: true
+  ansible.builtin.file:
+    path: "{{ caddy_ca_cert_host_path }}"
+    mode: "0644"
+  when: caddy_domain | length > 0

--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -16,8 +16,12 @@
 
 # Service reverse proxies
 {% for svc in caddy_reverse_proxy_services %}
+{% if svc.tls | default(true) %}
 {{ svc.subdomain }}.{{ caddy_domain }} {
 	tls internal
+{% else %}
+http://{{ svc.subdomain }}.{{ caddy_domain }} {
+{% endif %}
 	reverse_proxy {{ svc.proto | default('http') }}://host.containers.internal:{{ svc.port }} {
 {% if (svc.proto | default('http')) == 'https' %}
 		transport http {

--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -14,6 +14,26 @@ entephoto_albums_url: "http://{{ ansible_facts['default_ipv4']['address'] }}:300
 # Override when proxying MinIO through a reverse proxy.
 entephoto_s3_endpoint: "{{ ansible_facts['default_ipv4']['address'] }}:3200"
 
+# When museum must reach MinIO via an HTTPS reverse proxy on the same host
+# (so presigned URLs work over HTTPS in the browser without mixed-content
+# errors), set these two variables. Leaving them empty keeps the direct-to-
+# MinIO behaviour.
+#
+#   entephoto_s3_host: hostname portion of entephoto_s3_endpoint — mapped
+#                      to host-gateway inside the pod so museum can resolve
+#                      it without the host's DNS server.
+#   entephoto_caddy_ca_cert_path: host path to the Caddy internal root CA
+#                      (see caddy_ca_cert_host_path). Mounted read-only and
+#                      pointed to via SSL_CERT_FILE so museum's Go runtime
+#                      trusts Caddy's self-signed TLS.
+entephoto_s3_host: ""
+entephoto_caddy_ca_cert_path: ""
+
+# Museum signs presigned URLs as http:// when are_local_buckets is true and
+# https:// when false. It must match the scheme of entephoto_s3_endpoint:
+# HTTP when museum talks directly to MinIO, HTTPS when proxying via Caddy.
+entephoto_s3_local_buckets: true
+
 # MinIO admin username (password comes from vault: entephoto_minio_password)
 entephoto_minio_root_user: enteadmin
 

--- a/roles/entephoto/tasks/main.yml
+++ b/roles/entephoto/tasks/main.yml
@@ -45,7 +45,7 @@
     podman_quadlet_rootless_user_name: entephoto
     podman_quadlet_files_templates_src_path: "{{ entephoto_role_path }}"
     podman_quadlet_file_names:
-      - entephoto.pod
+      - entephoto.pod.j2
       - entephoto.network
       - entephoto-postgres.container.j2
       - entephoto-minio.container.j2

--- a/roles/entephoto/templates/quadlets/entephoto-museum.container.j2
+++ b/roles/entephoto/templates/quadlets/entephoto-museum.container.j2
@@ -11,5 +11,15 @@ AutoUpdate=registry
 Pod=entephoto.pod
 
 Volume=entephoto-museum-config.volume:/museum.yaml.d:ro
+{% if entephoto_caddy_ca_cert_path %}
+# Trust Caddy's internal root CA so museum can talk to MinIO via the
+# HTTPS reverse-proxy subdomain (needed when presigned URLs are HTTPS).
+# The matching host entry (entephoto_s3_host → host-gateway) lives on
+# the pod — AddHost on a pod-member container is rejected by Podman.
+Volume={{ entephoto_caddy_ca_cert_path }}:/etc/ssl/certs/caddy-root.crt:ro
+{% endif %}
 
 Environment=ENTE_CREDENTIALS_FILE=/museum.yaml.d/museum.yaml
+{% if entephoto_caddy_ca_cert_path %}
+Environment=SSL_CERT_FILE=/etc/ssl/certs/caddy-root.crt
+{% endif %}

--- a/roles/entephoto/templates/quadlets/entephoto.pod.j2
+++ b/roles/entephoto/templates/quadlets/entephoto.pod.j2
@@ -6,6 +6,14 @@ Wants=network-online.target
 [Pod]
 PodName=entephoto
 Network=entephoto.network
+{% if entephoto_s3_host %}
+# Resolve the S3 reverse-proxy hostname inside the pod to the host, so
+# museum reaches Caddy on the host without depending on the host's DNS.
+# Host entries must live on the pod (not individual pod-member containers);
+# Quadlet's [Pod] section has no HostAdd key, so pass it through as an extra
+# podman pod create argument.
+PodmanArgs=--add-host={{ entephoto_s3_host }}:host-gateway
+{% endif %}
 
 # Museum API
 PublishPort=8080:8080/tcp

--- a/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
+++ b/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
@@ -6,7 +6,7 @@ db:
     password: {{ entephoto_db_password }}
 
 s3:
-    are_local_buckets: true
+    are_local_buckets: {{ entephoto_s3_local_buckets | to_json }}
     use_path_style_urls: true
     b2-eu-cen:
         key: enteadmin


### PR DESCRIPTION
## Summary
- Open Caddy's HTTPS listen port directly so pod-to-host traffic can reach it (firewall 443→9443 forward only covers external traffic).
- Export Caddy's internal root CA to a host path; mount it into the Ente museum container and set `SSL_CERT_FILE` so museum's Go runtime trusts Caddy when talking to MinIO.
- Convert `entephoto.pod` to a template and add a pod-level `--add-host` via `PodmanArgs=` so museum resolves the S3 reverse-proxy subdomain without depending on host DNS (and without `HostAdd=`, which Quadlet rejects on `[Pod]`).
- Make `are_local_buckets` configurable (new `entephoto_s3_local_buckets`). This is what actually controls the scheme of presigned URLs in Ente — `true` → http://, `false` → https://.

Combined with the matching host_vars change (S3 subdomain + HTTPS endpoint + CA path), the photos web app can now be served fully over HTTPS without mixed-content blocking on image/thumbnail requests.

Closes #33.

## Test plan
- [x] `ansible-playbook playbooks/caddy.yml` — firewall shows `9443/tcp` open and `/etc/pki/caddy-internal/root.crt` exported.
- [x] `ansible-playbook playbooks/entephoto.yml` — museum starts with pod-level add-host and CA mount.
- [x] Museum renders `museum.yaml` with `are_local_buckets: false` and `endpoint: photos-s3.eddie.lan:9443`.
- [x] `curl` against `https://photos-s3.eddie.lan:9443/` (via Caddy) returns MinIO 403 (proxy + TLS working).
- [x] Browser with Caddy root CA trusted: login to `https://photos.eddie.lan`, albums load, thumbnails render from `https://photos-s3.eddie.lan:9443/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)