### PR TITLE
Automated post-install verification for Pi-hole (closes #37)

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -89,12 +89,62 @@ resolving recursively from the root servers.
 
 ## Verifying ad blocking
 
+### Automated (runs at end of every deploy)
+
+By default the role runs `tasks/verify.yml` after post-install. It
+hard-fails the play if anything looks wrong:
+
+- Pi-hole container is healthy and FTL is listening.
+- `systemd-resolved` on the host points at `127.0.0.1:1053`.
+- `gravity.db` has more than zero domains (catches a silent adlist
+  download failure).
+- A known legitimate canary (`pihole_verify_canary_legit`, default
+  `example.com`) resolves normally.
+- A known blocked canary (`pihole_verify_canary_blocked`, default
+  `ad.doubleclick.net`) is sinkholed.
+- `pihole_verify_random_count` domains (default 5) drawn live from
+  gravity are all sinkholed.
+- When `pihole_enable_unbound: true`: Unbound is active, listening on
+  `127.0.0.1:{{ pihole_unbound_port }}`, and Pi-hole's effective
+  upstream is exclusively that local Unbound (no Quad9/Cloudflare/
+  Google leak).
+
+Re-run the verification alone without redeploying:
+
+```bash
+ansible-playbook playbooks/pihole.yml --tags verify
+```
+
+Skip verification for a run:
+
+```bash
+ansible-playbook playbooks/pihole.yml --skip-tags verify
+```
+
+Disable permanently for a host by setting
+`pihole_run_verification: false` in that host's vars.
+
+#### Optional external-leak probe
+
+Set `pihole_verify_online: true` to also run a Mullvad DNS-leak probe
+(`https://am.i.mullvad.net/json`) from the Pi-hole host. Off by default
+because it requires outbound internet — leave it off for CI or
+disconnected environments. The probe fails if the answer shows a
+well-known external resolver (Quad9/Cloudflare/Google).
+
 ### Quick test
 
 Open [adblock.turtlecute.org](https://adblock.turtlecute.org/) in a
 browser that uses Pi-hole for DNS (disable DNS-over-HTTPS in browser
 settings first). The page tests requests against known ad/tracker
 domains and shows which ones are blocked.
+
+Note: some browser-level ad blockers (uBlock Origin, AdGuard) cancel
+requests at the extension layer with an error code the tester does
+not classify as "blocked", so the page can read "nothing filtered"
+even when both DNS- and browser-level blocking are active. The
+authoritative view is Pi-hole's own Query Log (admin UI → Query Log,
+or `sudo -u pihole podman exec pihole pihole -t`).
 
 ### Command-line test
 

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -45,6 +45,28 @@ pihole_enable_unbound: true
 # on localhost). Convention: 5335 to avoid conflict with Pi-hole on 53.
 pihole_unbound_port: 5335
 
+# Run the tasks in verify.yml at the end of deploy to assert that Pi-hole
+# actually works (container healthy, gravity populated, canary blocked,
+# upstream is Unbound and not leaking externally). Hard-fails the play on
+# regression. Set to false to skip, or use `--skip-tags verify`.
+pihole_run_verification: true
+
+# How many random domains to pull from gravity and re-check during
+# verification. Higher = more coverage, slower play. 5 is a good
+# compromise for smoke-test purposes.
+pihole_verify_random_count: 5
+
+# Canary domains used by verify.yml. Override if you want to test
+# something different — but these defaults are stable and should be in
+# every reasonable adlist / safe to resolve indefinitely.
+pihole_verify_canary_blocked: "ad.doubleclick.net"
+pihole_verify_canary_legit: "example.com"
+
+# Opt-in external-leak probe via Mullvad's `am.i.mullvad.net/json`.
+# Requires outbound internet from the Pi-hole host. Off by default so
+# verification works in offline/CI/restricted environments.
+pihole_verify_online: false
+
 # Backup manifest — consumed by the backup role and restore playbook.
 backup_manifest:
   service_user: pihole

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -100,6 +100,17 @@
     state: directory
     mode: "0755"
 
+# Remove the bootstrap drop-in that points at Quad9. systemd-resolved merges
+# all drop-ins additively — leaving this one behind adds 9.9.9.9 alongside
+# our 127.0.0.1:1053, and resolved freely round-robins between them, which
+# silently bypasses Pi-hole's blocking for whichever queries land on Quad9.
+- name: Remove bootstrap DNS drop-in (superseded by pihole.conf)
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/resolved.conf.d/temp-dns.conf
+    state: absent
+  register: pihole_resolved_bootstrap_removed
+
 - name: Configure systemd-resolved to use Pi-hole
   become: true
   ansible.builtin.copy:
@@ -116,10 +127,26 @@
   ansible.builtin.systemd_service:
     name: systemd-resolved
     state: restarted
-  when: pihole_resolved_config.changed
+  when: pihole_resolved_config.changed or pihole_resolved_bootstrap_removed.changed
+
+# Even after restart, clients that previously queried a given name may see
+# stale answers until their own DNS caches expire. Flushing resolved's
+# cache here ensures the host immediately starts getting fresh answers
+# through Pi-hole rather than replaying cached pre-install results.
+- name: Flush systemd-resolved DNS caches # noqa: no-changed-when
+  become: true
+  ansible.builtin.command: resolvectl flush-caches
+  changed_when: false
+  when: pihole_resolved_config.changed or pihole_resolved_bootstrap_removed.changed
 
 - name: Run post-install configuration
   ansible.builtin.import_tasks: postinstall.yml
+
+- name: Run post-install verification
+  ansible.builtin.import_tasks: verify.yml
+  when: pihole_run_verification | bool
+  tags:
+    - verify
 
 - name: Register backup manifest
   ansible.builtin.set_fact:

--- a/roles/pihole/tasks/verify.yml
+++ b/roles/pihole/tasks/verify.yml
@@ -1,0 +1,153 @@
+---
+# Post-install smoke tests. Hard-fails the playbook when Pi-hole is up but
+# not actually doing its job (gravity empty, canary leaking, Unbound
+# bypassed, etc.). Re-runnable with `--tags verify`. Skip entirely with
+# `--skip-tags verify` or set `pihole_run_verification: false`.
+
+# Flush the resolver cache before testing so we see the live behaviour,
+# not stale answers from before Pi-hole was deployed or last reconfigured.
+- name: Flush systemd-resolved DNS cache before verification # noqa: no-changed-when
+  become: true
+  ansible.builtin.command: resolvectl flush-caches
+  changed_when: false
+
+- name: Verify Pi-hole container reports FTL listening
+  become: true
+  ansible.builtin.command:
+    cmd: su - pihole -c 'podman exec pihole pihole status'
+  register: _pihole_verify_status
+  changed_when: false
+  failed_when: "'FTL is listening' not in _pihole_verify_status.stdout"
+
+- name: Verify systemd-resolved points at Pi-hole on 127.0.0.1:1053
+  become: true
+  ansible.builtin.command: resolvectl status
+  register: _pihole_verify_resolvectl
+  changed_when: false
+  failed_when: "'127.0.0.1:1053' not in _pihole_verify_resolvectl.stdout"
+
+- name: Read gravity entry count
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      su - pihole -c "podman exec pihole pihole-FTL sqlite3
+      /etc/pihole/gravity.db 'SELECT count(*) FROM gravity;'"
+  register: _pihole_verify_gravity_count
+  changed_when: false
+
+- name: Assert gravity has more than zero domains
+  ansible.builtin.assert:
+    that:
+      - _pihole_verify_gravity_count.stdout | int > 0
+    fail_msg: >-
+      Gravity DB is empty ({{ _pihole_verify_gravity_count.stdout | trim }}).
+      Adlist download likely failed — check `pihole -g` output and the
+      addresses in pihole_adlists.
+
+- name: Verify legitimate canary ({{ pihole_verify_canary_legit }}) resolves to a real address
+  ansible.builtin.command: "getent ahosts {{ pihole_verify_canary_legit }}"
+  register: _pihole_verify_legit
+  changed_when: false
+  failed_when: >-
+    _pihole_verify_legit.rc != 0 or
+    _pihole_verify_legit.stdout | length == 0 or
+    (_pihole_verify_legit.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is not none
+
+- name: Verify blocked canary ({{ pihole_verify_canary_blocked }}) is sinkholed
+  ansible.builtin.command: "getent ahosts {{ pihole_verify_canary_blocked }}"
+  register: _pihole_verify_blocked
+  changed_when: false
+  failed_when: >-
+    _pihole_verify_blocked.rc == 0 and
+    (_pihole_verify_blocked.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is none
+
+- name: Sample {{ pihole_verify_random_count }} random domains from gravity
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      su - pihole -c "podman exec pihole pihole-FTL sqlite3
+      /etc/pihole/gravity.db
+      'SELECT domain FROM gravity ORDER BY RANDOM() LIMIT {{ pihole_verify_random_count }};'"
+  register: _pihole_verify_random_sample
+  changed_when: false
+
+- name: Verify each random sample is sinkholed (no upstream leaks)
+  ansible.builtin.command: "getent ahosts {{ item }}"
+  register: _pihole_verify_random_check
+  changed_when: false
+  loop: "{{ _pihole_verify_random_sample.stdout_lines }}"
+  failed_when: >-
+    _pihole_verify_random_check.rc == 0 and
+    (_pihole_verify_random_check.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is none
+
+# --- Unbound path (only when pihole_enable_unbound is true) ---
+
+- name: Verify Unbound systemd unit is active
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      sudo -u pihole XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.pihole.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.pihole.uid }}/bus
+      systemctl --user is-active unbound
+  register: _pihole_verify_unbound_active
+  changed_when: false
+  failed_when: _pihole_verify_unbound_active.rc != 0
+  when: pihole_enable_unbound | bool
+
+- name: Verify Unbound is reachable on 127.0.0.1:{{ pihole_unbound_port }} from inside the Pi-hole pod
+  become: true
+  ansible.builtin.command:
+    # Unbound shares the pi-hole pod's network namespace and listens only
+    # on that namespace's loopback — invisible from the host. Probe it
+    # from inside the pihole container instead, where 127.0.0.1 reaches it.
+    cmd: >-
+      su - pihole -c "podman exec pihole timeout 2
+      bash -c '</dev/tcp/127.0.0.1/{{ pihole_unbound_port }}'"
+  register: _pihole_verify_unbound_listen
+  changed_when: false
+  failed_when: _pihole_verify_unbound_listen.rc != 0
+  when: pihole_enable_unbound | bool
+
+- name: Read Pi-hole effective upstream DNS
+  become: true
+  ansible.builtin.command:
+    # pihole-FTL --config dns.upstreams prints the resolved list on a single
+    # line like `[ 127.0.0.1#5335 ]` — easier to assert against than the
+    # multi-line TOML in pihole.toml.
+    cmd: "su - pihole -c 'podman exec pihole pihole-FTL --config dns.upstreams'"
+  register: _pihole_verify_upstreams
+  changed_when: false
+  when: pihole_enable_unbound | bool
+
+- name: Assert Pi-hole upstream is local Unbound only (no external DNS leak)
+  ansible.builtin.assert:
+    that:
+      - ('127.0.0.1#' ~ pihole_unbound_port) in _pihole_verify_upstreams.stdout
+      # Reject any well-known external resolver in the upstream list.
+      - "'9.9.9.9' not in _pihole_verify_upstreams.stdout"
+      - "'149.112.112.112' not in _pihole_verify_upstreams.stdout"
+      - "'1.1.1.1' not in _pihole_verify_upstreams.stdout"
+      - "'1.0.0.1' not in _pihole_verify_upstreams.stdout"
+      - "'8.8.8.8' not in _pihole_verify_upstreams.stdout"
+      - "'8.8.4.4' not in _pihole_verify_upstreams.stdout"
+    fail_msg: >-
+      Pi-hole upstream is NOT exclusively the local Unbound (127.0.0.1#{{ pihole_unbound_port }}).
+      Effective config: {{ _pihole_verify_upstreams.stdout | trim }}.
+      Either the deploy did not pick up pihole_enable_unbound=true,
+      or pihole_dns_upstreams is overriding it.
+  when: pihole_enable_unbound | bool
+
+# --- Optional external leak probe (off by default — needs internet) ---
+
+- name: External DNS-leak check via Mullvad (opt-in)
+  ansible.builtin.uri:
+    url: https://am.i.mullvad.net/json
+    return_content: true
+    timeout: 10
+  register: _pihole_verify_mullvad
+  failed_when: >-
+    _pihole_verify_mullvad.json.dns | default([])
+    | selectattr('ip', 'in', ['9.9.9.9','149.112.112.112','1.1.1.1','1.0.0.1','8.8.8.8','8.8.4.4'])
+    | list | length > 0
+  changed_when: false
+  when: pihole_verify_online | bool


### PR DESCRIPTION
## Summary
- New \`roles/pihole/tasks/verify.yml\` asserts that a freshly-deployed Pi-hole is actually blocking and that its upstream is exclusively Unbound (no external DNS leak).
- Hard-fails the playbook on regression. Re-runnable standalone with \`--tags verify\`. Opt-out via \`--skip-tags verify\` or \`pihole_run_verification: false\`.
- Optional \`pihole_verify_online: true\` enables a Mullvad external-leak probe.
- Fixes a latent bug caught by the very first run of the new verify task: the role now removes the bootstrap \`temp-dns.conf\` resolved drop-in and flushes the resolver cache when the DNS config changes. That stale file was silently adding \`9.9.9.9\` alongside \`127.0.0.1:1053\` in systemd-resolved, letting roughly half of queries bypass Pi-hole entirely.

## Test plan
- [x] \`ansible-playbook playbooks/pihole.yml -l homeserver --tags verify\` — all 14 assertions pass on a healthy system.
- [x] Verify task correctly *fails* on a real leak: the initial run flagged the \`temp-dns.conf\` bootstrap drop-in and the Quad9 leak it caused — without that, we'd still be running Pi-hole side-by-side with Quad9 and not knowing.
- [x] Canary domains (\`example.com\` / \`ad.doubleclick.net\`) and 5 random gravity samples all correctly classified.
- [x] Unbound tests: container active, reachable on \`127.0.0.1:5335\` inside the pod network namespace, Pi-hole upstream reads back as \`[ 127.0.0.1#5335 ]\` with no external IPs.
- [x] \`--skip-tags verify\` cleanly skips the block. \`pihole_run_verification: false\` gates the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)