### PR TITLE
Back up caddy-data to preserve internal root CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ ansible-playbook playbooks/pihole.yml
 | Service | Purpose | Container images | Volumes (backup method) |
 |---|---|---|---|
 | **Dashboard** | Static status page served by Caddy, showing all deployed services and their volumes. | — (static HTML rendered on host) | — |
-| **Caddy** | Front-door reverse proxy with internal TLS via a private CA. | `caddy:latest` | <ul><li>`caddy-data` — not backed up</li><li>`caddy-config` — not backed up</li><li>`caddy-etc` — not backed up</li></ul> |
+| **Caddy** | Front-door reverse proxy with internal TLS via a private CA. | `caddy:latest` | <ul><li>`caddy-data` — tar (preserves internal root CA)</li><li>`caddy-config` — not backed up</li><li>`caddy-etc` — not backed up</li></ul> |
 | **Pi-hole + Unbound** | Network-wide DNS ad/tracker blocking with a local recursive resolver (no upstream DNS leakage). HTTPS admin UI on port 8443. | <ul><li>`pi-hole/pihole:latest`</li><li>`klutchell/unbound:latest`</li></ul> | <ul><li>`pihole-etc` — tar</li><li>`pihole-dnsmasq` — tar</li></ul> |
 | **Shairport-sync** | AirPlay audio receiver for iOS/macOS devices. | `mikebrady/shairport-sync` | — (stateless) |
 | **Syncthing** | Peer-to-peer file synchronization between household devices. | `syncthing/syncthing:2` | <ul><li>`syncthing-config` — tar</li><li>`syncthing-data` — rsync</li></ul> |

--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -10,6 +10,7 @@
 #   ansible-playbook playbooks/restore.yml --limit homeserver
 #
 # Restore a single service:
+#   ansible-playbook playbooks/restore.yml --limit homeserver --tags caddy
 #   ansible-playbook playbooks/restore.yml --limit homeserver --tags pihole
 #   ansible-playbook playbooks/restore.yml --limit homeserver --tags syncthing
 #   ansible-playbook playbooks/restore.yml --limit homeserver --tags jukebox
@@ -37,6 +38,7 @@
     nfs_opts: "ro,noatime,vers=4"
     # Services that have backup manifests. Must match role directory names.
     _restorable_services:
+      - caddy
       - pihole
       - syncthing
       - jukebox
@@ -79,6 +81,14 @@
     # parameterised by the service's manifest. Static tags allow
     # --tags filtering.
     # ==================================================================
+
+    - name: Restore caddy
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | list | length > 0
+      tags: [caddy]
 
     - name: Restore pihole
       ansible.builtin.include_tasks:

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -110,6 +110,7 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 
 | Service   | Volume / DB                       | Method  |
 |-----------|-----------------------------------|---------|
+| caddy     | `caddy-data`                      | tar     |
 | pihole    | `systemd-pihole-etc`              | tar     |
 | pihole    | `systemd-pihole-dnsmasq`          | tar     |
 | syncthing | `systemd-syncthing-config`        | tar     |
@@ -121,8 +122,10 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 | entephoto | `entephoto-museum-config`         | tar     |
 | entephoto | `entephoto-minio-data`            | rsync   |
 
-> Caddy volumes are not currently backed up — they hold derivable
-> state (TLS certs, Caddy cache).
+> Only `caddy-data` is backed up — it holds Caddy's internal root
+> CA, which must survive reinstalls so devices that trust the root
+> don't need to re-import a fresh one. `caddy-etc` (Caddyfile) and
+> `caddy-config` (runtime state) are regenerated from the role.
 
 ## Deployment
 

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -30,3 +30,18 @@ caddy_domain: ""
 #     - { subdomain: photos, port: 3000 }
 #     - { subdomain: paperless, port: 8000 }
 caddy_reverse_proxy_services: []
+
+# Backup manifest for the caddy role.
+#
+# caddy-data contains Caddy's internal ACME CA (root cert + key under
+# caddy/pki/authorities/local/). Without this backup a reinstall would
+# produce a new root CA, forcing every device that trusts the old one
+# to re-import the new root.
+#
+# caddy-etc (Caddyfile) and caddy-config (runtime state) are intentionally
+# not backed up — they are regenerated from the role on each deploy.
+backup_manifest:
+  service_user: webproxy
+  service_unit: caddy
+  volumes:
+    - { name: caddy-data, method: tar }


### PR DESCRIPTION
Closes #48.

## Summary
- Add a \`backup_manifest\` to the caddy role with \`caddy-data\` as \`method: tar\` so Caddy's internal ACME root CA (cert + key) survives reinstalls.
- Wire \`caddy\` into \`playbooks/restore.yml\` (\`_restorable_services\`, a per-role restore block, and the tags list in the header comment).
- Update the top-level README services table and \`roles/backup/README.md\` to reflect the new coverage. \`caddy-etc\` (Caddyfile) and \`caddy-config\` (runtime state) stay unbacked — the role regenerates them on each deploy.

## Test plan
- [x] \`ansible-playbook playbooks/site.yml --syntax-check\`
- [x] \`ansible-playbook playbooks/restore.yml --syntax-check\`
- [ ] Deploy to eddie, run \`ansible-playbook playbooks/backup.yml\`, confirm a \`caddy-data-*.tar.gz\` appears on the NAS
- [ ] Capture current \`/etc/pki/caddy-internal/root.crt\` fingerprint, \`ansible-playbook playbooks/restore.yml --tags caddy\`, compare after: identical root CA