### PR TITLE
jellyfin: support NFS-backed media via extra mounts

### DIFF
--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -40,6 +40,28 @@ jellyfin_libraries:
   - { name: "Shows", type: "tvshows", path: "/media/tv" }
   - { name: "Home Videos", type: "homevideos", path: "/media/home-videos" }
 
+# Extra bind mounts into the Jellyfin container, beyond the role's own
+# `jellyfin-media` volume. Use this for NAS-backed media — mount the
+# NFS share on the host first (see `jellyfin_nas_mounts` below) and
+# point each entry's `host_path` at the host mountpoint. Read-only by
+# default; Jellyfin doesn't need to write to your media files.
+#
+# Example (in host_vars):
+#   jellyfin_extra_media_mounts:
+#     - { host_path: /srv/jellyfin-video, container_path: /media/video-nas, ro: true }
+jellyfin_extra_media_mounts: []
+
+# NFS shares to mount on the host before the container starts. Each
+# entry is mounted persistently via systemd (added to /etc/fstab).
+# Pair with `jellyfin_extra_media_mounts` so the in-container path
+# resolves to the NFS-backed host directory.
+#
+# Example (in host_vars):
+#   jellyfin_nas_mounts:
+#     - { src: "ds9:/volume1/video", path: /srv/jellyfin-video,
+#         opts: "ro,noatime,vers=4,_netdev" }
+jellyfin_nas_mounts: []
+
 # Backup manifest — consumed by the backup role and restore playbook.
 # The role's .volume files have no `VolumeName=`, so podman auto-prefixes
 # the actual volume names with `systemd-`. The backup script passes

--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -33,6 +33,33 @@
   ansible.builtin.set_fact:
     jellyfin_role_path: "{{ role_path }}"
 
+# NFS-backed media mounts on the host. Persistent via fstab so they
+# come up at boot before the rootless user systemd starts the
+# container. Read-only by default — see `jellyfin_nas_mounts` in
+# defaults for the var shape.
+- name: Ensure NFS mountpoints exist on host
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: "0755"
+    setype: container_file_t
+  loop: "{{ jellyfin_nas_mounts }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Mount NFS shares for Jellyfin
+  become: true
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: nfs
+    opts: "{{ item.opts | default('ro,noatime,vers=4,_netdev') }}"
+    state: mounted
+  loop: "{{ jellyfin_nas_mounts }}"
+  loop_control:
+    label: "{{ item.src }} -> {{ item.path }}"
+
 - name: Deploy jellyfin container using podman_quadlet
   ansible.builtin.include_role:
     name: luckynrslevin.podman_quadlet

--- a/roles/jellyfin/templates/quadlets/jellyfin.container.j2
+++ b/roles/jellyfin/templates/quadlets/jellyfin.container.j2
@@ -12,6 +12,10 @@ Network=host
 Volume=jellyfin-config.volume:/config
 Volume=jellyfin-cache.volume:/cache
 Volume=jellyfin-media.volume:/media
+{% for m in jellyfin_extra_media_mounts | default([]) %}
+Volume={{ m.host_path }}:{{ m.container_path }}{% if m.ro | default(true) %}:ro{% endif %}
+
+{% endfor %}
 
 Environment=TZ={{ jellyfin_time_zone }}
 


### PR DESCRIPTION
## Why
Video libraries are usually too large to fit alongside everything else on the home server's local disk. Allow Jellyfin to surface NAS-backed media via an NFS mount + bind mount, so the data stays on the NAS and Jellyfin just streams it over the LAN.

## What
Two new variables in the jellyfin role:
- `jellyfin_nas_mounts` — list of `{src, path, opts}` NFS shares mounted on the host via fstab.
- `jellyfin_extra_media_mounts` — list of `{host_path, container_path, ro}` extra Volume= lines for the Jellyfin container, layered on top of the existing `jellyfin-media` volume.

Library configuration in Jellyfin's web UI then points at `/media/<container_path>/<subfolder>` for each Movies/Shows/etc. library.

## Test plan
- [x] Deploy on host with the two vars set; verify `mount | grep jellyfin-video` shows the NFS mount, and `sudo -iu jellyfin podman exec jellyfin ls /media/video-nas` returns the NAS contents.
- [ ] In Jellyfin: add libraries pointing at `/media/video-nas/<folder>`, scan, verify metadata fetch.