### PR TITLE
firewall: drop direct HTTP-UI ports now that Caddy fronts everything

### DIFF
--- a/roles/entephoto/tasks/main.yml
+++ b/roles/entephoto/tasks/main.yml
@@ -59,10 +59,10 @@
         files:
           - src: museum.yaml.j2
             mode: "0600"
-    podman_quadlet_firewall_ports:
-      - "8080/tcp"         # museum API
-      - "3200/tcp"         # MinIO S3 API (for browser uploads via presigned URLs)
-      - "3000-3008/tcp"    # web apps (photos, accounts, albums, auth, cast, share, embed, paste)
+    # All Ente surfaces are reverse-proxied by Caddy at
+    # https://photos.<caddy_domain>, photos-api, photos-s3, accounts, cast,
+    # auth, etc. Direct LAN openings (8080, 3200, 3000-3008) intentionally
+    # not exposed.
 
 # --------------------------------------------------------------------------
 # MinIO bucket initialization

--- a/roles/jukebox/tasks/main.yml
+++ b/roles/jukebox/tasks/main.yml
@@ -82,11 +82,11 @@
             mode: "0700"
           - src: prefs/favorites.opml
             mode: "0600"
-    podman_quadlet_firewall_ports:
-      - "9100/tcp" # For access to  web interface
-      # - "9090/tcp" # only required for external clients (e.g. smart phone)
-      # - "3483/tcp" # player and server communicate over
-      # - "3483/udp" # pod related network
+    # Jukebox (LMS) web UI is reverse-proxied by Caddy at
+    # https://jukebox.<caddy_domain> — direct LAN access on 9100 intentionally
+    # not exposed.
+    # Squeezelite/LMS protocol ports (9090, 3483/tcp+udp) only needed for
+    # external clients; uncomment if/when needed.
 
 - name: Register backup manifest
   ansible.builtin.set_fact:

--- a/roles/paperless-ngx/tasks/main.yml
+++ b/roles/paperless-ngx/tasks/main.yml
@@ -53,8 +53,9 @@
       - paperless-data.volume
       - paperless-export.volume
       - paperless-consume.volume
-    podman_quadlet_firewall_ports:
-      - "8000/tcp"
+    # Paperless-NGX web UI is reverse-proxied by Caddy at
+    # https://paperless.<caddy_domain> — direct LAN access on 8000
+    # intentionally not exposed.
 
 # --------------------------------------------------------------------------
 # Optional SFTP sidecar — scanner drops PDFs straight into the paperless

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -61,8 +61,8 @@
     podman_quadlet_file_names: >-
       {{ ['pihole.container.j2', 'pihole-etc.volume', 'pihole-dnsmasq.volume']
          + (['unbound.container.j2'] if pihole_enable_unbound | bool else []) }}
-    podman_quadlet_firewall_ports:
-      - "{{ pihole_web_port_https }}/tcp"
+    # Pi-hole admin UI is reverse-proxied by Caddy at https://pihole.<caddy_domain>
+    # — direct LAN access on {{ pihole_web_port_https }} intentionally not exposed.
     podman_quadlet_firewall_port_forwards:
       - port: 53
         proto: tcp

--- a/roles/syncthing/tasks/main.yml
+++ b/roles/syncthing/tasks/main.yml
@@ -48,8 +48,11 @@
       - syncthing.container.j2
       - syncthing-config.volume
       - syncthing-data.volume
+    # Syncthing web UI is reverse-proxied by Caddy at
+    # https://syncthing.<caddy_domain> — direct LAN access on
+    # {{ syncthing_gui_port }} intentionally not exposed. Sync (22000) and
+    # discovery (21027) are P2P protocols and stay open.
     podman_quadlet_firewall_ports:
-      - "{{ syncthing_gui_port }}/tcp"
       - "{{ syncthing_listen_port }}/tcp"
       - "{{ syncthing_listen_port }}/udp"
       - "{{ syncthing_discovery_port }}/udp"


### PR DESCRIPTION
Refs #57.

## Summary
Drop redundant per-role HTTP-UI port openings — every UI is now reverse-proxied by Caddy on \`https://*.<caddy_domain>\` with a trusted internal CA.

| Role | Closed | Kept |
|---|---|---|
| pihole | 8443/tcp | DNS forwards 53→1053 |
| syncthing | 8384/tcp | 22000/tcp+udp, 21027/udp (P2P) |
| entephoto | 8080, 3200, 3000-3008 (all HTTP) | — |
| paperless-ngx | 8000/tcp | 2222/tcp (SFTP, when enabled) |
| jukebox | 9100/tcp | LMS protocol ports already commented out |

## Test plan
- [x] \`ansible-playbook playbooks/site.yml --syntax-check\`
- [ ] After merge + deploy, verify direct ports return connection refused while Caddy URLs still serve 200
- [ ] Verify Ente uploads from iPhone keep working (museum→S3 internal traffic uses host-gateway and is unaffected)

## Companion private-overlay change
Already committed in \`home-server-private\`: \`caddy_reverse_proxy_services\` extended with \`accounts\`, \`cast\`, \`auth\` subdomains for Ente sub-apps that lived on 3001/3002/3003. Plus matching \`pihole_local_dns_records\` entries.