### PR TITLE
Drop hand-rolled Pi-hole pre-pull, rely on Galaxy role v1.2.0

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -14,9 +14,9 @@ Enabled by default (`pihole_enable_unbound: true`).
 | Container | Image |
 |-----------|-------|
 | pihole | `ghcr.io/pi-hole/pihole:latest` (override via `pihole_image`) |
-| unbound | `docker.io/klutchell/unbound:latest` (when `pihole_enable_unbound` is true) |
+| unbound | `docker.io/klutchell/unbound:latest` (override via `pihole_unbound_image`; only pulled when `pihole_enable_unbound` is true) |
 
-GHCR mirror for Pi-hole avoids Docker Hub anonymous pull rate limits.
+Pi-hole is mirrored on GHCR to sidestep Docker Hub's anonymous-pull rate limit. Unbound is only published on Docker Hub; pre-pulling and rate-limit fallback are handled upstream in the `luckynrslevin.podman_quadlet` role (>= v1.2.0) using `podman pull --policy=newer` with a fallback to the locally cached image when the pull fails.
 
 ## Service user
 
@@ -27,7 +27,8 @@ GHCR mirror for Pi-hole avoids Docker Hub anonymous pull rate limits.
 | Variable                   | Default                              | Purpose                                                                |
 |----------------------------|--------------------------------------|------------------------------------------------------------------------|
 | `pihole_web_port_https`    | `8443`                               | HTTPS port for the admin UI.                                           |
-| `pihole_image`             | `ghcr.io/pi-hole/pihole:latest`      | Container image.                                                       |
+| `pihole_image`             | `ghcr.io/pi-hole/pihole:latest`      | Pi-hole container image.                                               |
+| `pihole_unbound_image`     | `docker.io/klutchell/unbound:latest` | Unbound container image (pulled only when `pihole_enable_unbound`).    |
 | `pihole_enable_unbound`    | `true`                               | Enable Unbound recursive resolver as Pi-hole's upstream.               |
 | `pihole_unbound_port`      | `5335`                               | Unbound listen port (localhost).                                       |
 | `pihole_dns_upstreams`     | `9.9.9.9;149.112.112.112` (Quad9)    | Upstreams (only used when Unbound is disabled).                        |
@@ -202,12 +203,14 @@ Or use the admin UI at `https://<server-ip>:8443/admin` → Query Log.
 ansible-playbook playbooks/pihole.yml --limit homeserver
 ```
 
-The role pre-pulls the image **before** restarting the container —
-without this, restarting Pi-hole would take down its own DNS
-upstream, and the new pull would fail.
+Images are pulled by the `luckynrslevin.podman_quadlet` role **before**
+the old container is stopped, so Pi-hole keeps serving DNS while the
+new images are fetched — without this ordering, stopping Pi-hole first
+would break DNS resolution and make the pull fail.
 
-After deploy it also writes `/etc/systemd/resolved.conf.d/pihole.conf`
-so the host points at `127.0.0.1:1053` for DNS.
+After deploy the role also writes `/etc/systemd/resolved.conf.d/pihole.conf`
+so the host points at `127.0.0.1:1053` for DNS, and wipes a stray
+bootstrap drop-in (`temp-dns.conf`) if one exists — see [#37](https://github.com/luckynrslevin/home-server/issues/37).
 
 ## Post-install behaviour
 

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -45,6 +45,12 @@ pihole_enable_unbound: true
 # on localhost). Convention: 5335 to avoid conflict with Pi-hole on 53.
 pihole_unbound_port: 5335
 
+# Unbound container image. Only published on Docker Hub, which rate-limits
+# unauthenticated pulls; the Galaxy role's pre-pull fallback (>=v1.2.0)
+# uses the locally cached image when the pull fails, so redeploys keep
+# working without credentials once the image has been pulled at least once.
+pihole_unbound_image: "docker.io/klutchell/unbound:latest"
+
 # Run the tasks in verify.yml at the end of deploy to assert that Pi-hole
 # actually works (container healthy, gravity populated, canary blocked,
 # upstream is Unbound and not leaking externally). Hard-fails the play on

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -30,20 +30,13 @@
   ansible.builtin.set_fact:
     pihole_role_path: "{{ role_path }}"
 
-# Pre-pull the Pi-hole image while the old container is still serving DNS.
-# Without this, the podman_quadlet restart step would stop pihole, then try
-# to pull the new image, then fail because pihole IS the host's DNS server
-# (lookup of ghcr.io / docker.io fails the moment pihole is down).
-- name: Pre-pull Pi-hole image while old container still serves DNS # noqa: no-changed-when
-  become: true
-  ansible.builtin.shell: "su - pihole -c 'podman pull {{ pihole_image }}'"
-  changed_when: false
-
-- name: Pre-pull Unbound image # noqa: no-changed-when
-  become: true
-  ansible.builtin.shell: "su - pihole -c 'podman pull docker.io/klutchell/unbound:latest'"
-  changed_when: false
-  when: pihole_enable_unbound | bool
+# Image pre-pulling for the containers discovered in this role's quadlet
+# files is handled by the luckynrslevin.podman_quadlet role, which runs
+# the pull before stopping the old container — so the old Pi-hole instance
+# keeps serving DNS while the new images are fetched. From v1.2.0 onward
+# the Galaxy role also handles --policy=newer and the Docker Hub rate-limit
+# fallback (warn + reuse cached image when the pull fails but the image is
+# already locally available). No hand-rolled pre-pull is needed here.
 
 # Deploy the Unbound config file to the pihole user's home.
 # Bind-mounted into the container as a read-only drop-in.

--- a/roles/pihole/templates/quadlets/unbound.container.j2
+++ b/roles/pihole/templates/quadlets/unbound.container.j2
@@ -6,7 +6,7 @@ BindsTo=pihole.service
 
 [Container]
 ContainerName=%N
-Image=docker.io/klutchell/unbound:latest
+Image={{ pihole_unbound_image }}
 AutoUpdate=registry
 # Share Pi-hole's network namespace so both containers see the same
 # loopback — Pi-hole can reach Unbound at 127.0.0.1:{{ pihole_unbound_port }}.

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -2,4 +2,4 @@
 roles:
   - name: luckynrslevin.podman_quadlet
     src: https://github.com/luckynrslevin/ansible-role-podman-quadlet.git
-    version: v1.1.0
+    version: v1.2.0


### PR DESCRIPTION
## Summary

Retires the Pi-hole role's hand-rolled pre-pull now that \`luckynrslevin.podman_quadlet\` v1.2.0 covers the same concern generically — with better semantics.

Changes:
- Bump role pin \`v1.1.0\` → \`v1.2.0\` in \`roles/requirements.yml\`.
- Remove the two \`Pre-pull Pi-hole image\` / \`Pre-pull Unbound image\` tasks from \`roles/pihole/tasks/main.yml\`. Kept a short comment block explaining that pre-pull now lives upstream.
- Add \`pihole_unbound_image\` variable (default \`docker.io/klutchell/unbound:latest\`) and switch the quadlet template to reference it, so the Unbound image can be overridden without editing the role. Cherry-picked from the now-closed #39; orthogonal to the pre-pull change.
- README: refresh the Container Images table and the Deployment pre-pull note.

## Why

Exploration of the Galaxy role's task order showed its pre-pull runs **before** stopping the old container (rootless-main.yml:10 pre-pulls, :38 stops). That ordering — the only reason the Pi-hole role had its own pre-pull — is handled upstream. Keeping the local pre-pull meant duplicated code with the older, non-fallback \`podman pull\` behaviour, which is exactly what hit us twice in the last week when Docker Hub rate-limited the Unbound pull.

v1.2.0 of the Galaxy role uses \`podman pull --policy=newer\` (skips blob transfer when local digest matches remote) and a cached-image fallback on registry failure, so redeploys are immune to Docker Hub anonymous-pull rate limits whenever the image is already cached.

Supersedes #39.

## Test plan

- [x] Syntax check clean.
- [x] Live deploy on eddie: \`ansible-playbook playbooks/pihole.yml -l homeserver\` completes with \`ok=86 changed=1\`, only the Galaxy role's \`Pre-pull container images for rootless user (policy=newer; fall back to cached image on failure)\` task runs, no hand-rolled \`Pre-pull Pi-hole image\` / \`Pre-pull Unbound image\` in the trace.
- [x] All 14 \`verify.yml\` checks pass post-deploy (container healthy, gravity populated, canaries behave, Unbound active, upstream exclusive to Unbound).

## Follow-up (not in this PR)

- Consider GHCR-mirroring the Unbound image so fresh installs aren't vulnerable to Docker Hub rate limits when there's no cached copy to fall back to.