### PR TITLE
Fall back to cached image when pre-pull fails

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -14,9 +14,14 @@ Enabled by default (`pihole_enable_unbound: true`).
 | Container | Image |
 |-----------|-------|
 | pihole | `ghcr.io/pi-hole/pihole:latest` (override via `pihole_image`) |
-| unbound | `docker.io/klutchell/unbound:latest` (when `pihole_enable_unbound` is true) |
+| unbound | `docker.io/klutchell/unbound:latest` (override via `pihole_unbound_image`; only pulled when `pihole_enable_unbound` is true) |
 
-GHCR mirror for Pi-hole avoids Docker Hub anonymous pull rate limits.
+Pi-hole's image is mirrored on GHCR to sidestep Docker Hub's anonymous
+pull rate limit. Unbound only exists on Docker Hub, so the pre-pull
+task treats pull failures (rate limit, transient DNS issue, etc.) as
+non-fatal when the image is already cached locally — redeploys keep
+working without authentication once the image has been pulled at least
+once.
 
 ## Service user
 

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -45,6 +45,13 @@ pihole_enable_unbound: true
 # on localhost). Convention: 5335 to avoid conflict with Pi-hole on 53.
 pihole_unbound_port: 5335
 
+# Unbound container image. Only published on Docker Hub, which
+# aggressively rate-limits unauthenticated pulls — the pre-pull task
+# falls back to the locally cached image when the pull fails, so
+# redeploys keep working without credentials once the image has been
+# pulled at least once.
+pihole_unbound_image: "docker.io/klutchell/unbound:latest"
+
 # Run the tasks in verify.yml at the end of deploy to assert that Pi-hole
 # actually works (container healthy, gravity populated, canary blocked,
 # upstream is Unbound and not leaking externally). Hard-fails the play on

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -34,16 +34,70 @@
 # Without this, the podman_quadlet restart step would stop pihole, then try
 # to pull the new image, then fail because pihole IS the host's DNS server
 # (lookup of ghcr.io / docker.io fails the moment pihole is down).
+#
+# If the pull itself fails (most commonly Docker Hub's anonymous-pull rate
+# limit on the Unbound image), fall back to whatever is already in the
+# local image store — redeploys shouldn't be blocked by a registry hiccup
+# when the image is already cached. We only hard-fail if both the pull
+# and the local-image check come back empty.
 - name: Pre-pull Pi-hole image while old container still serves DNS # noqa: no-changed-when
   become: true
-  ansible.builtin.shell: "su - pihole -c 'podman pull {{ pihole_image }}'"
+  ansible.builtin.command:
+    cmd: "su - pihole -c 'podman pull {{ pihole_image }}'"
+  register: _pihole_image_pull
+  changed_when: "'Writing manifest' in _pihole_image_pull.stdout"
+  failed_when: false
+
+- name: Verify Pi-hole image is available locally (pull OK or already cached)
+  become: true
+  ansible.builtin.command:
+    cmd: "su - pihole -c 'podman image exists {{ pihole_image }}'"
+  register: _pihole_image_cached
   changed_when: false
+  failed_when:
+    - _pihole_image_pull.rc != 0
+    - _pihole_image_cached.rc != 0
+
+- name: Warn when Pi-hole image pull failed but cached copy is in use
+  ansible.builtin.debug:
+    msg: >-
+      podman pull {{ pihole_image }} failed — continuing with the
+      locally cached image. Root cause (first line):
+      {{ (_pihole_image_pull.stderr | default('') | split('\n') | first) | trim }}
+  when:
+    - _pihole_image_pull.rc != 0
+    - _pihole_image_cached.rc == 0
 
 - name: Pre-pull Unbound image # noqa: no-changed-when
   become: true
-  ansible.builtin.shell: "su - pihole -c 'podman pull docker.io/klutchell/unbound:latest'"
-  changed_when: false
+  ansible.builtin.command:
+    cmd: "su - pihole -c 'podman pull {{ pihole_unbound_image }}'"
+  register: _pihole_unbound_pull
+  changed_when: "'Writing manifest' in _pihole_unbound_pull.stdout"
+  failed_when: false
   when: pihole_enable_unbound | bool
+
+- name: Verify Unbound image is available locally (pull OK or already cached)
+  become: true
+  ansible.builtin.command:
+    cmd: "su - pihole -c 'podman image exists {{ pihole_unbound_image }}'"
+  register: _pihole_unbound_cached
+  changed_when: false
+  failed_when:
+    - _pihole_unbound_pull.rc != 0
+    - _pihole_unbound_cached.rc != 0
+  when: pihole_enable_unbound | bool
+
+- name: Warn when Unbound image pull failed but cached copy is in use
+  ansible.builtin.debug:
+    msg: >-
+      podman pull {{ pihole_unbound_image }} failed — continuing with
+      the locally cached image. Root cause (first line):
+      {{ (_pihole_unbound_pull.stderr | default('') | split('\n') | first) | trim }}
+  when:
+    - pihole_enable_unbound | bool
+    - _pihole_unbound_pull.rc != 0
+    - _pihole_unbound_cached.rc == 0
 
 # Deploy the Unbound config file to the pihole user's home.
 # Bind-mounted into the container as a read-only drop-in.

--- a/roles/pihole/templates/quadlets/unbound.container.j2
+++ b/roles/pihole/templates/quadlets/unbound.container.j2
@@ -6,7 +6,7 @@ BindsTo=pihole.service
 
 [Container]
 ContainerName=%N
-Image=docker.io/klutchell/unbound:latest
+Image={{ pihole_unbound_image }}
 AutoUpdate=registry
 # Share Pi-hole's network namespace so both containers see the same
 # loopback — Pi-hole can reach Unbound at 127.0.0.1:{{ pihole_unbound_port }}.


### PR DESCRIPTION
## Summary
- Pi-hole and Unbound pre-pull tasks treat \`podman pull\` failure as non-fatal when \`podman image exists\` finds the image already cached. A warning is printed so the failure is visible, but the deploy continues.
- Fresh installs still hard-fail when the pull fails and there's no cached image — as they must.
- Extracts the Unbound image to a new \`pihole_unbound_image\` variable (default unchanged), so future GHCR mirrors or self-built images can be swapped in without editing the role.

## Motivation

Hit Docker Hub's anonymous-pull rate limit twice in the past week on redeploys where the Unbound image was already cached. That failure blocked the entire pihole playbook — including the DNS drop-in cleanup and (in the other PR) the verification task — for a transient registry issue that shouldn't have any effect on an already-cached image.

## Test plan
- [x] Syntax check passes.
- [x] Logic review: \`failed_when\` on the \`image exists\` check correctly hard-fails only when both pull AND local cache miss.
- [ ] Rate-limit scenario (live): next deploy that hits the Docker Hub limit will see the warning and continue instead of failing.
- [ ] Fresh-install scenario (no cached image, rate-limited): still fails — verified by reading the \`failed_when\` expression, untested live (would require wiping the podman storage on eddie).

## Scope

Role-only change in the public repo. No private-inventory changes needed; defaults keep today's behaviour bit-for-bit except for the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)