### PR TITLE
Seed Caddy internal CA from private overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ inventory/host_vars/homeserver-test
 roles/syncthing/files/volumes/syncthing-config/config/key.pem
 roles/syncthing/files/volumes/syncthing-config/config/cert.pem
 roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2
+
+# Caddy internal ACME CA — symlinks into the private overlay
+roles/caddy/files/volumes/caddy-data/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ ln -sf ../../../../../../../../home-server-private/roles/syncthing/files/volumes
 ln -sf ../../../../../../../../home-server-private/roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2 roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2
 ```
 
+For Caddy internal CA persistence (optional — see
+[roles/caddy/README.md](roles/caddy/README.md#internal-ca-persistence)
+for the one-time bootstrap that extracts the CA and populates the
+private overlay):
+
+```bash
+mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
+for f in root.crt root.key intermediate.crt intermediate.key; do
+  ln -sf ../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
+    roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
+done
+```
+
 ### 3. Generate and encrypt secrets
 
 ```bash
@@ -231,7 +244,7 @@ ansible-playbook playbooks/pihole.yml
 | Service | Purpose | Container images | Volumes (backup method) |
 |---|---|---|---|
 | **Dashboard** | Static status page served by Caddy, showing all deployed services and their volumes. | — (static HTML rendered on host) | — |
-| **Caddy** | Front-door reverse proxy with internal TLS via a private CA. | `caddy:latest` | <ul><li>`caddy-data` — not backed up</li><li>`caddy-config` — not backed up</li><li>`caddy-etc` — not backed up</li></ul> |
+| **Caddy** | Front-door reverse proxy with internal TLS via a private CA. | `caddy:latest` | <ul><li>`caddy-data` — internal CA seeded from private overlay (not backed up)</li><li>`caddy-config` — not backed up</li><li>`caddy-etc` — not backed up</li></ul> |
 | **Pi-hole + Unbound** | Network-wide DNS ad/tracker blocking with a local recursive resolver (no upstream DNS leakage). HTTPS admin UI on port 8443. | <ul><li>`pi-hole/pihole:latest`</li><li>`klutchell/unbound:latest`</li></ul> | <ul><li>`pihole-etc` — tar</li><li>`pihole-dnsmasq` — tar</li></ul> |
 | **Shairport-sync** | AirPlay audio receiver for iOS/macOS devices. | `mikebrady/shairport-sync` | — (stateless) |
 | **Syncthing** | Peer-to-peer file synchronization between household devices. | `syncthing/syncthing:2` | <ul><li>`syncthing-config` — tar</li><li>`syncthing-data` — rsync</li></ul> |

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ The solution emphasizes:
   - Rootless containers first — each rootless application runs as its own dedicated Linux user
   - Rootful containers only where rootless is not feasible, and always hardened
 - **Operational consistency**
-  - All applications fully integrated with systemd (start, stop, reboot)
   - Fully automatic reinstall from scratch, including restore of configuration and data
+  - All applications fully integrated with systemd (start, stop, reboot)
   - Simple but practical backup and restore of all your data
+  - Automatic release update of containers
 
 ---
 
@@ -208,7 +209,7 @@ private overlay):
 ```bash
 mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
 for f in root.crt root.key intermediate.crt intermediate.key; do
-  ln -sf ../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
+  ln -sf ../../../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
     roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
 done
 ```
@@ -243,7 +244,7 @@ ansible-playbook playbooks/pihole.yml
 
 | Service | Purpose | Container images | Volumes (backup method) |
 |---|---|---|---|
-| **Dashboard** | Static status page served by Caddy, showing all deployed services and their volumes. | — (static HTML rendered on host) | — |
+| **Dashboard** | Regularly updated Dashboard, showing all deployed services incl. status, related volumes and backup status. | — (static HTML rendered on host) | — |
 | **Caddy** | Front-door reverse proxy with internal TLS via a private CA. | `caddy:latest` | <ul><li>`caddy-data` — internal CA seeded from private overlay (not backed up)</li><li>`caddy-config` — not backed up</li><li>`caddy-etc` — not backed up</li></ul> |
 | **Pi-hole + Unbound** | Network-wide DNS ad/tracker blocking with a local recursive resolver (no upstream DNS leakage). HTTPS admin UI on port 8443. | <ul><li>`pi-hole/pihole:latest`</li><li>`klutchell/unbound:latest`</li></ul> | <ul><li>`pihole-etc` — tar</li><li>`pihole-dnsmasq` — tar</li></ul> |
 | **Shairport-sync** | AirPlay audio receiver for iOS/macOS devices. | `mikebrady/shairport-sync` | — (stateless) |

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -121,8 +121,12 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 | entephoto | `entephoto-museum-config`         | tar     |
 | entephoto | `entephoto-minio-data`            | rsync   |
 
-> Caddy volumes are not currently backed up — they hold derivable
-> state (TLS certs, Caddy cache).
+> Caddy volumes are not backed up. `caddy-etc` (Caddyfile) and
+> `caddy-config` (runtime state) are regenerated from the role.
+> Caddy's internal ACME root CA lives in `caddy-data` — it is
+> persisted via `caddy_seed_internal_ca` staging from the
+> `home-server-private` overlay, not via NAS backup. See
+> [roles/caddy/README.md](../caddy/README.md#internal-ca-persistence).
 
 ## Deployment
 

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -145,7 +145,7 @@ identity:
    cd home-server
    mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
    for f in root.crt root.key intermediate.crt intermediate.key; do
-     ln -sf ../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
+     ln -sf ../../../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
        roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
    done
    ```

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -21,6 +21,7 @@ subdomain-based routing and automatic HTTPS (self-signed certs).
 | `caddy_listen_port_https`       | `9443`  | Internal HTTPS port. Firewall forwards `443 → caddy_listen_port_https` (only when `caddy_domain` is set). |
 | `caddy_domain`                  | `""`    | Server domain (e.g. `eddie.lan`). Enables reverse proxy + HTTPS. Empty = simple dashboard mode. |
 | `caddy_reverse_proxy_services`  | `[]`    | List of `{subdomain, port, proto?}` dicts — one per proxied service. |
+| `caddy_seed_internal_ca`        | `false` | Stage the internal ACME CA (root + intermediate cert/key) from the private overlay on deploy. See [Internal CA persistence](#internal-ca-persistence). |
 
 ### Reverse proxy configuration example
 
@@ -97,6 +98,92 @@ The role:
 Caddy automatically generates self-signed certificates for `.lan`
 domains. Browsers will show a one-time cert warning — acceptable
 for a LAN home server. Certificate data is persisted in `caddy-data`.
+
+## Internal CA persistence
+
+Caddy uses `tls internal`, which runs a private ACME CA. The root and
+intermediate cert + key live in `caddy-data/caddy/pki/authorities/local/`.
+By default a reinstall rolls a new CA and every device that trusted the
+old root has to re-import the new one.
+
+To preserve the CA across reinstalls, stage the four CA files from the
+`home-server-private` overlay using the same pattern as syncthing's
+identity:
+
+### One-time bootstrap
+
+1. On the already-running host, extract the current CA:
+
+   ```bash
+   ./scripts/caddy-ca-extract.sh
+   ```
+
+   The script prints the staging directory and the next-step commands.
+
+2. Vault-encrypt the two private keys:
+
+   ```bash
+   ansible-vault encrypt <staging>/root.key <staging>/intermediate.key
+   ```
+
+3. Copy all four files into the private overlay at the exact path
+   Caddy expects:
+
+   ```
+   home-server-private/
+     roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/
+       root.crt
+       root.key           # vault-encrypted
+       intermediate.crt
+       intermediate.key   # vault-encrypted
+   ```
+
+4. Symlink the staging paths into the public repo (mirrors the
+   syncthing convention — see the project-level README):
+
+   ```bash
+   cd home-server
+   mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
+   for f in root.crt root.key intermediate.crt intermediate.key; do
+     ln -sf ../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
+       roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
+   done
+   ```
+
+5. In the host's `inventory/host_vars/<host>/main.yml`, set:
+
+   ```yaml
+   caddy_seed_internal_ca: true
+   ```
+
+6. Redeploy caddy and verify:
+
+   ```bash
+   # Capture current CA fingerprint
+   sudo openssl x509 -in /etc/pki/caddy-internal/root.crt \
+       -noout -fingerprint -sha256
+
+   # Destroy and recreate the volume to prove the seed works
+   sudo -u webproxy systemctl --user stop caddy
+   sudo -u webproxy podman volume rm caddy-data
+   ansible-playbook playbooks/caddy.yml --limit <host>
+
+   # Fingerprint must match
+   sudo openssl x509 -in /etc/pki/caddy-internal/root.crt \
+       -noout -fingerprint -sha256
+   ```
+
+### Why not back it up to the NAS?
+
+The private overlay is already the project's source of truth for
+host-specific identity (syncthing cert, vault-encrypted secrets).
+Putting the CA there keeps all long-lived identity in one place,
+avoids storing a private key in NAS tar archives, and removes the NAS
+from the "reinstall-from-scratch" critical path.
+
+`caddy-etc` (Caddyfile) and `caddy-config` (runtime state) are not
+seeded or backed up — both are regenerated from the role on each
+deploy.
 
 ## Backward compatibility
 

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -30,3 +30,21 @@ caddy_domain: ""
 #     - { subdomain: photos, port: 3000 }
 #     - { subdomain: paperless, port: 8000 }
 caddy_reverse_proxy_services: []
+
+# Seed Caddy's internal ACME CA (root + intermediate cert/key under
+# caddy/pki/authorities/local/) from files staged by the role.
+#
+# Set to true in host_vars when the four files are present under
+#   roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/
+#     root.crt
+#     root.key          (ansible-vault encrypted recommended)
+#     intermediate.crt
+#     intermediate.key  (ansible-vault encrypted recommended)
+# The project convention is to symlink these paths into the
+# home-server-private overlay (see roles/caddy/README.md for bootstrap).
+#
+# When false (default), Caddy generates a fresh CA on first start. To
+# preserve the CA across reinstalls, extract it once with
+# scripts/caddy-ca-extract.sh, vault-encrypt the two .key files, commit
+# them to the private overlay, and flip this flag to true.
+caddy_seed_internal_ca: false

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -53,11 +53,29 @@
       - caddy-data.volume
       - caddy-config.volume
       - caddy-etc.volume
-    podman_quadlet_volumes_files_to_stage:
-      - name: caddy-etc
-        files:
-          - src: Caddyfile.j2
-            mode: "0644"
+    podman_quadlet_volumes_files_to_stage: >-
+      {{
+        [
+          {
+            'name': 'caddy-etc',
+            'files': [{'src': 'Caddyfile.j2', 'mode': '0644'}]
+          }
+        ]
+        + (
+          [
+            {
+              'name': 'caddy-data',
+              'files': [
+                {'src': 'caddy/pki/authorities/local/',                 'mode': '0700'},
+                {'src': 'caddy/pki/authorities/local/root.crt',         'mode': '0644'},
+                {'src': 'caddy/pki/authorities/local/root.key',         'mode': '0600'},
+                {'src': 'caddy/pki/authorities/local/intermediate.crt', 'mode': '0644'},
+                {'src': 'caddy/pki/authorities/local/intermediate.key', 'mode': '0600'}
+              ]
+            }
+          ] if caddy_seed_internal_ca else []
+        )
+      }}
     podman_quadlet_firewall_port_forwards: >-
       {{ [{'port': 80, 'proto': 'tcp', 'toport': caddy_listen_port}]
          + ([{'port': 443, 'proto': 'tcp', 'toport': caddy_listen_port_https}]

--- a/scripts/caddy-ca-extract.sh
+++ b/scripts/caddy-ca-extract.sh
@@ -25,7 +25,7 @@ mkdir -p "$OUT_DIR"
 chmod 0700 "$OUT_DIR"
 
 for f in root.crt root.key intermediate.crt intermediate.key; do
-    sudo -u "$USER_NAME" podman exec "$CONTAINER" cat "$SRC_DIR/$f" > "$OUT_DIR/$f"
+    sudo -iu "$USER_NAME" podman exec "$CONTAINER" cat "$SRC_DIR/$f" > "$OUT_DIR/$f"
     chmod 0600 "$OUT_DIR/$f"
 done
 chmod 0644 "$OUT_DIR/root.crt" "$OUT_DIR/intermediate.crt"

--- a/scripts/caddy-ca-extract.sh
+++ b/scripts/caddy-ca-extract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ============================================================================
+# caddy-ca-extract.sh
+#
+# One-shot helper: pulls Caddy's auto-generated internal ACME CA (root +
+# intermediate cert/key) out of a running caddy container and writes the
+# four files into a staging directory. Run this once, on the host where
+# caddy is already running and has generated its CA, then vault-encrypt
+# the two .key files and commit them into the home-server-private overlay
+# so the CA can be re-seeded on reinstall.
+#
+# Usage:
+#   ./scripts/caddy-ca-extract.sh [output_dir]
+#
+# Defaults to /tmp/caddy-ca-<timestamp>/.
+# ============================================================================
+set -euo pipefail
+
+OUT_DIR="${1:-/tmp/caddy-ca-$(date +%Y%m%d-%H%M%S)}"
+CONTAINER="caddy"
+USER_NAME="webproxy"
+SRC_DIR="/data/caddy/pki/authorities/local"
+
+mkdir -p "$OUT_DIR"
+chmod 0700 "$OUT_DIR"
+
+for f in root.crt root.key intermediate.crt intermediate.key; do
+    sudo -u "$USER_NAME" podman exec "$CONTAINER" cat "$SRC_DIR/$f" > "$OUT_DIR/$f"
+    chmod 0600 "$OUT_DIR/$f"
+done
+chmod 0644 "$OUT_DIR/root.crt" "$OUT_DIR/intermediate.crt"
+
+echo
+echo "Extracted Caddy internal CA to: $OUT_DIR"
+ls -l "$OUT_DIR"
+echo
+echo "Next steps:"
+echo "  1. Vault-encrypt the two private keys:"
+echo "       ansible-vault encrypt $OUT_DIR/root.key $OUT_DIR/intermediate.key"
+echo
+echo "  2. Copy all four files into home-server-private at:"
+echo "       roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/"
+echo
+echo "  3. Add the symlinks in home-server (see roles/caddy/README.md)."
+echo
+echo "  4. In your host_vars, set:  caddy_seed_internal_ca: true"
+echo
+echo "  5. Redeploy caddy and verify the root.crt fingerprint is unchanged."


### PR DESCRIPTION
Closes #48. Replaces #50 (closed).

## Why this approach
Caddy's \`tls internal\` runs a private ACME CA stored in \`caddy-data/caddy/pki/authorities/local/\`. A reinstall without intervention rolls a new CA and every device that imported the old root loses trust.

#50 solved that by adding \`caddy-data\` to the \`backup_manifest\` (tar to NAS). This PR takes a different route: **move CA identity into \`home-server-private\`** alongside the other identity material (syncthing cert/key, vault-encrypted secrets). The NAS then holds no CA material, the CA survives NAS outages, and the project's architectural split stays clean: identity → private overlay; derived state → on-host volumes; bulk data → NAS.

## Summary
- New default \`caddy_seed_internal_ca: false\`. When \`true\`, the role extends \`podman_quadlet_volumes_files_to_stage\` with the four CA files at the exact paths Caddy expects, so Caddy reuses them on first start.
- \`scripts/caddy-ca-extract.sh\` — one-shot helper that pulls root/intermediate cert+key out of the running caddy container. Operator vault-encrypts the two keys, commits into the private overlay, symlinks into the public repo, flips the flag.
- \`roles/caddy/README.md\` — new **Internal CA persistence** section with bootstrap + verify steps.
- Top-level \`README.md\` services table + \`roles/backup/README.md\` note updated to reflect the seed mechanism.
- \`.gitignore\` excludes the symlink target directory from the public repo.

## Test plan
- [x] \`ansible-playbook playbooks/site.yml --syntax-check\`
- [x] \`ansible-lint roles/caddy/\`
- [ ] On eddie: capture current \`/etc/pki/caddy-internal/root.crt\` SHA-256 fingerprint
- [ ] Run \`scripts/caddy-ca-extract.sh\`, vault-encrypt keys, commit into \`home-server-private\`, add symlinks, set \`caddy_seed_internal_ca: true\` in host_vars
- [ ] Destroy and recreate the volume: \`systemctl --user stop caddy && podman volume rm caddy-data && ansible-playbook playbooks/caddy.yml\`
- [ ] Re-check fingerprint — must match pre-change value
- [ ] Idempotency: second playbook run → \`changed=0\` on the stage step