### PR TITLE
Pre-create scan subdirectories via paperless_sftp_scan_subdirs

### DIFF
--- a/roles/paperless-ngx/README.md
+++ b/roles/paperless-ngx/README.md
@@ -31,6 +31,7 @@ Gotenberg (document conversion).
 | `paperless_sftp_image` | `docker.io/atmoz/sftp:latest` | Sidecar image — override only if mirroring to GHCR or similar. |
 | `paperless_sftp_port` | `2222` | Host TCP port the sidecar publishes. |
 | `paperless_sftp_ingest_authorized_keys` | `[]` | List of SSH public-key strings authorised to SFTP as `paperless-scanner`. Typically set from vault. |
+| `paperless_sftp_scan_subdirs` | `[]` | Subdirectories pre-created under `/scan/` so the scanner can target specific folders (e.g., `dirk`, `dirk/rechnungen`, `astrid/steuer`). Nested paths supported via `mkdir -p`. |
 
 ## Secrets
 
@@ -117,6 +118,16 @@ paperless_sftp_ingest_enabled: true
 paperless_sftp_ingest_authorized_keys:
   - "ssh-ed25519 AAAA…host-key-comment scanner@brother"
   # additional keys on additional lines
+
+# Optional: pre-create destination subfolders so the scanner can pick
+# one from its own folder picker without having to mkdir on first scan.
+# Nested paths are supported (created with `mkdir -p`). Entries never
+# removed from the volume by this role — delete folders manually via
+# SFTP if you want to retire one.
+paperless_sftp_scan_subdirs:
+  - dirk
+  - dirk/rechnungen
+  - astrid/steuer
 ```
 
 Typical setup is to **vault-encrypt** the `paperless_sftp_ingest_authorized_keys`

--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -41,6 +41,20 @@ paperless_sftp_port: 2222
 # Empty list + enabled flag = hard fail at deploy (see tasks/main.yml).
 paperless_sftp_ingest_authorized_keys: []
 
+# Pre-created subdirectories inside the SFTP scan folder. Each entry
+# is a path relative to /scan/ (inside the scanner's SFTP session) and
+# is created with `mkdir -p`, so nested paths like "dirk/rechnungen"
+# work. Useful for letting the scanner drop scans into topic-specific
+# folders without needing to create the folder tree on the first scan.
+# Ownership is set so the SFTP user can write; the role does not
+# remove folders that disappear from this list on subsequent deploys.
+# Example:
+#   paperless_sftp_scan_subdirs:
+#     - dirk
+#     - dirk/rechnungen
+#     - astrid/steuer
+paperless_sftp_scan_subdirs: []
+
 # Backup manifest — consumed by the backup role and restore playbook.
 backup_manifest:
   service_user: paperless

--- a/roles/paperless-ngx/tasks/main.yml
+++ b/roles/paperless-ngx/tasks/main.yml
@@ -100,6 +100,35 @@
       - "{{ paperless_sftp_port }}/tcp"
   when: paperless_sftp_ingest_enabled | bool
 
+# Pre-create scan subdirs inside the paperless-consume volume so the
+# scanner can target a specific folder without needing to create it
+# on first use. Runs under `podman unshare` as the paperless rootless
+# user so the resulting UID/GID (1000:1000 inside the container) maps
+# to the right host-side subuid automatically — same scheme the SFTP
+# sidecar and paperless-ngx both rely on.
+- name: Discover paperless-consume volume mountpoint
+  become: true
+  ansible.builtin.command:
+    cmd: su - paperless -c "podman volume inspect paperless-consume --format '{% raw %}{{ .Mountpoint }}{% endraw %}'"
+  register: _paperless_consume_mp
+  changed_when: false
+  when:
+    - paperless_sftp_ingest_enabled | bool
+    - paperless_sftp_scan_subdirs | length > 0
+
+- name: Pre-create SFTP scan subdirectories
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      su - paperless -c
+      "podman unshare bash -c 'mkdir -p {{ (_paperless_consume_mp.stdout + '/' + item) | quote }}
+      && chown 1000:1000 {{ (_paperless_consume_mp.stdout + '/' + item) | quote }}'"
+  loop: "{{ paperless_sftp_scan_subdirs }}"
+  changed_when: false
+  when:
+    - paperless_sftp_ingest_enabled | bool
+    - paperless_sftp_scan_subdirs | length > 0
+
 - name: Register backup manifest
   ansible.builtin.set_fact:
     _backup_manifests: >-


### PR DESCRIPTION
## Summary

Adds a new inventory-level variable \`paperless_sftp_scan_subdirs\` (default \`[]\`) that lets you pre-create named subdirectories inside the SFTP sidecar's \`/scan/\` drop target. Useful for organising scans by topic/person without having to \`mkdir\` from the scanner UI on first use.

Nested paths work via \`mkdir -p\`, so \`dirk/rechnungen\` creates both layers in one go.

Example (in private host_vars):
\`\`\`yaml
paperless_sftp_scan_subdirs:
  - dirk
  - dirk/rechnungen
  - astrid/steuer
\`\`\`

## Design

- Uses the established \`su - paperless -c \"podman unshare ...\"\` pattern to run \`mkdir\` + \`chown 1000:1000\` under paperless's user namespace. That lines the dir ownership up with both paperless's \`USERMAP_UID=1000\` AND the SFTP sidecar's \`paperless-scanner\` UID, so reads, writes, and deletes work cleanly across both containers.
- Gated on \`paperless_sftp_ingest_enabled: true\` AND \`paperless_sftp_scan_subdirs\` non-empty — otherwise the tasks skip cleanly, preserving no-op deploys for users who don't need the feature.
- Non-destructive: if you remove an entry from the list, the role leaves the directory in place (with any content). Explicit \`podman unshare rm -rf\` is required to retire a folder.

## Test plan

- [x] Syntax check clean.
- [x] Flag-off deploy: \`ok=137 changed=0 skipped=34\`, subdir tasks correctly skipped.
- [x] Populated test list (\`test-a\`, \`test-a/nested\`, \`test-b\`) via \`-e\` override:
  - Directories created with correct ownership (\`paperless-scanner:group_1000\` from sidecar view, \`paperless:paperless\` from paperless-ngx view — both UID 1000).
  - Nested path handled correctly (\`test-a/nested\` created in one go).
  - Cleanup via \`podman unshare rm -rf\` worked.

## Out of scope

- Subdirs-as-tags (\`PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS=true\`) — separate role-env tweak if you want each folder to auto-tag consumed docs with the folder's name. Not needed for this PR.
- Removal semantics — this PR adds only; removing a folder still requires manual action. Could add a corresponding \`paperless_sftp_scan_subdirs_remove\` list later if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)