### PR TITLE
caddy: publish .mobileconfig profile for Apple device trust

### DIFF
--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -99,6 +99,20 @@ Caddy automatically generates self-signed certificates for `.lan`
 domains. Browsers will show a one-time cert warning — acceptable
 for a LAN home server. Certificate data is persisted in `caddy-data`.
 
+## Distributing the internal CA to client devices
+
+The role publishes the root CA at two URLs on the dashboard:
+
+| URL                              | For                       | UX                                                                                                  |
+|----------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------|
+| `/caddy-trust.mobileconfig`      | iOS / iPadOS / macOS      | Tap in Safari → install Apple configuration profile → two-tap trust on iOS, one-tap on macOS.       |
+| `/caddy-root.crt`                | Linux / Android / other   | Raw PEM cert; install via OS / browser certificate manager.                                         |
+
+The mobileconfig profile is generated from
+`templates/caddy-trust.mobileconfig.j2` on every deploy, so a CA
+rotation regenerates the file automatically. The profile is
+unsigned (Apple displays a "Verify" prompt; the user accepts).
+
 ## Internal CA persistence
 
 Caddy uses `tls internal`, which runs a private ACME CA. The root and

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -157,3 +157,29 @@
     mode: "0644"
     setype: container_file_t
   when: caddy_domain | length > 0
+
+# Apple-flavoured one-tap trust: the same root CA wrapped into a
+# .mobileconfig profile. iOS / iPadOS / macOS install it via Safari
+# in two taps, much friendlier than the raw .crt path. Linux/Android
+# clients keep using caddy-root.crt above.
+#
+# We slurp the cert from the target host so the template lookup
+# doesn't try to read it from the Ansible controller (which won't
+# have it on cross-host deploys).
+- name: Read Caddy root CA from target for mobileconfig
+  become: true
+  ansible.builtin.slurp:
+    src: "{{ caddy_ca_cert_host_path }}"
+  register: _caddy_ca_pem
+  when: caddy_domain | length > 0
+
+- name: Publish Caddy mobileconfig profile via dashboard
+  become: true
+  ansible.builtin.template:
+    src: caddy-trust.mobileconfig.j2
+    dest: /var/www/dashboard/caddy-trust.mobileconfig
+    mode: "0644"
+    setype: container_file_t
+  vars:
+    caddy_ca_pem_content: "{{ _caddy_ca_pem.content | b64decode }}"
+  when: caddy_domain | length > 0

--- a/roles/caddy/templates/caddy-trust.mobileconfig.j2
+++ b/roles/caddy/templates/caddy-trust.mobileconfig.j2
@@ -1,0 +1,55 @@
+{# Apple configuration profile that bundles Caddy's internal root CA.
+   Tapping the link in Safari (iOS or macOS) installs the profile in
+   one prompt; on iOS the user then enables trust under Certificate
+   Trust Settings.
+
+   PayloadUUID/PayloadIdentifier are derived from caddy_domain so a
+   re-render replaces an existing profile cleanly rather than stacking.
+
+   The PayloadContent for com.apple.security.root expects base64-encoded
+   DER. The PEM file at caddy_ca_cert_host_path is BEGIN/END markers
+   wrapping base64-DER; stripping the markers gives us the right value.
+-#}
+{%- set _ca_b64 = caddy_ca_pem_content
+      | regex_replace('-----BEGIN [A-Z ]+-----', '')
+      | regex_replace('-----END [A-Z ]+-----', '')
+      | regex_replace('\\s+', '') -%}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>PayloadIdentifier</key>
+    <string>lan.{{ caddy_domain }}.caddy.trust</string>
+    <key>PayloadUUID</key>
+    <string>{{ ('caddy-trust-profile-' ~ caddy_domain) | to_uuid }}</string>
+    <key>PayloadDisplayName</key>
+    <string>Caddy Internal CA — {{ caddy_domain }}</string>
+    <key>PayloadDescription</key>
+    <string>Trusts certificates issued by your home Caddy instance.</string>
+    <key>PayloadOrganization</key>
+    <string>home-server</string>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.apple.security.root</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>PayloadIdentifier</key>
+            <string>lan.{{ caddy_domain }}.caddy.trust.root</string>
+            <key>PayloadUUID</key>
+            <string>{{ ('caddy-trust-root-' ~ caddy_domain) | to_uuid }}</string>
+            <key>PayloadDisplayName</key>
+            <string>Caddy Local Authority — {{ caddy_domain }}</string>
+            <key>PayloadCertificateFileName</key>
+            <string>caddy-root.crt</string>
+            <key>PayloadContent</key>
+            <data>{{ _ca_b64 }}</data>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/roles/dashboard/files/home-server-dashboard.py
+++ b/roles/dashboard/files/home-server-dashboard.py
@@ -347,24 +347,35 @@ def generate_html(services_data, generated_at, nas_host_display):
 <h1>Home Server Dashboard</h1>
 <div class="ca-install">
   Trust this server's HTTPS:
+  <a href="/caddy-trust.mobileconfig"><strong>Install Apple profile</strong></a>
+  &nbsp;&middot;&nbsp;
   <a href="/caddy-root.crt" download>Download root certificate</a>
   <details>
-    <summary>iOS / iPadOS install</summary>
+    <summary>iOS / iPadOS install (Apple profile, recommended)</summary>
     <ol>
-      <li>Open this page in <strong>Safari</strong> (not Chrome) and tap the link above.</li>
-      <li>Tap <em>Allow</em> when iOS offers to download the configuration profile.</li>
-      <li>Open <em>Settings &rarr; General &rarr; VPN &amp; Device Management</em>, tap the
-          <em>Caddy Local Authority</em> profile, then <em>Install</em>.</li>
+      <li>Open this page in <strong>Safari</strong> (not Chrome) and tap <em>Install Apple profile</em>.</li>
+      <li>Tap <em>Allow</em>, then open <em>Settings &rarr; General &rarr; VPN &amp; Device Management</em>
+          and tap the downloaded profile to install.</li>
       <li>Open <em>Settings &rarr; General &rarr; About &rarr; Certificate Trust Settings</em>
-          and turn the toggle on for the new root.</li>
+          and turn on trust for the new root.</li>
     </ol>
   </details>
   <details>
-    <summary>macOS install</summary>
+    <summary>macOS install (Apple profile, recommended)</summary>
     <ol>
-      <li>Download the certificate, then open it &mdash; Keychain Access launches.</li>
-      <li>Add it to the <strong>System</strong> keychain.</li>
-      <li>Double-click the entry, expand <em>Trust</em>, set <em>When using this certificate: Always Trust</em>.</li>
+      <li>Open this page in Safari and click <em>Install Apple profile</em>.</li>
+      <li>System Settings opens to the Profiles pane &mdash; click <em>Install</em>.</li>
+      <li>Trust is applied automatically; HTTPS works in Safari and Chrome immediately.</li>
+    </ol>
+  </details>
+  <details>
+    <summary>Linux / Android / other</summary>
+    <ol>
+      <li>Use <em>Download root certificate</em> instead of the Apple profile.</li>
+      <li>Linux: copy to <code>/etc/pki/ca-trust/source/anchors/</code> (Fedora/RHEL) or
+          <code>/usr/local/share/ca-certificates/</code> (Debian/Ubuntu) and run
+          <code>update-ca-trust</code> / <code>update-ca-certificates</code>.</li>
+      <li>Android &le; 6 / desktop Chrome: import via the OS certificate manager.</li>
     </ol>
   </details>
 </div>


### PR DESCRIPTION
Closes #65.

## Summary
- Templated `.mobileconfig` profile bundling Caddy's internal root CA, served at `https://<caddy_domain>/caddy-trust.mobileconfig`.
- iOS / iPadOS / macOS install in two taps (one tap on macOS) — much smoother than the four-step raw-cert path.
- Dashboard banner gains the new link alongside the existing `.crt` download.
- Slurp from target host so the template render works on cross-host deploys.

## Test plan
- [x] Deploy on host, verify `/var/www/dashboard/caddy-trust.mobileconfig` exists with `container_file_t` SELinux label
- [x] HTTP GET via Caddy returns 200, valid plist
- [x] `python3 -c 'import plistlib; print(plistlib.load(open("file")).get("PayloadDisplayName"))'` returns "Caddy Internal CA — <domain>"
- [x] Dashboard HTML includes the `/caddy-trust.mobileconfig` link
- [ ] Tap link in Safari on iPhone → profile install + trust toggle works
- [ ] Tap link in Safari on Mac → System Settings → Profiles install works