### PR TITLE
jellyfin: fix backup_manifest volume names (systemd- prefix)

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -120,6 +120,8 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 | entephoto | `ente_db` (Postgres)              | pgdump  |
 | entephoto | `entephoto-museum-config`         | tar     |
 | entephoto | `entephoto-minio-data`            | rsync   |
+| jellyfin  | `systemd-jellyfin-config`         | tar     |
+| jellyfin  | `systemd-jellyfin-media`          | rsync   |
 
 > Caddy volumes are not backed up. `caddy-etc` (Caddyfile) and
 > `caddy-config` (runtime state) are regenerated from the role.

--- a/roles/jellyfin/README.md
+++ b/roles/jellyfin/README.md
@@ -81,10 +81,23 @@ intentionally not exposed.
 
 ## Volumes
 
-- `jellyfin-config` — SQLite database, server settings, metadata.
-- `jellyfin-cache` — transcoding cache and image cache (regenerable,
-  not backed up).
-- `jellyfin-media` — your media library (movies, TV, music).
+The `.volume` files declare no explicit `VolumeName=`, so podman
+auto-prefixes them with `systemd-`. The on-disk names (and the names
+the backup manifest references) are:
+
+- `systemd-jellyfin-config` — SQLite database, server settings, metadata.
+- `systemd-jellyfin-cache` — transcoding cache and image cache
+  (regenerable, not backed up).
+- `systemd-jellyfin-media` — your media library (movies, TV, music).
+
+## Backup prerequisites
+
+The Jellyfin media volume is mirrored to NFS share
+`backup-jellyfin-media` on the project NAS via the `backup` role.
+Before the first nightly run will succeed, **create the share on the
+NAS** (e.g. Synology DSM → File Services → NFS → New Folder named
+`backup-jellyfin-media`, allow the home-server's IP, squash to
+`admin`). Same shape as the existing `backup-paperless-media` share.
 
 ## Deployment
 

--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -41,9 +41,15 @@ jellyfin_libraries:
   - { name: "Home Videos", type: "homevideos", path: "/media/home-videos" }
 
 # Backup manifest — consumed by the backup role and restore playbook.
+# The role's .volume files have no `VolumeName=`, so podman auto-prefixes
+# the actual volume names with `systemd-`. The backup script passes
+# `vol.name` straight to `podman volume inspect` with no rewriting, so
+# the manifest must use the on-disk names. Same shape pihole and
+# syncthing already use (e.g. `systemd-pihole-etc`,
+# `systemd-syncthing-data`).
 backup_manifest:
   service_user: jellyfin
   service_unit: jellyfin
   volumes:
-    - { name: jellyfin-config, method: tar }
-    - { name: jellyfin-media, method: rsync, nas_share: jellyfin-media, restore_opt_in: true }
+    - { name: systemd-jellyfin-config, method: tar }
+    - { name: systemd-jellyfin-media, method: rsync, nas_share: jellyfin-media, restore_opt_in: true }


### PR DESCRIPTION
## Why
The Jellyfin backup pipeline has been silently broken since deploy. `backup_manifest` declared the volume name `jellyfin-media`, but the actual rootless-podman volume is `systemd-jellyfin-media` (no `VolumeName=` in the .volume file → podman auto-prefixes). The backup script's `podman volume inspect` returns "no such volume", aborting the run before any data is copied.

## What
- Rename both volumes in `backup_manifest` to their on-disk names — same prefix shape pihole and syncthing already use.
- Update the role README's Volumes table and add a Backup prerequisites section documenting the manual one-time NAS-share creation.
- Add the two missing rows to `roles/backup/README.md`'s 'What gets backed up per service' table.

## Test plan
- [x] `ansible-playbook playbooks/site.yml --syntax-check`
- [x] `ansible-lint roles/jellyfin`
- [ ] After merge + deploy: `grep systemd-jellyfin /usr/local/bin/home-server-backup.sh` shows both names; manual `systemctl start home-server-backup.service` produces a successful rsync of `systemd-jellyfin-media` and tar of `systemd-jellyfin-config` on the NAS