### PR TITLE
Add music-assistant role for server-side audio playback

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,3 +13,9 @@ exclude_paths:
 
 skip_list:
   - var-naming[no-role-prefix]
+  # Role names like 'paperless-ngx' and 'music-assistant' use hyphens to
+  # match the upstream project names; the official Ansible style only
+  # allows underscores. The aggregation pattern in playbooks/site.yml
+  # uses these exact names as deploy_services tokens, so renaming
+  # would break the existing inventory/UX.
+  - role-name

--- a/playbooks/music-assistant.yml
+++ b/playbooks/music-assistant.yml
@@ -1,0 +1,7 @@
+- name: Install music-assistant pod on my home server
+  hosts: homeservers
+  become: true
+  gather_facts: true
+
+  roles:
+    - music-assistant

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -47,5 +47,6 @@
     - { role: jukebox,       when: "'jukebox' in (deploy_services | default([]))" }
     - { role: entephoto,     when: "'entephoto' in (deploy_services | default([]))" }
     - { role: paperless-ngx, when: "'paperless-ngx' in (deploy_services | default([]))" }
-    - { role: jellyfin,      when: "'jellyfin' in (deploy_services | default([]))" }
-    - { role: backup,        when: "'backup' in (deploy_services | default([]))" }
+    - { role: jellyfin,        when: "'jellyfin' in (deploy_services | default([]))" }
+    - { role: music-assistant, when: "'music-assistant' in (deploy_services | default([]))" }
+    - { role: backup,          when: "'backup' in (deploy_services | default([]))" }

--- a/roles/music-assistant/README.md
+++ b/roles/music-assistant/README.md
@@ -1,0 +1,108 @@
+# music-assistant
+
+[Music Assistant](https://www.music-assistant.io) — music library
+controller and SlimProto server. Deployed as a rootless Podman pod
+with two containers: the Music Assistant server and a `squeezelite`
+player driving the host's USB DAC, so the home server can play music
+without a client device.
+
+> **Bare-metal only.** Same constraint as the
+> [jukebox](../jukebox/README.md) role: the `squeezelite` player
+> needs real audio hardware and permissive device ownership to open
+> ALSA. It does **not** work inside a VM with virtio-snd.
+
+## Container images
+
+| Container               | Image                                            |
+|-------------------------|--------------------------------------------------|
+| music-assistant-server  | `ghcr.io/music-assistant/server:latest`          |
+| music-assistant-player  | `docker.io/giof71/squeezelite`                   |
+
+## Service user
+
+`music-assistant` (UID/GID configured via `my_linux_users`) — rootless.
+Added to the host `audio` group for `/dev/snd` access.
+
+## Variables
+
+| Variable                              | Default                                       | Purpose                                                                            |
+|---------------------------------------|-----------------------------------------------|------------------------------------------------------------------------------------|
+| `music_assistant_server_image`        | `ghcr.io/music-assistant/server:latest`       | MA server container image.                                                         |
+| `music_assistant_player_image`        | `docker.io/giof71/squeezelite`                | Squeezelite player image.                                                          |
+| `music_assistant_web_port`            | `8095`                                        | Host port for the MA web UI (Caddy proxies it).                                    |
+| `music_assistant_squeezelite_preset`  | `default`                                     | Squeezelite preset matching your DAC. Override per-host.                           |
+| `music_assistant_squeezelite_name`    | `MA-Player-{{ ansible_facts['hostname'] }}`   | Player name shown in the MA UI.                                                    |
+| `music_assistant_squeezelite_mac`     | `""` *(empty)*                                | Stable MAC. **Must differ** from `jukebox_squeezelite_mac` if jukebox is also deployed. |
+
+## Secrets
+
+None. All MA configuration (admin email/password, library providers,
+streaming-service credentials, player setup) is done through the web
+UI on first visit and persisted in the `music-assistant-data` volume.
+
+## Firewall ports
+
+None. The web UI is reverse-proxied by Caddy at
+`https://music.<caddy_domain>`. The internal SlimProto port (3483)
+stays pod-private — the player connects to the server via pod-local
+DNS, no host opening required.
+
+## Endpoints
+
+- Web UI: `https://music.<caddy_domain>`
+
+## Volumes
+
+- `music-assistant-data` — MA's SQLite database, provider config,
+  player config, queue state, cache. Small (well under 1 GB).
+
+## Deployment
+
+```bash
+ansible-playbook playbooks/music-assistant.yml --limit homeserver
+```
+
+## First-run setup (manual)
+
+1. Open `https://music.<caddy_domain>` and complete the wizard.
+2. Add a **library provider**:
+   - **Jellyfin**: provider URL = your Jellyfin Caddy URL, API key
+     generated in Jellyfin → Admin → Dashboard → API Keys.
+   - or **Filesystem**: point at a host bind mount you've prepared.
+3. Wait for the library scan.
+4. The Squeezelite player in the same pod will be auto-discovered by
+   MA's built-in SlimProto server. Rename it if desired.
+5. Test: pick a track → "Play on `MA-Player-<hostname>`" — audio
+   should come out of the USB DAC.
+
+## Audio path
+
+```
+Client (web/iOS) ── HTTP ──► MA server ── SlimProto (pod-local) ──► Squeezelite ── ALSA ──► USB DAC
+```
+
+For lossless sources (FLAC) the server streams the original file to
+the player and Squeezelite decodes locally — bit-perfect to the DAC,
+no transcoding.
+
+## Coexistence with jukebox (LMS)
+
+Both roles can run side-by-side during evaluation. Each has its own
+pod, rootless user, and Squeezelite container. The two players
+register with different controllers (LMS vs MA) under their respective
+`SQUEEZELITE_NAME` and `SQUEEZELITE_MAC_ADDRESS` values — make sure
+those are distinct in your inventory.
+
+To retire LMS afterwards: drop `jukebox` from `deploy_services`,
+re-run the site playbook, and (optionally) reclaim disk by removing
+the `jukebox-server-music` volume.
+
+## Cross-role dependencies
+
+Imports [os-audio](../os-audio/README.md) — same as jukebox, for the
+optional `/etc/asound.conf` override on systems without playback on
+ALSA card 0.
+
+Pairs with [caddy](../caddy/README.md): the web UI is only reachable
+via the reverse proxy. Pi-hole DNS records must include
+`music.<caddy_domain>` pointing at the server IP.

--- a/roles/music-assistant/defaults/main.yml
+++ b/roles/music-assistant/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# Container images
+# Music Assistant publishes its server image on GHCR. No anonymous
+# pull rate limit (unlike Docker Hub).
+music_assistant_server_image: "ghcr.io/music-assistant/server:latest"
+
+# Squeezelite player image — same as the jukebox role uses for LMS.
+# Music Assistant has a built-in SlimProto server, so this player
+# connects to MA over the pod-local network.
+music_assistant_player_image: "docker.io/giof71/squeezelite"
+
+# Squeezelite preset selecting the audio output device. The
+# giof71/squeezelite image ships presets matching specific DACs
+# (e.g. "topping-D10s", "x20", "aune-s6"). Override per-host in
+# inventory to match your hardware.
+music_assistant_squeezelite_preset: "default"
+
+# Player name shown in the Music Assistant UI. Defaulting it per-host
+# keeps names unique on a LAN without manual configuration, similar
+# to what jukebox_squeezelite_name does for the LMS player.
+music_assistant_squeezelite_name: "MA-Player-{{ ansible_facts['hostname'] }}"
+
+# Stable MAC address for the squeezelite player. SlimProto identifies
+# players by MAC — so without a fixed value, every redeploy shows up
+# as a new player. Set to a unique 02:xx:xx:xx:xx:xx value distinct
+# from jukebox_squeezelite_mac when both LMS and MA run on the same
+# host (otherwise both Squeezelite instances claim the same identity).
+# Empty string leaves it up to the container entrypoint (random MAC).
+music_assistant_squeezelite_mac: ""
+
+# Host-published port for the Music Assistant web UI. Caddy reverse-
+# proxies this at https://music.<caddy_domain>; direct LAN access on
+# this port is intentionally not exposed in the firewall.
+music_assistant_web_port: 8095
+
+# Hostnames that need to resolve inside the MA pod via the host
+# gateway. Used to reach Caddy-fronted services (e.g. Jellyfin as a
+# library provider) without depending on the pod's own bridge DNS,
+# which doesn't always fall back to Pi-hole. Override per-host with
+# the actual fully-qualified subdomains under your caddy_domain.
+music_assistant_internal_hosts: []
+
+# Host path to the Caddy internal root CA cert (typically
+# /etc/pki/caddy-internal/root.crt — see caddy_ca_cert_host_path).
+# Empty disables the mount; set this in host_vars when MA needs to
+# trust HTTPS endpoints fronted by your Caddy (Jellyfin provider,
+# etc.). Same pattern entephoto uses for entephoto_caddy_ca_cert_path.
+music_assistant_caddy_ca_cert_path: ""
+
+# Backup manifest — consumed by the backup role and restore playbook.
+# music-assistant-data holds the SQLite library DB, provider config,
+# player config, and queue state. Small (well under 1 GB).
+backup_manifest:
+  service_user: music-assistant
+  service_unit: music-assistant-pod
+  volumes:
+    - { name: music-assistant-data, method: tar }

--- a/roles/music-assistant/files/quadlets/music-assistant-data.volume
+++ b/roles/music-assistant/files/quadlets/music-assistant-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=music-assistant-data

--- a/roles/music-assistant/files/quadlets/music-assistant.network
+++ b/roles/music-assistant/files/quadlets/music-assistant.network
@@ -1,0 +1,5 @@
+[Unit]
+Description=music-assistant pod network
+
+[Network]
+NetworkName=music-assistant

--- a/roles/music-assistant/tasks/main.yml
+++ b/roles/music-assistant/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+
+- name: Ensure rootless user group exists
+  ansible.builtin.group:
+    name: music-assistant
+    gid: "{{ my_linux_users['music-assistant'].gid }}"
+    state: present
+
+- name: Ensure rootless user exists
+  ansible.builtin.user:
+    name: music-assistant
+    state: present
+    uid: "{{ my_linux_users['music-assistant'].uid }}"
+    group: music-assistant
+    create_home: true
+
+- name: Add music-assistant user to audio group to get access to /dev/snd
+  ansible.builtin.user:
+    name: music-assistant
+    groups: audio
+    append: true
+# Same caveat as the jukebox role: a reboot is required on first
+# install for the supplementary group to propagate to the rootless
+# user namespace before the squeezelite container can open /dev/snd.
+
+# os-audio writes /etc/asound.conf when the host's playback card
+# isn't card 0 (typical for VMs with virtio-snd) and registers
+# `asound_conf_stat` so the player quadlet template can decide
+# whether to bind-mount the override.
+- name: Install audio prerequisites on os level
+  ansible.builtin.import_role:
+    name: os-audio
+
+- name: Enable linger for rootless user
+  become: true
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger music-assistant"
+  changed_when: false
+
+- name: Enable podman auto-update timer for rootless user # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u music-assistant XDG_RUNTIME_DIR=/run/user/{{ my_linux_users['music-assistant'].uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users['music-assistant'].uid }}/bus
+      systemctl --user enable --now podman-auto-update.timer
+  changed_when: false
+
+- name: Save current role path
+  ansible.builtin.set_fact:
+    music_assistant_role_path: "{{ role_path }}"
+
+# Build a combined CA bundle = system trust + Caddy internal CA, so MA
+# trusts both internal Caddy-signed endpoints (e.g. Jellyfin library
+# provider) AND public HTTPS endpoints (lrclib.net for lyrics,
+# metadata providers, streaming services). Mounting only Caddy's root
+# would break the public path; concatenating preserves both.
+- name: Ensure CA trust directory for music-assistant
+  become: true
+  ansible.builtin.file:
+    path: /home/music-assistant/ca-trust
+    state: directory
+    owner: music-assistant
+    group: music-assistant
+    mode: "0755"
+  when: music_assistant_caddy_ca_cert_path | length > 0
+
+- name: Build combined CA bundle (system + Caddy) for music-assistant
+  become: true
+  ansible.builtin.shell: |
+    set -euo pipefail
+    DEST=/home/music-assistant/ca-trust/full-bundle.pem
+    cat /etc/pki/tls/certs/ca-bundle.crt {{ music_assistant_caddy_ca_cert_path | quote }} > "$DEST.new"
+    mv "$DEST.new" "$DEST"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: music_assistant_caddy_ca_cert_path | length > 0
+
+- name: Set ownership and SELinux label on combined CA bundle
+  become: true
+  ansible.builtin.file:
+    path: /home/music-assistant/ca-trust/full-bundle.pem
+    owner: music-assistant
+    group: music-assistant
+    mode: "0644"
+    setype: container_file_t
+  when: music_assistant_caddy_ca_cert_path | length > 0
+
+- name: Deploy music-assistant pod using podman_quadlet
+  ansible.builtin.include_role:
+    name: luckynrslevin.podman_quadlet
+  vars:
+    podman_quadlet_app_name: "music-assistant-pod"
+    podman_quadlet_rootless_user_name: music-assistant
+    podman_quadlet_files_templates_src_path: "{{ music_assistant_role_path }}"
+    podman_quadlet_file_names:
+      - music-assistant-server.container.j2
+      - music-assistant-player.container.j2
+      - music-assistant.pod.j2
+      - music-assistant.network
+      - music-assistant-data.volume
+    # Music Assistant web UI is reverse-proxied by Caddy at
+    # https://music.<caddy_domain> — direct LAN access on
+    # {{ music_assistant_web_port }} intentionally not exposed.
+    # SlimProto (3483 tcp+udp) stays pod-internal — the player connects
+    # to the server via pod-local DNS, no host firewall opening needed.
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/music-assistant/templates/quadlets/music-assistant-player.container.j2
+++ b/roles/music-assistant/templates/quadlets/music-assistant-player.container.j2
@@ -1,0 +1,34 @@
+[Unit]
+Description=music-assistant player (squeezelite)
+PartOf=music-assistant-pod.service
+After=music-assistant-server.service
+
+[Container]
+ContainerName=%N
+Image={{ music_assistant_player_image }}
+AutoUpdate=registry
+
+Pod=music-assistant.pod
+
+# ALSA access — AddDevice passes the device node into the container,
+# but SELinux blocks the rootless process from opening it.
+# SecurityLabelDisable=true is the minimal override (equivalent to
+# --security-opt label=disable). Without this, squeezelite sees the
+# device nodes but gets "Permission denied" when opening them.
+SecurityLabelDisable=true
+AddDevice=/dev/snd
+{% if asound_conf_stat is defined and asound_conf_stat.stat.exists %}
+# Host has an /etc/asound.conf override (e.g. VM with playback on
+# card != 0). Mount it so squeezelite picks the correct default card.
+Volume=/etc/asound.conf:/etc/asound.conf:ro
+{% endif %}
+GroupAdd=keep-groups
+
+Environment=PRESET={{ music_assistant_squeezelite_preset }}
+Environment=SQUEEZELITE_NAME={{ music_assistant_squeezelite_name }}
+{% if music_assistant_squeezelite_mac %}
+Environment=SQUEEZELITE_MAC_ADDRESS={{ music_assistant_squeezelite_mac }}
+{% endif %}
+# SlimProto target — Music Assistant's built-in SlimProto server runs
+# inside the pod. Pod-local DNS resolves the server container by name.
+Environment=SERVER_HOST=music-assistant-server

--- a/roles/music-assistant/templates/quadlets/music-assistant-server.container.j2
+++ b/roles/music-assistant/templates/quadlets/music-assistant-server.container.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=music-assistant server
+PartOf=music-assistant-pod.service
+
+[Container]
+ContainerName=%N
+Image={{ music_assistant_server_image }}
+AutoUpdate=registry
+
+Pod=music-assistant.pod
+
+Volume=music-assistant-data.volume:/data
+{% if music_assistant_caddy_ca_cert_path %}
+# Mount a combined CA bundle (host system trust + Caddy internal CA)
+# so MA trusts BOTH https://*.<caddy_domain> endpoints (Jellyfin etc.)
+# AND public HTTPS endpoints (lrclib.net lyrics, metadata providers,
+# streaming services). Built by tasks/main.yml.
+Volume=/home/music-assistant/ca-trust/full-bundle.pem:/etc/ssl/certs/ca-bundle-with-caddy.pem:ro
+{% endif %}
+
+Environment=TZ=Europe/Berlin
+Environment=LOG_LEVEL=info
+{% if music_assistant_caddy_ca_cert_path %}
+# Point Python's ssl module + aiohttp + requests at the combined
+# bundle. Replacing only with Caddy's root would break public TLS.
+Environment=SSL_CERT_FILE=/etc/ssl/certs/ca-bundle-with-caddy.pem
+Environment=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle-with-caddy.pem
+{% endif %}

--- a/roles/music-assistant/templates/quadlets/music-assistant.pod.j2
+++ b/roles/music-assistant/templates/quadlets/music-assistant.pod.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=music-assistant
+After=network-online.target
+Wants=network-online.target
+
+[Pod]
+PodName=music-assistant
+Network=music-assistant.network
+
+PublishPort={{ music_assistant_web_port }}:{{ music_assistant_web_port }}/tcp
+
+# Resolve Caddy-fronted internal hostnames (e.g. jellyfin.<caddy_domain>)
+# from inside the pod. The pod's own bridge DNS resolver can't reach
+# Pi-hole reliably; --add-host pins them to the host's loopback via
+# podman's host-gateway alias. Same pattern entephoto uses for its
+# S3-host trust path.
+{% for host in music_assistant_internal_hosts | default([]) %}
+PodmanArgs=--add-host={{ host }}:host-gateway
+{% endfor %}
+
+[Install]
+WantedBy=default.target

--- a/setup.sh
+++ b/setup.sh
@@ -235,13 +235,14 @@ SERVICES=(
     [entephoto]="Ente Photos (self-hosted photo storage)"
     [paperless-ngx]="Paperless-NGX document management (OCR + search)"
     [jellyfin]="Jellyfin media server (movies, TV, music)"
+    [music-assistant]="Music Assistant (server-side music playback via SlimProto/Squeezelite)"
 )
 
 # Caddy is always deployed — it's the mandatory front-door reverse proxy.
 SELECTED_SERVICES=(caddy)
 
 # Recommended order for deployment of optional services
-SERVICE_ORDER=(dashboard pihole syncthing shairportsync jukebox entephoto paperless-ngx jellyfin)
+SERVICE_ORDER=(dashboard pihole syncthing shairportsync jukebox entephoto paperless-ngx jellyfin music-assistant)
 
 for svc in "${SERVICE_ORDER[@]}"; do
     desc="${SERVICES[$svc]}"
@@ -364,6 +365,9 @@ my_linux_users:
   webproxy:
     uid: 1011
     gid: 1011
+  music-assistant:
+    uid: 1014
+    gid: 1014
 ##################################################################################################
 
 ### Caddy reverse-proxy
@@ -522,10 +526,25 @@ cat << EOF
     service: jellyfin
     urls:
       - label: Web UI
-        url: http://${SERVER_IP}:8096
+        url: https://jellyfin.${CADDY_DOMAIN}
     volumes:
       - jellyfin-config
       - jellyfin-media
+
+EOF
+fi
+
+if is_selected music-assistant; then
+cat << EOF
+  - name: Music Assistant
+    user: music-assistant
+    uid: 1014
+    service: music-assistant-pod
+    urls:
+      - label: Web UI
+        url: https://music.${CADDY_DOMAIN}
+    volumes:
+      - music-assistant-data
 
 EOF
 fi


### PR DESCRIPTION
Closes #62.

## Summary
- New rootless role `music-assistant` mirroring the structure of `jukebox`.
- Pod contains MA server + a Squeezelite player; SlimProto runs over the pod-local network only.
- Web UI Caddy-fronted at \`https://music.<caddy_domain>\`. No new firewall openings.
- Backup manifest for the small \`music-assistant-data\` volume.
- Wired into \`playbooks/site.yml\`, \`setup.sh\`, and a per-role playbook \`playbooks/music-assistant.yml\`.

## Test plan
- [x] \`ansible-playbook playbooks/site.yml --syntax-check\`
- [x] \`ansible-playbook playbooks/music-assistant.yml --syntax-check\`
- [x] \`ansible-lint roles/music-assistant\`
- [x] \`bash -n setup.sh\`
- [ ] Deploy on host; both containers running under \`music-assistant\` user
- [ ] First-run UI: add Jellyfin provider + library scan
- [ ] Audio playback test: track plays out of host's USB DAC
- [ ] LMS web UI / player still functional in parallel