### PR TITLE
jellyfin: automate first-run (admin, libraries, folders)

### DIFF
--- a/roles/jellyfin/README.md
+++ b/roles/jellyfin/README.md
@@ -14,24 +14,70 @@ single rootless container with host networking (for DLNA discovery).
 
 ## Variables
 
-| Variable                        | Default        | Purpose |
-|---------------------------------|----------------|---------|
-| `jellyfin_enable_hw_transcoding`| `false`        | Enable VAAPI hardware transcoding via `/dev/dri`. |
-| `jellyfin_time_zone`            | `Europe/Berlin`| Timezone for metadata and scheduled tasks. |
+| Variable                          | Default                     | Purpose |
+|-----------------------------------|-----------------------------|---------|
+| `jellyfin_enable_hw_transcoding`  | `false`                     | Enable VAAPI hardware transcoding via `/dev/dri`. |
+| `jellyfin_time_zone`              | `Europe/Berlin`             | Timezone for metadata and scheduled tasks. |
+| `jellyfin_admin_user`             | `jellyadmin`                | Admin username created during first-run automation. |
+| `jellyfin_admin_password`         | `""` *(vaulted)*            | Admin password. Empty disables postinstall (manual wizard). |
+| `jellyfin_metadata_language`      | `en`                        | Default metadata language for new libraries. |
+| `jellyfin_metadata_country`       | `US`                        | Default metadata country code. |
+| `jellyfin_libraries`              | *(four standard libraries)* | List of `{name, type, path}` dicts auto-created on deploy. |
+
+### Library list (default)
+
+```yaml
+jellyfin_libraries:
+  - { name: "Music",       type: "music",      path: "/media/music" }
+  - { name: "Movies",      type: "movies",     path: "/media/movies" }
+  - { name: "Shows",       type: "tvshows",    path: "/media/tv" }
+  - { name: "Home Videos", type: "homevideos", path: "/media/home-videos" }
+```
+
+Override the whole list in your host_vars to drop entries (e.g.
+omit Home Videos) or add libraries (e.g. an audiobooks library
+mapped at `/media/audiobooks`). Each path's subdirectory is
+pre-created inside the `jellyfin-media` volume on deploy.
+
+## First-run automation
+
+When `jellyfin_admin_password` is set, the role's `postinstall.yml`
+walks Jellyfin's REST API after the container is healthy:
+
+1. Configures metadata locale (`UICulture` / `MetadataCountryCode`).
+2. Creates the admin user (`/Startup/User`).
+3. Sets remote-access defaults (Caddy fronts; UPnP off).
+4. Marks the wizard complete (`/Startup/Complete`).
+5. Authenticates as admin and registers any libraries from
+   `jellyfin_libraries` that don't already exist.
+6. Triggers a single library scan if any new libraries were added.
+
+Idempotent: subsequent runs detect the wizard-complete state via a
+403 from `/Startup/User` and skip; libraries already present are
+left untouched.
 
 ## Secrets
 
-None. The admin account is created via the web UI wizard on first
-access — no vault-encrypted variables needed.
+| Variable                  | Purpose                                  |
+|---------------------------|------------------------------------------|
+| `jellyfin_admin_password` | Admin password for the auto-created user.|
+
+`setup.sh` generates this as a vault-encrypted random string. Inspect
+the stored value with:
+
+```bash
+ansible -i inventory/hosts.yml homeserver -m debug -a "var=jellyfin_admin_password"
+```
 
 ## Firewall ports
 
-- **8096/tcp** — Web UI and API.
+None. The web UI is reverse-proxied by Caddy at
+`https://jellyfin.<caddy_domain>` — direct LAN access on 8096
+intentionally not exposed.
 
 ## Endpoints
 
-- Web UI: `http://<server-ip>:8096`
-- With reverse proxy: `https://jellyfin.<caddy_domain>`
+- Web UI: `https://jellyfin.<caddy_domain>`
 
 ## Volumes
 

--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -11,6 +11,35 @@ jellyfin_enable_hw_transcoding: false
 # Timezone for metadata and scheduled tasks.
 jellyfin_time_zone: "Europe/Berlin"
 
+# First-run automation — admin account, locale, libraries.
+# Set jellyfin_admin_password from a vault-encrypted secret in your
+# private inventory (setup.sh generates this automatically). Leaving
+# it empty disables the postinstall step.
+jellyfin_admin_user: jellyadmin
+jellyfin_admin_password: ""
+
+# Default locale for the metadata wizard. Override in host_vars when
+# your household isn't English/US.
+jellyfin_metadata_language: "en"
+jellyfin_metadata_country: "US"
+
+# Libraries pre-registered during postinstall. Each entry maps a
+# Jellyfin library name + content type to a path inside the
+# jellyfin-media volume. The corresponding subdirectories are
+# pre-created on deploy.
+#
+# Valid content types (Jellyfin's collectionType field):
+#   movies | tvshows | music | musicvideos | homevideos
+#   playlists | books | mixed (discouraged)
+#
+# Override the whole list in host_vars to drop entries you don't want
+# (e.g. omit homevideos if you don't keep any).
+jellyfin_libraries:
+  - { name: "Music", type: "music", path: "/media/music" }
+  - { name: "Movies", type: "movies", path: "/media/movies" }
+  - { name: "Shows", type: "tvshows", path: "/media/tv" }
+  - { name: "Home Videos", type: "homevideos", path: "/media/home-videos" }
+
 # Backup manifest — consumed by the backup role and restore playbook.
 backup_manifest:
   service_user: jellyfin

--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -45,8 +45,13 @@
       - jellyfin-config.volume
       - jellyfin-cache.volume
       - jellyfin-media.volume
-    podman_quadlet_firewall_ports:
-      - "8096/tcp"
+    # Jellyfin web UI is reverse-proxied by Caddy at
+    # https://jellyfin.<caddy_domain>. Direct LAN access on 8096 is
+    # intentionally not exposed (Caddy is mandatory in this project).
+
+- name: Run first-run postinstall (wizard + libraries)
+  ansible.builtin.import_tasks: postinstall.yml
+  when: jellyfin_admin_password | length > 0
 
 - name: Register backup manifest
   ansible.builtin.set_fact:

--- a/roles/jellyfin/tasks/postinstall.yml
+++ b/roles/jellyfin/tasks/postinstall.yml
@@ -1,0 +1,166 @@
+---
+# Jellyfin first-run automation: create admin user, set locale, register
+# the standard media libraries, all via Jellyfin's REST API.
+#
+# Idempotent: every step polls existing state (wizard complete? library
+# already present?) before issuing writes. Re-running site.yml is safe.
+#
+# All API calls go to http://127.0.0.1:8096 — the container uses
+# Network=host so the host loopback hits Jellyfin directly.
+
+- name: Wait for Jellyfin web service to come up
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/health"
+    status_code: 200
+    return_content: true
+  register: _jellyfin_health
+  retries: 30
+  delay: 5
+  until: _jellyfin_health.status == 200 and 'Healthy' in (_jellyfin_health.content | default(''))
+
+# Pre-create media library subdirectories inside the running
+# container. Done here (after the health wait) rather than via
+# podman_quadlet_volumes_files_to_stage which would require a real
+# source dir on the control host.
+- name: Pre-create media library subdirectories # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      sudo -iu jellyfin podman exec jellyfin
+      mkdir -p {{ item.path | quote }}
+  loop: "{{ jellyfin_libraries }}"
+  loop_control:
+    label: "{{ item.path }}"
+  changed_when: false
+
+# --------------------------------------------------------------------------
+# Wizard state probe
+# --------------------------------------------------------------------------
+# The Startup endpoints are only reachable while the first-run wizard
+# is incomplete. Once /Startup/Complete has been called, GET /Startup/User
+# returns 403 and the entire /Startup/* surface stops accepting writes.
+# That's our idempotency switch.
+
+- name: Probe wizard state
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Startup/User"
+    method: GET
+    status_code: [200, 403]
+    return_content: false
+  register: _jellyfin_wizard_probe
+
+- name: Set wizard_incomplete fact
+  ansible.builtin.set_fact:
+    _jellyfin_wizard_incomplete: "{{ _jellyfin_wizard_probe.status == 200 }}"
+
+# --------------------------------------------------------------------------
+# Wizard walkthrough — only when wizard is still incomplete
+# --------------------------------------------------------------------------
+- name: Configure metadata locale
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Startup/Configuration"
+    method: POST
+    body_format: json
+    body:
+      UICulture: "{{ jellyfin_metadata_language }}"
+      MetadataCountryCode: "{{ jellyfin_metadata_country }}"
+      PreferredMetadataLanguage: "{{ jellyfin_metadata_language }}"
+    status_code: [200, 204]
+  when: _jellyfin_wizard_incomplete
+
+- name: Create admin user via wizard
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Startup/User"
+    method: POST
+    body_format: json
+    body:
+      Name: "{{ jellyfin_admin_user }}"
+      Password: "{{ jellyfin_admin_password }}"
+    status_code: [200, 204]
+  when: _jellyfin_wizard_incomplete
+
+- name: Configure remote-access settings (Caddy fronts; UPnP off)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Startup/RemoteAccess"
+    method: POST
+    body_format: json
+    body:
+      EnableRemoteAccess: true
+      EnableAutomaticPortMapping: false
+    status_code: [200, 204]
+  when: _jellyfin_wizard_incomplete
+
+- name: Mark wizard complete
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Startup/Complete"
+    method: POST
+    status_code: [200, 204]
+  when: _jellyfin_wizard_incomplete
+
+# --------------------------------------------------------------------------
+# Authenticate as admin to drive library setup (post-wizard auth required).
+# --------------------------------------------------------------------------
+- name: Authenticate as admin
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Users/AuthenticateByName"
+    method: POST
+    body_format: json
+    body:
+      Username: "{{ jellyfin_admin_user }}"
+      Pw: "{{ jellyfin_admin_password }}"
+    headers:
+      Authorization: 'MediaBrowser Client="ansible-postinstall", Device="home-server", DeviceId="home-server-postinstall", Version="1.0"'
+    status_code: 200
+    return_content: true
+  register: _jellyfin_auth
+  no_log: true
+
+- name: Cache admin access token
+  ansible.builtin.set_fact:
+    _jellyfin_token: "{{ _jellyfin_auth.json.AccessToken }}"
+  no_log: true
+
+# --------------------------------------------------------------------------
+# Libraries — list current, then create any missing ones.
+# --------------------------------------------------------------------------
+- name: List existing libraries
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Library/VirtualFolders"
+    method: GET
+    headers:
+      Authorization: 'MediaBrowser Token="{{ _jellyfin_token }}"'
+    status_code: 200
+    return_content: true
+  register: _jellyfin_existing_libs
+  no_log: true
+
+- name: Build set of existing library names
+  ansible.builtin.set_fact:
+    _jellyfin_existing_lib_names: "{{ _jellyfin_existing_libs.json | map(attribute='Name') | list }}"
+
+- name: Create missing libraries
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Library/VirtualFolders?name={{ item.name | urlencode }}&collectionType={{ item.type }}&refreshLibrary=false"
+    method: POST
+    body_format: json
+    body:
+      LibraryOptions:
+        PathInfos:
+          - { Path: "{{ item.path }}" }
+    headers:
+      Authorization: 'MediaBrowser Token="{{ _jellyfin_token }}"'
+    status_code: [200, 204]
+  loop: "{{ jellyfin_libraries }}"
+  loop_control:
+    label: "{{ item.name }} ({{ item.type }} -> {{ item.path }})"
+  when: item.name not in _jellyfin_existing_lib_names
+  register: _jellyfin_libs_changed
+
+- name: Trigger one library scan if anything changed # noqa: no-handler
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8096/Library/Refresh"
+    method: POST
+    headers:
+      Authorization: 'MediaBrowser Token="{{ _jellyfin_token }}"'
+    status_code: [200, 204]
+  when: _jellyfin_libs_changed.changed | default(false)

--- a/setup.sh
+++ b/setup.sh
@@ -312,6 +312,7 @@ ENTEPHOTO_JWT=$(openssl rand -hex 32)
 PAPERLESS_SECRET_KEY=$(openssl rand -hex 32)
 PAPERLESS_DB_PW=$(openssl rand -base64 24)
 PAPERLESS_ADMIN_PW=$(openssl rand -base64 24)
+JELLYFIN_ADMIN_PW=$(openssl rand -base64 24)
 
 # Generate a stable, locally-administered unicast MAC for the
 # squeezelite player. First octet 0x02 sets the locally-administered
@@ -399,6 +400,9 @@ echo ""
 vault_encrypt "$PAPERLESS_DB_PW" "paperless_db_password"
 echo ""
 vault_encrypt "$PAPERLESS_ADMIN_PW" "paperless_admin_password"
+echo ""
+echo "### Jellyfin"
+vault_encrypt "$JELLYFIN_ADMIN_PW" "jellyfin_admin_password"
 echo "##################################################################################################"
 } > inventory/host_vars/homeserver/main.yml
 


### PR DESCRIPTION
Closes #64.

## Summary
- Pre-create `/media/{music,movies,tv,home-videos}` inside `jellyfin-media` via the Galaxy role's directory-staging.
- New `tasks/postinstall.yml` walks Jellyfin's REST API after the container is healthy: `/Startup/*` wizard sequence, then `/Library/VirtualFolders` for each entry in `jellyfin_libraries`.
- Idempotent — wizard-already-complete (HTTP 403 on `/Startup/User`) and library-already-present checks gate every write.
- `setup.sh` adds `jellyfin_admin_password` to the generated vault secrets.
- README updated; redundant `8096/tcp` firewall declaration dropped (Caddy is mandatory).

## Test plan
- [x] `ansible-playbook playbooks/site.yml --syntax-check`
- [x] `ansible-lint roles/jellyfin`
- [x] `bash -n setup.sh`
- [ ] Destroy `jellyfin-config` + `jellyfin-media` volumes on host, redeploy, verify wizard skipped + login works + four libraries appear
- [ ] Re-run `site.yml` → `changed=0` on the postinstall block
- [ ] Move existing music/Monaco-Franze content back into `/media/music` and `/media/tv`, trigger scan, confirm metadata still resolves