### PR TITLE
jukebox: fix lyrionmusicserver registry path (lms-community)

### DIFF
--- a/roles/jukebox/README.md
+++ b/roles/jukebox/README.md
@@ -17,7 +17,7 @@ host plays music from its own library through its sound card.
 
 | Container       | Image                                  |
 |-----------------|----------------------------------------|
-| jukebox-server  | `docker.io/lmscommunity/lyrionmusicserver` |
+| jukebox-server  | `ghcr.io/lms-community/lyrionmusicserver:stable` |
 | jukebox-player  | `docker.io/giof71/squeezelite`         |
 
 ## Service user

--- a/roles/jukebox/defaults/main.yml
+++ b/roles/jukebox/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 # Container images
-jukebox_server_image: "ghcr.io/lmscommunity/lyrionmusicserver"
+# GHCR org is "lms-community" (with hyphen), not "lmscommunity".
+# The hyphen-less variant returns 403/NAME_UNKNOWN. GHCR has no
+# anonymous-pull rate limit (unlike Docker Hub), so prefer it.
+# 'stable' is the rolling stable tag; pin to e.g. '9.1.1-stable' for
+# reproducible deploys. 'latest' does not exist on this repo.
+jukebox_server_image: "ghcr.io/lms-community/lyrionmusicserver:stable"
 jukebox_player_image: "docker.io/giof71/squeezelite"
 
 # Squeezelite preset selecting the audio output device. The


### PR DESCRIPTION
Closes #60.

The role default was `ghcr.io/lmscommunity/lyrionmusicserver` — that org doesn't exist on GHCR (NAME_UNKNOWN), which is why pulls returned 403. The actual GHCR org is **`lms-community` with a hyphen**.

Verified by direct pull on eddie:
```
podman pull ghcr.io/lms-community/lyrionmusicserver:stable
# → Writing manifest to image destination
```

GHCR has no anonymous-pull rate limit (unlike Docker Hub), so this is the preferred source. `stable` is the rolling release tag the upstream repo provides — pin to e.g. `9.1.1-stable` for reproducible deploys. `latest` does not exist on this repo (would 404), so naming the tag explicitly is required.