### PR TITLE
caddy: set container_file_t on exported root CA

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -137,6 +137,11 @@
   ansible.builtin.file:
     path: "{{ caddy_ca_cert_host_path }}"
     mode: "0644"
+    # container_file_t so other rootless containers can read this file
+    # when bind-mounted (entephoto-museum mounts it at
+    # /etc/ssl/certs/caddy-root.crt). The default cert_t inherited from
+    # /etc/pki/ blocks confined containers from reading it.
+    setype: container_file_t
   when: caddy_domain | length > 0
 
 # Publish the root CA via the dashboard so devices on the LAN can


### PR DESCRIPTION
Fixes a silent breakage seen on eddie this week.

After yesterday's caddy redeploy, `/etc/pki/caddy-internal/root.crt` was rewritten with default `cert_t` SELinux context. The Ente museum container bind-mounts that file at `/etc/ssl/certs/caddy-root.crt` and reads it as a non-root user; SELinux container policy blocks reading `cert_t`, so museum dropped back to system trust, didn't trust Caddy's CA, and every S3 HEAD against `https://photos-s3.eddie.lan:9443` failed with x509 errors. iPhone uploads stalled for ~24 h.

The publish-to-dashboard task already sets `setype: container_file_t`. Mirror that on the host-export task so the role is self-healing.