### PR TITLE
Expose PAPERLESS_CONSUMER_{RECURSIVE,SUBDIRS_AS_TAGS,DELETE_DUPLICATES}

### DIFF
--- a/roles/paperless-ngx/README.md
+++ b/roles/paperless-ngx/README.md
@@ -27,6 +27,9 @@ Gotenberg (document conversion).
 | `paperless_time_zone` | `Europe/Berlin` | Timezone for timestamps and scheduler. |
 | `paperless_ocr_language` | `deu+eng` | OCR languages (ISO 639-2, `+` separated). |
 | `paperless_enable_gotenberg` | `true` | Enable Gotenberg for Office doc conversion. |
+| `paperless_consumer_recursive` | `false` | Watch subdirectories of the consume volume, not just the top level. Required if you drop files into per-topic subfolders. |
+| `paperless_consumer_subdirs_as_tags` | `false` | Auto-tag each ingested document with the name of the subdirectory it was dropped into. Pairs with `paperless_sftp_scan_subdirs`. |
+| `paperless_consumer_delete_duplicates` | `false` | Silently delete dropped files whose MD5 matches an existing document, instead of moving them to the error area. Cleaner than repeated manual cleanup. |
 | `paperless_sftp_ingest_enabled` | `false` | Deploy the SFTP sidecar so scanners / SFTP clients can drop PDFs straight into the consume volume. See [Scanner SFTP auto-ingest](#scanner-sftp-auto-ingest) below. |
 | `paperless_sftp_image` | `docker.io/atmoz/sftp:latest` | Sidecar image — override only if mirroring to GHCR or similar. |
 | `paperless_sftp_port` | `2222` | Host TCP port the sidecar publishes. |

--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -19,6 +19,27 @@ paperless_ocr_language: "deu+eng"
 # Enable Gotenberg for Office document conversion (docx, xlsx, pptx → PDF).
 paperless_enable_gotenberg: true
 
+# Consumer behaviour.
+#
+# consumer_recursive:        watch subdirectories of /usr/src/paperless/consume,
+#                            not just the top level. Needed for use-cases that
+#                            organise scans into subfolders (e.g. the SFTP
+#                            sidecar with paperless_sftp_scan_subdirs).
+# consumer_subdirs_as_tags:  auto-tag each ingested document with the names
+#                            of the subdirectories it was dropped into. Works
+#                            well combined with paperless_sftp_scan_subdirs =
+#                            pick a folder in the scanner, get a tag.
+# consumer_delete_duplicates: when a dropped file is an exact duplicate
+#                            (MD5) of an existing doc, silently delete the
+#                            incoming file instead of moving it to the
+#                            error/duplicates area. Cleaner scan-reattempt
+#                            workflow; skipped docs just vanish.
+#
+# All three default False (paperless's own defaults).
+paperless_consumer_recursive: false
+paperless_consumer_subdirs_as_tags: false
+paperless_consumer_delete_duplicates: false
+
 # SFTP sidecar (opt-in). When enabled, an atmoz/sftp container runs
 # alongside the paperless pod under the same rootless user and mounts
 # `paperless-consume.volume` as its SFTP drop target. A scanner (or any

--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -49,6 +49,11 @@ Environment=PAPERLESS_URL={{ paperless_url | default('') }}
 Environment=USERMAP_UID=1000
 Environment=USERMAP_GID=1000
 
+# Consumer behaviour
+Environment=PAPERLESS_CONSUMER_RECURSIVE={{ paperless_consumer_recursive | bool | string | lower }}
+Environment=PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS={{ paperless_consumer_subdirs_as_tags | bool | string | lower }}
+Environment=PAPERLESS_CONSUMER_DELETE_DUPLICATES={{ paperless_consumer_delete_duplicates | bool | string | lower }}
+
 HealthCmd=curl -fs http://localhost:8000 || exit 1
 HealthInterval=30s
 HealthStartPeriod=120s


### PR DESCRIPTION
## Summary

Exposes three paperless consumer-behaviour env vars as role variables:

| Variable | Default | Effect |
|---|---|---|
| \`paperless_consumer_recursive\` | \`false\` | Watch subdirectories of the consume volume, not just the top level. Needed if you use \`paperless_sftp_scan_subdirs\` (#43) or otherwise drop into subfolders. |
| \`paperless_consumer_subdirs_as_tags\` | \`false\` | Auto-tag each ingested document with the name of the subdirectory it was dropped into. |
| \`paperless_consumer_delete_duplicates\` | \`false\` | Silently delete dropped files whose MD5 matches an existing document, instead of piling up in the error area. |

All three default \`false\` — i.e. paperless's own defaults — so existing deployments are unchanged unless a host explicitly opts in.

## Why

The original ds9 paperless-ngx compose file had all three set to \`true\`. With the recent ds9→eddie migration we lost that config; the eddie role's \`paperless_ngx.container.j2\` template didn't expose them. Adding them now restores parity and unblocks the full "scanner SFTPs into topic-specific subfolder, paperless auto-tags from folder name, duplicate retries don't accumulate junk" workflow that PR #43 was building toward.

Rendering: \`{{ var | bool | string | lower }}\` converts Python bool → lowercase \`true\`/\`false\` string, which is what paperless's Django config parser expects.

## Test plan

- [x] Syntax check.
- [x] Flag-default deploy: all three env vars rendered as \`false\` in the running container (\`podman exec paperless-ngx env | grep PAPERLESS_CONSUMER\` confirms). Behaviour identical to pre-change state.
- [ ] After merge: set one or more to \`true\` in host_vars, redeploy, verify \`env | grep\` inside the container reflects the change.

## Scope

Orthogonal to #43 (scan subdirs) — merges in any order; both land on the same template file but different blocks. Natural pairing: enable \`recursive\` + \`subdirs_as_tags\` together when adopting \`paperless_sftp_scan_subdirs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)