### PR TITLE
Seed Caddy CA from host_vars variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ inventory/host_vars/homeserver-test
 roles/syncthing/files/volumes/syncthing-config/config/key.pem
 roles/syncthing/files/volumes/syncthing-config/config/cert.pem
 roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2
-
-# Caddy internal ACME CA — symlinks into the private overlay
-roles/caddy/files/volumes/caddy-data/

--- a/README.md
+++ b/README.md
@@ -201,19 +201,6 @@ ln -sf ../../../../../../../../home-server-private/roles/syncthing/files/volumes
 ln -sf ../../../../../../../../home-server-private/roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2 roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2
 ```
 
-For Caddy internal CA persistence (optional — see
-[roles/caddy/README.md](roles/caddy/README.md#internal-ca-persistence)
-for the one-time bootstrap that extracts the CA and populates the
-private overlay):
-
-```bash
-mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
-for f in root.crt root.key intermediate.crt intermediate.key; do
-  ln -sf ../../../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
-    roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
-done
-```
-
 ### 3. Generate and encrypt secrets
 
 ```bash

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -106,9 +106,19 @@ intermediate cert + key live in `caddy-data/caddy/pki/authorities/local/`.
 By default a reinstall rolls a new CA and every device that trusted the
 old root has to re-import the new one.
 
-To preserve the CA across reinstalls, stage the four CA files from the
-`home-server-private` overlay using the same pattern as syncthing's
-identity:
+The role can pre-seed the CA into `caddy-data` on every deploy, driven
+by four variables in `host_vars`:
+
+| Variable                       | Contents                              |
+|--------------------------------|---------------------------------------|
+| `caddy_ca_root_crt`            | Root certificate (PEM)                |
+| `caddy_ca_root_key`            | Root private key (PEM, vault-encrypt) |
+| `caddy_ca_intermediate_crt`    | Intermediate certificate (PEM)        |
+| `caddy_ca_intermediate_key`    | Intermediate private key (PEM, vault-encrypt) |
+
+With `caddy_seed_internal_ca: true`, the role renders these into the
+volume at the exact paths Caddy expects. Caddy reuses them on startup
+instead of generating a new CA.
 
 ### One-time bootstrap
 
@@ -118,45 +128,41 @@ identity:
    ./scripts/caddy-ca-extract.sh
    ```
 
-   The script prints the staging directory and the next-step commands.
+   The script writes the four files to a `/tmp/caddy-ca-<timestamp>/`
+   staging directory and prints the next-step commands.
 
-2. Vault-encrypt the two private keys:
-
-   ```bash
-   ansible-vault encrypt <staging>/root.key <staging>/intermediate.key
-   ```
-
-3. Copy all four files into the private overlay at the exact path
-   Caddy expects:
-
-   ```
-   home-server-private/
-     roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/
-       root.crt
-       root.key           # vault-encrypted
-       intermediate.crt
-       intermediate.key   # vault-encrypted
-   ```
-
-4. Symlink the staging paths into the public repo (mirrors the
-   syncthing convention — see the project-level README):
+2. Vault-encrypt each private key into a YAML-ready block:
 
    ```bash
-   cd home-server
-   mkdir -p roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local
-   for f in root.crt root.key intermediate.crt intermediate.key; do
-     ln -sf ../../../../../../../../../../home-server-private/roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f \
-       roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/$f
-   done
+   ansible-vault encrypt_string --stdin-name 'caddy_ca_root_key' \
+       < /tmp/caddy-ca-*/root.key
+   ansible-vault encrypt_string --stdin-name 'caddy_ca_intermediate_key' \
+       < /tmp/caddy-ca-*/intermediate.key
    ```
 
-5. In the host's `inventory/host_vars/<host>/main.yml`, set:
+   Paste each block into the host's `inventory/host_vars/<host>/main.yml`.
+
+3. Paste the two certificates as plain YAML literal-block strings:
+
+   ```yaml
+   caddy_ca_root_crt: |
+     -----BEGIN CERTIFICATE-----
+     ... contents of root.crt ...
+     -----END CERTIFICATE-----
+
+   caddy_ca_intermediate_crt: |
+     -----BEGIN CERTIFICATE-----
+     ... contents of intermediate.crt ...
+     -----END CERTIFICATE-----
+   ```
+
+4. Flip the flag in the same `host_vars`:
 
    ```yaml
    caddy_seed_internal_ca: true
    ```
 
-6. Redeploy caddy and verify:
+5. Redeploy caddy and verify:
 
    ```bash
    # Capture current CA fingerprint
@@ -176,8 +182,8 @@ identity:
 ### Why not back it up to the NAS?
 
 The private overlay is already the project's source of truth for
-host-specific identity (syncthing cert, vault-encrypted secrets).
-Putting the CA there keeps all long-lived identity in one place,
+host-specific identity and secrets. Putting the CA inline with the
+rest of the host_vars keeps all per-host configuration in one file,
 avoids storing a private key in NAS tar archives, and removes the NAS
 from the "reinstall-from-scratch" critical path.
 

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -32,19 +32,17 @@ caddy_domain: ""
 caddy_reverse_proxy_services: []
 
 # Seed Caddy's internal ACME CA (root + intermediate cert/key under
-# caddy/pki/authorities/local/) from files staged by the role.
+# caddy/pki/authorities/local/) from inventory variables. The four
+# variables below hold the PEM contents; private keys should be
+# ansible-vault encrypted in host_vars.
 #
-# Set to true in host_vars when the four files are present under
-#   roles/caddy/files/volumes/caddy-data/caddy/pki/authorities/local/
-#     root.crt
-#     root.key          (ansible-vault encrypted recommended)
-#     intermediate.crt
-#     intermediate.key  (ansible-vault encrypted recommended)
-# The project convention is to symlink these paths into the
-# home-server-private overlay (see roles/caddy/README.md for bootstrap).
-#
-# When false (default), Caddy generates a fresh CA on first start. To
-# preserve the CA across reinstalls, extract it once with
-# scripts/caddy-ca-extract.sh, vault-encrypt the two .key files, commit
-# them to the private overlay, and flip this flag to true.
+# Set caddy_seed_internal_ca: true in host_vars when the four variables
+# are populated. When false (default), Caddy generates a fresh CA on
+# first start. To preserve the CA across reinstalls, extract it once
+# with scripts/caddy-ca-extract.sh, vault-encrypt the two .key PEM
+# strings into host_vars, and flip this flag to true.
 caddy_seed_internal_ca: false
+caddy_ca_root_crt: ""
+caddy_ca_root_key: ""
+caddy_ca_intermediate_crt: ""
+caddy_ca_intermediate_key: ""

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -66,11 +66,11 @@
             {
               'name': 'caddy-data',
               'files': [
-                {'src': 'caddy/pki/authorities/local/',                 'mode': '0700'},
-                {'src': 'caddy/pki/authorities/local/root.crt',         'mode': '0644'},
-                {'src': 'caddy/pki/authorities/local/root.key',         'mode': '0600'},
-                {'src': 'caddy/pki/authorities/local/intermediate.crt', 'mode': '0644'},
-                {'src': 'caddy/pki/authorities/local/intermediate.key', 'mode': '0600'}
+                {'src': 'caddy/pki/authorities/local/',                     'mode': '0700'},
+                {'src': 'caddy/pki/authorities/local/root.crt.j2',          'mode': '0644'},
+                {'src': 'caddy/pki/authorities/local/root.key.j2',          'mode': '0600'},
+                {'src': 'caddy/pki/authorities/local/intermediate.crt.j2',  'mode': '0644'},
+                {'src': 'caddy/pki/authorities/local/intermediate.key.j2',  'mode': '0600'}
               ]
             }
           ] if caddy_seed_internal_ca else []

--- a/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/intermediate.crt.j2
+++ b/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/intermediate.crt.j2
@@ -1,0 +1,1 @@
+{{ caddy_ca_intermediate_crt | trim }}

--- a/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/intermediate.key.j2
+++ b/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/intermediate.key.j2
@@ -1,0 +1,1 @@
+{{ caddy_ca_intermediate_key | trim }}

--- a/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/root.crt.j2
+++ b/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/root.crt.j2
@@ -1,0 +1,1 @@
+{{ caddy_ca_root_crt | trim }}

--- a/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/root.key.j2
+++ b/roles/caddy/templates/volumes/caddy-data/caddy/pki/authorities/local/root.key.j2
@@ -1,0 +1,1 @@
+{{ caddy_ca_root_key | trim }}


### PR DESCRIPTION
Refactor of #51: the four CA PEMs live as variables in the host's inventory main.yml instead of staged files. Trivial .j2 templates in the role render each variable into the caddy-data volume. Private keys continue to be vault-encrypted.

Rationale: consolidate all per-host Caddy config into one file, drop the file-staging layer and the cross-repo symlink convention for this role.

**Tested on eddie**: volume destroy + redeploy preserves the root CA fingerprint.