### PR TITLE
pihole: add OUTPUT-chain DNS redirect so host can self-resolve *.eddie.lan

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -80,6 +80,46 @@ No third-party resolver sees your full query stream. Authoritative
 servers each see only their piece (root sees TLD lookup, `.com` sees
 domain name, etc.).
 
+## Local resolution on the Pi-hole host itself
+
+The host runs Pi-hole rootless on `:1053`, with `systemd-resolved`
+holding `:53` for its stub listener. Inbound DNS from the LAN works
+via a firewalld port-forward (`53 → 1053`) on the **PREROUTING** chain.
+
+NetworkManager additionally hands `systemd-resolved` a per-link DNS
+from DHCP — typically the host's own LAN IP. Resolved sends queries
+matching the link's DNS-Domain (e.g. `*.lan`) to that link DNS first.
+But that destination is the host's own LAN IP on port 53, where
+nothing listens locally. The PREROUTING redirect doesn't fire for
+locally-generated traffic, so the host (and any host-network
+container) gets `Connection refused` when resolving `*.<caddy_domain>`.
+
+The role works around this with a second firewalld direct rule on the
+**OUTPUT** chain that mirrors the PREROUTING redirect, restricted to
+traffic destined to the host's own LAN IP. This way:
+
+- Inbound LAN DNS → PREROUTING REDIRECT → Pi-hole :1053 (existing)
+- Local outbound DNS to own IP:53 → OUTPUT REDIRECT → Pi-hole :1053 (new)
+- Unbound's recursive queries to public root servers (destination is
+  not the host's own IP) → no redirect, pass through normally.
+
+Verify the rules are present:
+
+```
+sudo firewall-cmd --direct --get-all-rules | grep dport.53
+```
+
+Expected: two `OUTPUT` lines (tcp + udp) and the existing PREROUTING
+forwards. To remove (e.g. if Pi-hole is moved off-host):
+
+```
+sudo firewall-cmd --permanent --direct --remove-rule ipv4 nat OUTPUT 0 \
+  -d <host-lan-ip> -p tcp --dport 53 -j REDIRECT --to-ports 1053
+sudo firewall-cmd --permanent --direct --remove-rule ipv4 nat OUTPUT 0 \
+  -d <host-lan-ip> -p udp --dport 53 -j REDIRECT --to-ports 1053
+sudo firewall-cmd --reload
+```
+
 ### Verifying Unbound works
 
 Use the [Mullvad DNS leak test](https://mullvad.net/en/check) or

--- a/roles/pihole/handlers/main.yml
+++ b/roles/pihole/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload firewalld
+  become: true
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: false

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -151,6 +151,15 @@
   when: item.rc != 0
   notify: Reload firewalld
 
+# Force the firewalld reload immediately, before any downstream task
+# in this playbook can fail and skip the handler-flush phase. Without
+# this, an unrelated failure further down (e.g. another role's NFS
+# mount) would leave the rules sitting in `--permanent` but never
+# loaded into runtime — the host would still see "Connection refused"
+# for *.<caddy_domain>.
+- name: Flush handlers so the firewalld reload happens now
+  ansible.builtin.meta: flush_handlers
+
 # Start and enable Unbound (it's a separate systemd unit, not part of
 # the pihole app unit, so the Galaxy role's restart doesn't cover it).
 - name: Enable and start Unbound # noqa: no-changed-when

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -71,6 +71,86 @@
         proto: udp
         toport: 1053
 
+# ----------------------------------------------------------------------
+# OUTPUT-chain DNS redirect — match the PREROUTING port-53→1053 forward
+# above, but for locally-generated traffic.
+#
+# `ansible.posix.firewalld`'s `port_forward` only writes a PREROUTING
+# rule, which catches LAN-incoming DNS but not eddie's own outbound
+# queries. NetworkManager hands systemd-resolved a per-link DNS from
+# DHCP — typically the host's own LAN IP — and resolved sends
+# `*.<domain>` queries (matched on the link's DNS Domain) to that
+# link DNS first. The destination is the host's LAN IP on port 53,
+# where nothing listens locally (Pi-hole is on :1053, systemd-resolved
+# on 127.0.0.53:53). Result: `Connection refused` whenever the host or
+# any host-network container tries to resolve `*.<caddy_domain>`.
+#
+# We restrict by destination IP so we don't redirect Unbound's
+# recursive queries to public root servers — those go to external
+# IPs, not the host itself.
+# ----------------------------------------------------------------------
+
+- name: Detect host's primary LAN IP for OUTPUT redirect rule
+  ansible.builtin.set_fact:
+    pihole_host_lan_ip: "{{ ansible_default_ipv4.address }}"
+
+- name: Check if OUTPUT-chain DNS redirect rules already exist
+  become: true
+  ansible.builtin.command:
+    argv:
+      - firewall-cmd
+      - --permanent
+      - --direct
+      - --query-rule
+      - ipv4
+      - nat
+      - OUTPUT
+      - "0"
+      - -d
+      - "{{ pihole_host_lan_ip }}"
+      - -p
+      - "{{ item }}"
+      - --dport
+      - "53"
+      - -j
+      - REDIRECT
+      - --to-ports
+      - "1053"
+  register: pihole_output_redirect_check
+  changed_when: false
+  failed_when: false
+  loop:
+    - tcp
+    - udp
+
+- name: Add OUTPUT-chain DNS redirect rules (tcp + udp)
+  become: true
+  ansible.builtin.command:
+    argv:
+      - firewall-cmd
+      - --permanent
+      - --direct
+      - --add-rule
+      - ipv4
+      - nat
+      - OUTPUT
+      - "0"
+      - -d
+      - "{{ pihole_host_lan_ip }}"
+      - -p
+      - "{{ item.item }}"
+      - --dport
+      - "53"
+      - -j
+      - REDIRECT
+      - --to-ports
+      - "1053"
+  loop: "{{ pihole_output_redirect_check.results }}"
+  loop_control:
+    label: "{{ item.item }}/53 -> 1053 (-d {{ pihole_host_lan_ip }})"
+  when: item.rc != 0
+  notify: Reload firewalld
+
 # Start and enable Unbound (it's a separate systemd unit, not part of
 # the pihole app unit, so the Galaxy role's restart doesn't cover it).
 - name: Enable and start Unbound # noqa: no-changed-when


### PR DESCRIPTION
## Summary
- `roles/pihole/tasks/main.yml`: idempotent firewalld direct rule on OUTPUT for tcp+udp port 53 → 1053, restricted to traffic destined to the host's own LAN IP
- `roles/pihole/handlers/main.yml`: new `Reload firewalld` handler
- `roles/pihole/README.md`: new "Local resolution on the Pi-hole host itself" section explaining the rationale and rollback steps

Closes #75. Will let me drop the `--add-host=` workaround from the entephoto-export role (#74) once this lands and is verified.

## Why
`ansible.posix.firewalld port_forward` only writes a PREROUTING rule. It catches LAN-incoming DNS but not locally-generated traffic. eddie's DHCP-supplied link DNS is its own LAN IP on port 53, where nothing listens locally — so the host can't self-resolve `*.eddie.lan`. Workaround in #74 was `--add-host=`; this PR removes the need entirely.

The OUTPUT redirect is restricted by `-d <host-lan-ip>` so Unbound's recursive queries to public root servers (different destination IP) are not affected.

## Test plan
- [ ] `ansible-playbook playbooks/site.yml --limit homeserver --tags pihole` is idempotent (no changes on second run)
- [ ] `firewall-cmd --direct --get-all-rules | grep dport.53` shows two OUTPUT lines after deploy
- [ ] `resolvectl query photos-api.eddie.lan` on eddie returns the A record (was failing before)
- [ ] `resolvectl query github.com` on eddie still works (Unbound recursion not redirected)
- [ ] iPhone / homer DNS unchanged (PREROUTING rule untouched)
- [ ] Survives `firewall-cmd --reload` and reboot (`--permanent`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)