### PR TITLE
Bump luckynrslevin.podman_quadlet to v1.2.1

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -2,4 +2,4 @@
 roles:
   - name: luckynrslevin.podman_quadlet
     src: https://github.com/luckynrslevin/ansible-role-podman-quadlet.git
-    version: v1.2.0
+    version: v1.2.1


### PR DESCRIPTION
## Summary

One-line bump of the Galaxy role pin: \`v1.2.0\` → \`v1.2.1\`.

v1.2.1 is functionally identical to v1.2.0 (same \`--policy=newer\` + cached-image fallback behaviour) but is the first Galaxy-published release since v1.0.0 — v1.1.0 and v1.2.0 tag pushes silently skipped publish because the lint gate failed. Fixed in [luckynrslevin/ansible-role-podman-quadlet#4](https://github.com/luckynrslevin/ansible-role-podman-quadlet/pull/4), then cut as v1.2.1.

## Test plan

- [x] \`ansible-galaxy install -r roles/requirements.yml\` pulls v1.2.1 cleanly (\"changing role … from v1.2.0 to v1.2.1 … installed successfully\").
- [x] Syntax check on \`playbooks/paperless-ngx.yml\` passes with the new role version.
- [ ] Next live deploy on eddie will exercise the bumped role; no behavioural change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)