### PR TITLE
Make Caddy mandatory; enforce + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The solution emphasizes:
   - Secrets stored encrypted with `ansible-vault`
   - Rootless containers first — each rootless application runs as its own dedicated Linux user
   - Rootful containers only where rootless is not feasible, and always hardened
+  - Caddy is the mandatory front door — every web UI is reachable only via `https://<subdomain>.<caddy_domain>` with a single trusted internal CA; per-service HTTP ports are not exposed on the LAN
 - **Operational consistency**
   - Fully automatic reinstall from scratch, including restore of configuration and data
   - All applications fully integrated with systemd (start, stop, reboot)

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -16,8 +16,30 @@
   become: true
   gather_facts: true
 
+  pre_tasks:
+    # Caddy is mandatory: every web UI in the project is reverse-proxied
+    # through Caddy on https://*.<caddy_domain>. Without Caddy + a
+    # configured domain, services have no externally trusted access path.
+    - name: Assert Caddy is in deploy_services
+      ansible.builtin.assert:
+        that:
+          - "'caddy' in (deploy_services | default([]))"
+        fail_msg: >-
+          'caddy' must be in deploy_services. Caddy is the mandatory
+          front-door reverse proxy for this project — direct per-service
+          HTTP ports are no longer exposed.
+    - name: Assert caddy_domain is set
+      ansible.builtin.assert:
+        that:
+          - caddy_domain is defined
+          - caddy_domain | length > 0
+        fail_msg: >-
+          caddy_domain must be set in host_vars (e.g. 'eddie.lan').
+          Without it, Caddy serves no reverse-proxy routes and every
+          web UI becomes unreachable.
+
   roles:
-    - { role: caddy,         when: "'caddy' in (deploy_services | default([]))" }
+    - { role: caddy }
     - { role: dashboard,     when: "'dashboard' in (deploy_services | default([]))" }
     - { role: pihole,        when: "'pihole' in (deploy_services | default([]))" }
     - { role: syncthing,     when: "'syncthing' in (deploy_services | default([]))" }

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -1,9 +1,10 @@
 # caddy
 
-Front-door web server and reverse proxy. In simple mode (default),
-it serves the [dashboard](../dashboard/README.md) on port 80. When
-`caddy_domain` is set, it becomes a full reverse proxy with
-subdomain-based routing and automatic HTTPS (self-signed certs).
+Front-door web server and reverse proxy. **Mandatory** in this project:
+every per-service web UI is fronted at `https://<subdomain>.<caddy_domain>`
+with an internally-trusted CA, and direct per-service HTTP ports are not
+exposed in the firewall. `caddy_domain` must be set in host_vars; an
+empty value will cause `playbooks/site.yml` to fail fast.
 
 ## Container image
 
@@ -63,13 +64,12 @@ None.
 ## Firewall ports
 
 - **80/tcp** (port-forward → `caddy_listen_port`)
-- **443/tcp** (port-forward → `caddy_listen_port_https`) — only when
-  `caddy_domain` is set
+- **443/tcp** (port-forward → `caddy_listen_port_https`)
 
 ## Endpoints
 
-- Simple mode: `http://<server-ip>/`
-- Reverse proxy mode: `https://<caddy_domain>/` + `https://<subdomain>.<caddy_domain>/`
+- Dashboard: `https://<caddy_domain>/`
+- Per-service: `https://<subdomain>.<caddy_domain>/` (one per `caddy_reverse_proxy_services` entry)
 
 ## Volumes
 
@@ -190,12 +190,6 @@ from the "reinstall-from-scratch" critical path.
 `caddy-etc` (Caddyfile) and `caddy-config` (runtime state) are not
 seeded or backed up — both are regenerated from the role on each
 deploy.
-
-## Backward compatibility
-
-Direct `IP:port` access still works — existing firewall rules
-remain. The reverse proxy is an additional access path, not a
-replacement.
 
 ## Cross-role dependencies
 

--- a/roles/entephoto/README.md
+++ b/roles/entephoto/README.md
@@ -64,16 +64,19 @@ ansible -i inventory/hosts.yml homeserver -m debug -a "var=entephoto_jwt_secret"
 
 ## Firewall ports
 
-- **8080/tcp** — Museum (API)
-- **3200/tcp** — MinIO S3 (browser uploads via presigned URLs)
-- **3000-3008/tcp** — Web apps (photos, accounts, albums, auth, cast,
-  share, embed, paste)
+None. All Ente surfaces (photos, accounts, cast, auth, museum API,
+S3) are reverse-proxied by Caddy on `https://*.<caddy_domain>` —
+direct LAN access on 8080, 3200, and 3000-3008 is intentionally not
+exposed.
 
 ## Endpoints
 
-- Photos: `http://<server-ip>:3000`
-- Albums: `http://<server-ip>:3002`
-- API health: `http://<server-ip>:8080/ping`
+- Photos: `https://photos.<caddy_domain>`
+- Accounts: `https://accounts.<caddy_domain>`
+- Cast: `https://cast.<caddy_domain>`
+- Auth: `https://auth.<caddy_domain>`
+- API: `https://photos-api.<caddy_domain>`
+- S3: `https://photos-s3.<caddy_domain>`
 
 ## Volumes
 

--- a/roles/jukebox/README.md
+++ b/roles/jukebox/README.md
@@ -55,16 +55,16 @@ and therefore captured by the backup role.
 
 ## Firewall ports
 
-- **9100/tcp** — Web UI.
+None. The web UI on port 9100 is **not** exposed in the firewall —
+access it via Caddy at `https://jukebox.<caddy_domain>`.
 
-(Optional, commented out in [tasks/main.yml](tasks/main.yml):
-`9090/tcp` for external Squeezebox-protocol clients,
-`3483/tcp+udp` for player ↔ server — not needed when both run in the
-same pod.)
+(Optional Squeezebox-protocol ports (`9090/tcp`, `3483/tcp+udp`) are
+commented out in [tasks/main.yml](tasks/main.yml); not needed when
+player and server run in the same pod.)
 
 ## Endpoints
 
-- Web UI: `http://<server-ip>:9100`
+- Web UI: `https://jukebox.<caddy_domain>`
 
 ## Volumes
 

--- a/roles/paperless-ngx/README.md
+++ b/roles/paperless-ngx/README.md
@@ -59,11 +59,15 @@ ansible -i inventory/hosts.yml homeserver -m debug -a "var=paperless_secret_key"
 
 ## Firewall ports
 
-- **8000/tcp** — Web UI and API.
+The web UI / API on port 8000 is **not** exposed in the firewall —
+access it via Caddy at `https://paperless.<caddy_domain>`.
+
+When the SFTP sidecar is enabled, **{{ paperless_sftp_port }}/tcp**
+(default 2222) opens for the scanner ingest path.
 
 ## Endpoints
 
-- Web UI: `http://<server-ip>:8000`
+- Web UI: `https://paperless.<caddy_domain>`
 
 ## Volumes
 

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -185,11 +185,13 @@ Or use the admin UI at `https://<server-ip>:8443/admin` → Query Log.
 
 - **53/tcp** and **53/udp** (port-forwarded to `1053` for the
   rootless container)
-- **8443/tcp** — HTTPS admin UI
+
+The HTTPS admin UI on port 8443 is **not** exposed in the firewall —
+access it via Caddy at `https://pihole.<caddy_domain>/admin`.
 
 ## Endpoints
 
-- Admin UI: `https://<server-ip>:8443/admin`
+- Admin UI: `https://pihole.<caddy_domain>/admin`
 
 ## Volumes
 

--- a/roles/syncthing/README.md
+++ b/roles/syncthing/README.md
@@ -28,13 +28,15 @@ at `https://<server-ip>:8384`.
 
 ## Firewall ports
 
-- **8384/tcp** — GUI
 - **22000/tcp** + **22000/udp** — sync protocol
 - **21027/udp** — local discovery
 
+The web UI on port 8384 is **not** exposed in the firewall — access it
+via Caddy at `https://syncthing.<caddy_domain>`.
+
 ## Endpoints
 
-- Web UI: `https://<server-ip>:8384`
+- Web UI: `https://syncthing.<caddy_domain>`
 
 ## Volumes
 

--- a/setup.sh
+++ b/setup.sh
@@ -187,6 +187,13 @@ ask "Server hostname [$DEFAULT_HOSTNAME]:"
 read -r SERVER_HOSTNAME
 SERVER_HOSTNAME=${SERVER_HOSTNAME:-$DEFAULT_HOSTNAME}
 
+# caddy_domain — used for HTTPS reverse-proxy subdomains. Caddy is
+# mandatory in this project, so the domain is required.
+DEFAULT_CADDY_DOMAIN="${SERVER_HOSTNAME}.lan"
+ask "Caddy domain (for https://*.<domain>) [$DEFAULT_CADDY_DOMAIN]:"
+read -r CADDY_DOMAIN
+CADDY_DOMAIN=${CADDY_DOMAIN:-$DEFAULT_CADDY_DOMAIN}
+
 ask "Your username [$DEFAULT_USER]:"
 read -r SERVER_USER
 SERVER_USER=${SERVER_USER:-$DEFAULT_USER}
@@ -220,7 +227,6 @@ echo
 
 declare -A SERVICES
 SERVICES=(
-    [caddy]="Web server (serves the dashboard) — recommended"
     [dashboard]="Status dashboard showing all services — recommended"
     [pihole]="Pi-hole DNS ad-blocker"
     [syncthing]="Syncthing file synchronization"
@@ -231,19 +237,21 @@ SERVICES=(
     [jellyfin]="Jellyfin media server (movies, TV, music)"
 )
 
-# Recommended order for deployment
-SERVICE_ORDER=(caddy dashboard pihole syncthing shairportsync jukebox entephoto paperless-ngx jellyfin)
-SELECTED_SERVICES=()
+# Caddy is always deployed — it's the mandatory front-door reverse proxy.
+SELECTED_SERVICES=(caddy)
+
+# Recommended order for deployment of optional services
+SERVICE_ORDER=(dashboard pihole syncthing shairportsync jukebox entephoto paperless-ngx jellyfin)
 
 for svc in "${SERVICE_ORDER[@]}"; do
     desc="${SERVICES[$svc]}"
-    if [[ "$svc" == "caddy" || "$svc" == "dashboard" ]]; then
+    if [[ "$svc" == "dashboard" ]]; then
         ask "Deploy $svc? ($desc) [Y/n]:"
     else
         ask "Deploy $svc? ($desc) [y/N]:"
     fi
     read -r answer
-    if [[ "$svc" == "caddy" || "$svc" == "dashboard" ]]; then
+    if [[ "$svc" == "dashboard" ]]; then
         [[ ! "$answer" =~ ^[Nn]$ ]] && SELECTED_SERVICES+=("$svc")
     else
         [[ "$answer" =~ ^[Yy]$ ]] && SELECTED_SERVICES+=("$svc")
@@ -357,6 +365,9 @@ my_linux_users:
     uid: 1011
     gid: 1011
 ##################################################################################################
+
+### Caddy reverse-proxy
+caddy_domain: "$CADDY_DOMAIN"
 
 ### Pi-hole
 pihole_local_network: "$LAN_CIDR"


### PR DESCRIPTION
Refs #57. Companion to #58 (drops the per-role HTTP firewall openings).

## Summary
- \`playbooks/site.yml\` pre_tasks assert \`caddy\` is in \`deploy_services\` and \`caddy_domain\` is non-empty; both fail fast with clear messages otherwise.
- \`setup.sh\` always includes \`caddy\` in the generated \`deploy_services\` (drops the Y/N prompt). Prompts for \`caddy_domain\` and emits it into the generated host_vars.
- Caddy README — dropped \"Backward compatibility — Direct IP:port still works\" and \"Simple mode\". Header explains Caddy is mandatory.
- Top-level README — adds a one-line note under Security-conscious design.
- Per-role READMEs (pihole, syncthing, entephoto, paperless-ngx, jukebox) — Firewall ports and Endpoints sections updated to drop the closed ports and reference the Caddy URLs.

## Test plan
- [x] \`ansible-playbook playbooks/site.yml --syntax-check\`
- [x] \`bash -n setup.sh\`
- [ ] After merge: \`ansible-playbook playbooks/site.yml\` against a host with \`caddy\` removed from deploy_services → must fail with the assertion. Restore + re-run.