### PR TITLE
dashboard: publish Caddy root CA + install instructions

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"848e957a-d122-45d0-ac9a-2e81a12c8553","pid":445551,"acquiredAt":1777103974131}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"848e957a-d122-45d0-ac9a-2e81a12c8553","pid":445551,"acquiredAt":1777103974131}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ inventory/host_vars/homeserver-test
 roles/syncthing/files/volumes/syncthing-config/config/key.pem
 roles/syncthing/files/volumes/syncthing-config/config/cert.pem
 roles/syncthing/templates/volumes/syncthing-config/config/config.xml.j2
+.claude/scheduled_tasks.lock

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -138,3 +138,17 @@
     path: "{{ caddy_ca_cert_host_path }}"
     mode: "0644"
   when: caddy_domain | length > 0
+
+# Publish the root CA via the dashboard so devices on the LAN can
+# install it. Caddy bind-mounts /var/www/dashboard read-only and serves
+# it at https://<caddy_domain>/, so dropping the cert here makes it
+# fetchable at https://<caddy_domain>/caddy-root.crt.
+- name: Publish Caddy root CA via dashboard
+  become: true
+  ansible.builtin.copy:
+    src: "{{ caddy_ca_cert_host_path }}"
+    dest: /var/www/dashboard/caddy-root.crt
+    remote_src: true
+    mode: "0644"
+    setype: container_file_t
+  when: caddy_domain | length > 0

--- a/roles/dashboard/files/home-server-dashboard.py
+++ b/roles/dashboard/files/home-server-dashboard.py
@@ -335,10 +335,39 @@ def generate_html(services_data, generated_at, nas_host_display):
   .unknown { background: #e2e3e5; color: #383d41; }
   .backup-path { color: #6c757d; font-style: italic; }
   .footer { margin-top: 15px; color: #888; font-size: 0.85em; }
+  .ca-install { margin: 0 0 18px 0; padding: 10px 14px; background: #eef5ff;
+                border: 1px solid #b6d4fe; border-radius: 6px; font-size: 0.92em; }
+  .ca-install a { color: #084298; font-weight: 600; }
+  .ca-install details { margin-top: 6px; }
+  .ca-install summary { cursor: pointer; color: #555; }
+  .ca-install ol { margin: 6px 0 0 22px; padding: 0; }
 </style>
 </head>
 <body>
 <h1>Home Server Dashboard</h1>
+<div class="ca-install">
+  Trust this server's HTTPS:
+  <a href="/caddy-root.crt" download>Download root certificate</a>
+  <details>
+    <summary>iOS / iPadOS install</summary>
+    <ol>
+      <li>Open this page in <strong>Safari</strong> (not Chrome) and tap the link above.</li>
+      <li>Tap <em>Allow</em> when iOS offers to download the configuration profile.</li>
+      <li>Open <em>Settings &rarr; General &rarr; VPN &amp; Device Management</em>, tap the
+          <em>Caddy Local Authority</em> profile, then <em>Install</em>.</li>
+      <li>Open <em>Settings &rarr; General &rarr; About &rarr; Certificate Trust Settings</em>
+          and turn the toggle on for the new root.</li>
+    </ol>
+  </details>
+  <details>
+    <summary>macOS install</summary>
+    <ol>
+      <li>Download the certificate, then open it &mdash; Keychain Access launches.</li>
+      <li>Add it to the <strong>System</strong> keychain.</li>
+      <li>Double-click the entry, expand <em>Trust</em>, set <em>When using this certificate: Always Trust</em>.</li>
+    </ol>
+  </details>
+</div>
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- caddy role copies the exported root CA into \`/var/www/dashboard/caddy-root.crt\` after deploy. Caddy already bind-mounts that directory, so the cert is fetchable at \`https://<caddy_domain>/caddy-root.crt\` over the same trusted-internal HTTPS that the dashboard uses.
- dashboard page renders a small banner with the download link and collapsible iOS / macOS install steps.

## Verified on eddie
- File published (627 B, mode 0644)
- HTTPS GET via Caddy returns 200 + matching SHA-256 fingerprint
- Dashboard HTML contains the link