### PR TITLE
unbound: disable use-caps-for-id

### DIFF
--- a/roles/pihole/templates/volumes/unbound-config/unbound.conf.j2
+++ b/roles/pihole/templates/volumes/unbound-config/unbound.conf.j2
@@ -36,7 +36,13 @@ server:
     # Privacy
     hide-identity: yes
     hide-version: yes
-    use-caps-for-id: yes
+    # use-caps-for-id (DNS-0x20 case randomization) is disabled. It
+    # randomizes case in outgoing queries as a spoofing defense, but
+    # many large CDN / load-balancer stacks (Akamai, CloudFront, MSFT
+    # Akadns, Cloudflare, etc.) don't preserve case in responses —
+    # unbound then flags those answers as potential spoofs and returns
+    # SERVFAIL, which users see as intermittent "server not found".
+    use-caps-for-id: no
     minimal-responses: yes
     aggressive-nsec: yes
 


### PR DESCRIPTION
## Problem
Users see intermittent \"server not found\" in browsers for popular CDN-fronted domains (xing.com, update.code.visualstudio.com, hub.docker.com, various apple/akadns/akamai hosts).

## Diagnosis
Pi-hole-FTL stats on eddie show 140 SERVFAILs in 6 hours concentrated on CDN/load-balancer domains. These stacks don't preserve case in DNS responses, and unbound's \`use-caps-for-id: yes\` (DNS-0x20 case randomization) then flags the answers as potential spoof attempts and returns SERVFAIL.

## Fix
Set \`use-caps-for-id: no\` (unbound's own default) with an inline comment explaining why.

## Verification
- Deployed to eddie, unbound restarted cleanly.
- Previous top offenders (\`update.code.visualstudio.com\`, \`production.cloudflare.docker.com\`, \`www.xing.com\`) now return NOERROR on repeated queries.