### PR TITLE
scripts: add bootstrap-host.sh for fresh AlmaLinux 9 hosts

### DIFF
--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -86,7 +86,7 @@ ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
 |          |   bootstrap-host.sh   +------------------+
 |          |  ───────────────────► | managed host #2  |
 +----------+                       +------------------+
-     ↑                                      │
+     │                                      │
      └─────── ansible playbooks ────────────┘
             (ssh -p <port> ansible@host)
 ```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -15,7 +15,7 @@ roles. Idempotent — safe to re-run.
 ## Quick start
 
 ```bash
-bash scripts/bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
+bash scripts/bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)" -p 2222
 ```
 
 The script SSHs from your laptop to `root@1.2.3.4:22` (password or key

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -78,8 +78,9 @@ ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
 ```
 +----------+   bootstrap-host.sh   +------------------+
 |  laptop  |  ───────────────────► | managed host #1  |
-|          |   bootstrap-host.sh   | (ansible user,   |
-|          |  ───────────────────► |  sshd hardened)  |
+|          |                       +------------------+
+|          |   bootstrap-host.sh   +------------------+
+|          |  ───────────────────► | managed host #2  |
 +----------+                       +------------------+
      ↑                                      │
      └─────── ansible playbooks ────────────┘

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -2,71 +2,80 @@
 
 `scripts/bootstrap-host.sh` prepares a freshly-installed AlmaLinux 9
 (or RHEL 9 / Rocky 9) machine to be managed by this project's Ansible
-playbooks. It's the symmetric counterpart to `setup.sh` at the repo
-root:
+playbooks.
+
+The script is a **remote driver**: you run it on your laptop (or any
+Ansible-control machine), it SSHs to the new host as root, runs the
+hardening payload, prompts you to update any external firewall, then
+reconnects via the new port and user to verify everything works.
+
+Symmetric layout with the rest of the project:
 
 | Script | Run on | What it does |
 |---|---|---|
 | `setup.sh` | The **control machine** | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
-| `scripts/bootstrap-host.sh` | A **fresh managed host** | Creates the `myuser` user, installs your SSH key, hardens sshd, installs Python (for Ansible) and Podman. |
+| `scripts/bootstrap-host.sh` | The **control machine** | SSHs to a fresh managed host as root and prepares it for Ansible. |
 
-The script is idempotent — safe to re-run.
+Idempotent — safe to re-run.
 
 ---
 
 ## Prerequisites
 
-- A freshly installed AlmaLinux 9, RHEL 9, or Rocky 9 host with network
-  reachability and root login (typically via the provider's web VNC
-  console for cloud VMs, or via the physical console for self-hosted
-  hardware).
-- Your laptop's SSH **public** key, accessible somehow. Usual options:
-  - GitHub `.keys` endpoint (paste your public key into Settings →
-    SSH and GPG keys, then `curl https://github.com/<user>.keys`).
-  - A public gist (`gh gist create ~/.ssh/id_ed25519.pub --public`)
-    optionally shortened via `is.gd`.
-  - The provider's "send text" feature if VNC clipboard works.
+**On the new host** (fresh install):
 
-> **Why this matters**: the script disables password authentication
-> on sshd as a hardening step. If your key isn't in place when sshd
-> restarts, you can be locked out. The script always installs the key
-> *before* it disables passwords, but it can only do that if you
-> actually pass it the key.
+- Network reachability with sshd listening on port 22.
+- Root login enabled with either a password or an SSH key you control.
+  Most cloud providers (Hetzner, Netcup, OVH, Contabo, AWS, GCP, …)
+  give you one of these by default.
+
+**On your laptop**:
+
+- `bash`, `ssh`. That's it.
+- Your SSH **public** key file at hand (`~/.ssh/id_ed25519.pub`).
+- The matching private key loaded in your ssh-agent (or available at a
+  known path) so the verification step at the end can connect.
 
 ---
 
-## Quick start (single command)
-
-On the new host, as root:
+## Quick start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/scripts/bootstrap-host.sh \
-  | sudo bash -s -- -k "$(curl -fsSL https://github.com/<your-gh-user>.keys | head -1)" \
-                    -n new-server
+bash scripts/bootstrap-host.sh \
+  -H 1.2.3.4 \
+  -k "$(cat ~/.ssh/id_ed25519.pub)" \
+  -n new-server
 ```
 
-`bash -s --` reads the script body from stdin and forwards everything
-after `--` as positional arguments to that script.
+That's the whole interaction:
 
-If you prefer to inspect before running:
-
-```bash
-curl -fsSL -o /tmp/bootstrap.sh https://raw.githubusercontent.com/luckynrslevin/home-server/main/scripts/bootstrap-host.sh
-less /tmp/bootstrap.sh        # optional: read what's about to run
-sudo bash /tmp/bootstrap.sh -k "ssh-ed25519 AAAA... user@laptop"
-```
+1. The script prints what it's about to do, then SSHs to root@1.2.3.4
+   on port 22. If you don't have key auth as root, ssh prompts you for
+   the password (one time).
+2. Hardening runs remotely; the new sshd port (default 2222) is added
+   to the host's local firewalld and SELinux. **Port 22 stays open**
+   as a safety net.
+3. The script pauses with a prompt: "Update any external firewall now
+   (cloud security group, edge router, …) — open the new port,
+   close 22 — then press Enter."
+4. You press Enter. The script SSHs back in via the new port as the
+   new user and runs `hostnamectl --static` to confirm.
+5. If verification works, the script offers to also close port 22 in
+   the host's **local** firewalld via the new SSH connection. Press
+   `y` to do it now, or `n` and run that command later.
 
 ---
 
 ## Options
 
 ```
-bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
-| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The script installs this in `~<user>/.ssh/authorized_keys` **before** disabling password auth. |
+| `-H <host>` | (required) | Target hostname or IP. The script connects as `root@<host>:22`. |
+| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The key is installed in `~<user>/.ssh/authorized_keys` **before** sshd is hardened, so the verification step can authenticate. |
 | `-u <user>` | `myuser` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
 | `-p <port>` | `2222` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
 | `-n <hostname>` | (unchanged) | Hostname to set via `hostnamectl`. RFC 1123 charset. Omit to leave the current hostname untouched. |
@@ -77,7 +86,10 @@ layout, edit `NEW_KEYMAP` at the top of the script.
 
 ---
 
-## What it does (in order)
+## What runs on the target (in order)
+
+The remote payload performs these nine steps as root, all in a single
+SSH session, all idempotent:
 
 | # | Step |
 |---|---|
@@ -87,23 +99,35 @@ layout, edit `NEW_KEYMAP` at the top of the script.
 | 4 | Creates the user (default `myuser`) with a home directory and bash login shell. |
 | 5 | Drops `/etc/sudoers.d/90-<user>` granting passwordless sudo. Validated with `visudo -cf` before being made effective. |
 | 6 | Creates `~<user>/.ssh/`, installs the public key into `authorized_keys` (idempotent — appended only if not already present), and runs `restorecon -R` on the directory to ensure SELinux labels are correct. |
-| 7 | Opens the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and reloads. **Port 22 stays open** until you manually close it after verifying the new port works. |
+| 7 | Opens the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and reloads. Port 22 stays open until phase 4. |
 | 8 | Adds the new SSH port to SELinux's `ssh_port_t` set via `semanage`. Skipped if already labeled. |
-| 9 | Writes `/etc/ssh/sshd_config.d/99-bootstrap.conf` with `Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`. Validates with `sshd -t` before restarting `sshd`. Runs `restorecon` on the file to ensure correct SELinux labels. |
+| 9 | Writes `/etc/ssh/sshd_config.d/99-bootstrap.conf` with `Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`. Validates with `sshd -t` before restarting `sshd`. Runs `restorecon` on the file. |
 
-The script prints `[N/9]` headers for each step so a partial failure
-is easy to localize.
+Each step prints a `[N/9]` header so a partial failure is easy to
+localize.
+
+---
+
+## Phases as the script itself sees them
+
+| Phase | Where | What happens |
+|---|---|---|
+| 1 | `ssh root@host:22` | Run the nine remote-payload steps above. sshd is restarted onto the new port at the end. The active SSH session keeps running until the script ends because Linux preserves established connections across a daemon restart. |
+| 2 | Local pause | Print a banner asking the user to update any external firewall (cloud security group, etc.). User presses Enter. |
+| 3 | `ssh -p <new-port> <user>@host` | Verify connectivity with the new credentials. `hostnamectl --static` is run to confirm the host's identity. |
+| 4 | `ssh -p <new-port> <user>@host` (optional) | If the user answers `y` to a final prompt, removes the `ssh` service from local firewalld so port 22 is no longer reachable. |
 
 ---
 
 ## SELinux notes
 
-This script keeps SELinux **Enforcing** (the AlmaLinux/RHEL default) and
+The script keeps SELinux **Enforcing** (the AlmaLinux/RHEL default) and
 makes the necessary policy adjustments:
 
-- A pre-flight check reads `getenforce` and prints a warning (but does
-  not abort) if SELinux is not currently Enforcing. Re-enable with
-  `setenforce 1` and edit `/etc/selinux/config`.
+- A pre-flight check inside the remote payload reads `getenforce` and
+  prints a warning (but does not abort) if SELinux is not currently
+  Enforcing. Re-enable with `setenforce 1` and edit
+  `/etc/selinux/config`.
 - `semanage port -a -t ssh_port_t -p tcp <port>` allows sshd to bind
   the new port. Without this, `systemctl restart sshd` would fail
   even though the firewall rule and config look fine.
@@ -114,110 +138,76 @@ makes the necessary policy adjustments:
   files are created via shell redirection rather than by the
   expected daemon.
 
-If something does fail with a permission-denied error after a clean
-run, check `ausearch -m avc -ts recent` for AVC denials.
-
----
-
-## After it finishes
-
-The script ends with a banner that recaps the verification and
-lockdown steps:
-
-### 1. Verify the new SSH port works
-
-From your laptop (or any other machine that holds the matching
-private key):
-
-```bash
-ssh -p <new-port> <user>@<host>
-```
-
-Test that key auth works and that root login + password auth are both
-refused:
-
-```bash
-ssh -p <new-port> root@<host>            # → refused
-ssh -p <new-port> -o PreferredAuthentications=password <user>@<host>   # → refused
-```
-
-### 2. Close port 22 in the firewall
-
-Once the new port is verified working, on the host:
-
-```bash
-sudo firewall-cmd --permanent --remove-service=ssh
-sudo firewall-cmd --reload
-```
-
-Done. The host is now reachable only via the new port.
-
-### 3. (If applicable) Add a host alias on your laptop
-
-Optional convenience. In `~/.ssh/config`:
-
-```
-Host new-server
-  HostName <ip>
-  User myuser
-  Port 2222
-  IdentityFile ~/.ssh/id_ed25519
-```
-
-Then `ssh new-server` works directly.
-
-### 4. Add the host to your inventory
-
-Edit `inventory/hosts.yml` (in your private inventory if you use the
-two-repo split) and add the new host alongside the existing
-`homeserver` / `homeserver-test` entries. Then deploy services:
-
-```bash
-ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit <new-host>
-```
+If something fails with a permission-denied error after a clean run,
+on the target check `ausearch -m avc -ts recent` for AVC denials.
 
 ---
 
 ## Failure recovery
 
 The script uses `set -euo pipefail`, so it stops at the first error.
-If it fails partway through:
 
 | Failure mode | What to check |
 |---|---|
-| dnf install errors | Network reachability, EPEL availability for your version. |
+| `ssh root@<host>` rejects connection | Is the host actually up? Provider firewall blocking your IP from port 22? Wrong root password / key? |
+| dnf install errors | Network reachability **from the target**, EPEL availability for the target's version. |
 | `visudo -cf` fails | Should never happen with the generated content; if it does, inspect `/etc/sudoers.d/90-<user>` for damage. |
-| `sshd -t` fails | Look at the printed message; the drop-in file in `/etc/ssh/sshd_config.d/99-bootstrap.conf` is the only file the script touched. |
-| `systemctl restart sshd` fails after `sshd -t` succeeded | Almost always SELinux — `journalctl -u sshd -n 50` and `ausearch -m avc -ts recent`. |
-| `semanage port -a` says port already labeled | Idempotency — already handled, the script continues. |
+| `sshd -t` fails | Look at the printed message; the only file the script touched is `/etc/ssh/sshd_config.d/99-bootstrap.conf`. |
+| `systemctl restart sshd` fails after `sshd -t` succeeded | Almost always SELinux — `journalctl -u sshd -n 50` and `ausearch -m avc -ts recent` on the target. |
+| Phase 3 verification fails | External firewall not yet updated, ssh-agent missing the matching private key, or DNS/IP propagation delay. The banner walks through each. Port 22 on the target is still open at this point — you can ssh back in as root and remove `/etc/ssh/sshd_config.d/99-bootstrap.conf` to undo. |
 
-The fact that the script keeps **port 22 open** until you manually
-close it is your safety net: even a bug that makes the new port
-unreachable still leaves you able to SSH in via the original port.
-Fix from there.
+The script keeps **port 22 open in local firewalld** until phase 4 is
+explicitly accepted. That's your safety net: even if the new port
+configuration breaks somehow, you can SSH in via the original port,
+inspect, and fix.
 
 ---
 
 ## When to use this vs setup.sh
 
-- Use **`setup.sh`** when you want to turn a Fedora Server into the
-  Ansible *control machine* (the one that runs `ansible-playbook`).
-- Use **`scripts/bootstrap-host.sh`** when you want to add a new
-  *managed host* that the control machine will then reach over SSH.
+- Use **`setup.sh`** to turn a Fedora Server into the Ansible *control
+  machine* (the one that runs `ansible-playbook`).
+- Use **`scripts/bootstrap-host.sh`** to add a new *managed host* the
+  control machine will then reach over SSH.
 
 Some servers will be both — your control machine is also the host
 running services. That's fine; run `setup.sh` and skip the bootstrap
 script.
 
-A typical multi-host topology:
+A typical multi-host topology after running both:
 
 ```
-+--------------+        SSH         +-------------------+
-| control host |  ───────────────►  | managed host #1   |
-| (setup.sh)   |        SSH         | (bootstrap-host)  |
-|              |  ───────────────►  +-------------------+
-|              |        SSH         +-------------------+
-|              |  ───────────────►  | managed host #2   |
-+--------------+                    | (bootstrap-host)  |
-                                    +-------------------+
++--------------+    bootstrap-host.sh    +-------------------+
+| control host |  ─────────────────────► | managed host #1   |
+| (setup.sh)   |    bootstrap-host.sh    | (sshd hardened    |
+|              |  ─────────────────────► | by remote driver) |
+|              |                         +-------------------+
+|              |    bootstrap-host.sh    +-------------------+
+|              |  ─────────────────────► | managed host #2   |
++--------------+                         | (sshd hardened)   |
+                                         +-------------------+
+        ↑                                         │
+        └─────── ansible playbooks ───────────────┘
+              (ssh -p <new-port> <user>@host)
+```
+
+---
+
+## After it finishes
+
+The script ends with a banner that reminds you to add a `~/.ssh/config`
+entry on your laptop and add the new host to your Ansible inventory:
+
+```
+Host new-server
+  HostName 1.2.3.4
+  User myuser
+  Port 2222
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+Then add to `inventory/hosts.yml` and deploy services:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
 ```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -68,7 +68,7 @@ bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
 |---|---|---|
 | `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The script installs this in `~<user>/.ssh/authorized_keys` **before** disabling password auth. |
 | `-u <user>` | `ds` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
-| `-p <port>` | `2343` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
+| `-p <port>` | `2222` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
 | `-n <hostname>` | (unchanged) | Hostname to set via `hostnamectl`. RFC 1123 charset. Omit to leave the current hostname untouched. |
 | `-h` | — | Show help and exit. |
 
@@ -160,7 +160,7 @@ Optional convenience. In `~/.ssh/config`:
 Host new-server
   HostName <ip>
   User ds
-  Port 2343
+  Port 2222
   IdentityFile ~/.ssh/id_ed25519
 ```
 

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -1,20 +1,26 @@
-# Bootstrap a fresh host as an Ansible target
+# Open an Ansible path to a fresh host
 
-`scripts/bootstrap-host.sh` prepares a freshly-installed AlmaLinux 9
-(or RHEL 9 / Rocky 9) machine to be managed by this project's Ansible
-playbooks.
+`scripts/bootstrap-host.sh` does the bare minimum needed for Ansible to
+take over on a freshly-installed AlmaLinux 9 / RHEL 9 / Rocky 9 host:
 
-The script is a **remote driver**: you run it on your laptop (or any
-Ansible-control machine), it SSHs to the new host as root, runs the
-hardening payload, prompts you to update any external firewall, then
-reconnects via the new port and user to verify everything works.
+- Creates an `ansible` user with passwordless sudo
+- Installs your SSH public key for that user
+- Hardens sshd onto a non-default port, disables root login + password auth
+- Opens the new port in firewalld and SELinux
 
-Symmetric layout with the rest of the project:
+That's it. Everything else (packages, hostname, container runtime,
+services, monitoring) belongs in Ansible roles, where it stays
+idempotent and reviewable. The bootstrap is intentionally a thin wedge.
+
+The script is a **remote driver**: you run it on your laptop / control
+machine, it SSHs to the new host as root, runs the hardening, prompts
+you to update any external firewall, then verifies via the new
+connection.
 
 | Script | Run on | What it does |
 |---|---|---|
-| `setup.sh` | The **control machine** | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
-| `scripts/bootstrap-host.sh` | The **control machine** | SSHs to a fresh managed host as root and prepares it for Ansible. |
+| `setup.sh` | Control machine | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
+| `scripts/bootstrap-host.sh` | Control machine | SSHs to a fresh managed host as root and prepares it for Ansible. |
 
 Idempotent — safe to re-run.
 
@@ -24,122 +30,92 @@ Idempotent — safe to re-run.
 
 **On the new host** (fresh install):
 
-- Network reachability with sshd listening on port 22.
-- Root login enabled with either a password or an SSH key you control.
-  Most cloud providers (Hetzner, Netcup, OVH, Contabo, AWS, GCP, …)
-  give you one of these by default.
+- Network reachability with sshd listening on port 22
+- Root login enabled with either a password or an SSH key you control
+- `python3` (default on AlmaLinux 9; the script installs it if missing)
 
 **On your laptop**:
 
-- `bash`, `ssh`. That's it.
-- Your SSH **public** key file at hand (`~/.ssh/id_ed25519.pub`).
+- `bash`, `ssh`
+- Your SSH **public** key file at hand (`~/.ssh/id_ed25519.pub`)
 - The matching private key loaded in your ssh-agent (or available at a
-  known path) so the verification step at the end can connect.
+  known path) so the verification step can authenticate
 
 ---
 
 ## Quick start
 
 ```bash
-bash scripts/bootstrap-host.sh \
-  -H 1.2.3.4 \
-  -k "$(cat ~/.ssh/id_ed25519.pub)" \
-  -n new-server
+bash scripts/bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
 ```
 
-That's the whole interaction:
+The whole interaction:
 
-1. The script prints what it's about to do, then SSHs to root@1.2.3.4
-   on port 22. If you don't have key auth as root, ssh prompts you for
-   the password (one time).
+1. The script SSHs to root@1.2.3.4 on port 22. If you don't have key
+   auth as root, ssh prompts you for the password (one time).
 2. Hardening runs remotely; the new sshd port (default 2222) is added
    to the host's local firewalld and SELinux. **Port 22 stays open**
    as a safety net.
 3. The script pauses with a prompt: "Update any external firewall now
    (cloud security group, edge router, …) — open the new port,
    close 22 — then press Enter."
-4. You press Enter. The script SSHs back in via the new port as the
-   new user and runs `hostnamectl --static` to confirm.
+4. You press Enter. The script SSHs back as `ansible` on the new port
+   and runs `whoami` + `hostnamectl --static` to confirm.
 5. If verification works, the script offers to also close port 22 in
-   the host's **local** firewalld via the new SSH connection. Press
-   `y` to do it now, or `n` and run that command later.
+   the host's **local** firewalld via the new SSH connection.
 
 ---
 
 ## Options
 
 ```
-bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
 | `-H <host>` | (required) | Target hostname or IP. The script connects as `root@<host>:22`. |
-| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The key is installed in `~<user>/.ssh/authorized_keys` **before** sshd is hardened, so the verification step can authenticate. |
-| `-u <user>` | `myuser` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
+| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. Installed in `~<user>/.ssh/authorized_keys` **before** sshd is hardened, so the verification step can authenticate. |
+| `-u <user>` | `ansible` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
 | `-p <port>` | `2222` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
-| `-n <hostname>` | (unchanged) | Hostname to set via `hostnamectl`. RFC 1123 charset. Omit to leave the current hostname untouched. |
 | `-h` | — | Show help and exit. |
 
-The console keymap is set to `de` by default. If you want a different
-layout, edit `NEW_KEYMAP` at the top of the script.
+Things this script does **not** do (Ansible's job):
+
+- Install `bpytop`, `podman`, or any other application
+- Run `dnf -y update`
+- Set hostname (use Ansible host_vars + a small role)
+- Set console keymap
 
 ---
 
 ## What runs on the target (in order)
 
-The remote payload performs these nine steps as root, all in a single
+The remote payload performs these six steps as root, all in a single
 SSH session, all idempotent:
 
 | # | Step |
 |---|---|
-| 1 | Enables EPEL, runs `dnf -y update`, installs prerequisites: `sudo`, `openssh-server`, `python3`, `python3-pip`, `policycoreutils-python-utils`, `firewalld`, `podman`, `bpytop`. Enables and starts `firewalld`. |
-| 2 | Sets the hostname (only if `-n` was passed). |
-| 3 | Sets the console keymap to `de` via `localectl`. |
-| 4 | Creates the user (default `myuser`) with a home directory and bash login shell. |
-| 5 | Drops `/etc/sudoers.d/90-<user>` granting passwordless sudo. Validated with `visudo -cf` before being made effective. |
-| 6 | Creates `~<user>/.ssh/`, installs the public key into `authorized_keys` (idempotent — appended only if not already present), and runs `restorecon -R` on the directory to ensure SELinux labels are correct. |
-| 7 | Opens the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and reloads. Port 22 stays open until phase 4. |
-| 8 | Adds the new SSH port to SELinux's `ssh_port_t` set via `semanage`. Skipped if already labeled. |
-| 9 | Writes `/etc/ssh/sshd_config.d/99-bootstrap.conf` with `Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`. Validates with `sshd -t` before restarting `sshd`. Runs `restorecon` on the file. |
+| 1 | Ensure prerequisites: `python3`, `firewalld`, and `policycoreutils-python-utils` (for `semanage`). Conditional install — only the missing ones get fetched. |
+| 2 | Enable + start `firewalld`. |
+| 3 | Create the user (default `ansible`) with home + bash + passwordless sudo via `/etc/sudoers.d/90-<user>` (validated with `visudo -cf`). |
+| 4 | Create `~<user>/.ssh/`, append the public key to `authorized_keys` (idempotent), `restorecon -R`. |
+| 5 | Open the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and label it `ssh_port_t` via `semanage`. Port 22 stays open until phase 4. |
+| 6 | Write `/etc/ssh/sshd_config.d/99-bootstrap.conf` (`Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`), `restorecon`, validate with `sshd -t`, restart sshd. |
 
-Each step prints a `[N/9]` header so a partial failure is easy to
+Each step prints a `[N/6]` header so a partial failure is easy to
 localize.
 
 ---
 
 ## Phases as the script itself sees them
 
-| Phase | Where | What happens |
+| Phase | Where | What |
 |---|---|---|
-| 1 | `ssh root@host:22` | Run the nine remote-payload steps above. sshd is restarted onto the new port at the end. The active SSH session keeps running until the script ends because Linux preserves established connections across a daemon restart. |
-| 2 | Local pause | Print a banner asking the user to update any external firewall (cloud security group, etc.). User presses Enter. |
-| 3 | `ssh -p <new-port> <user>@host` | Verify connectivity with the new credentials. `hostnamectl --static` is run to confirm the host's identity. |
-| 4 | `ssh -p <new-port> <user>@host` (optional) | If the user answers `y` to a final prompt, removes the `ssh` service from local firewalld so port 22 is no longer reachable. |
-
----
-
-## SELinux notes
-
-The script keeps SELinux **Enforcing** (the AlmaLinux/RHEL default) and
-makes the necessary policy adjustments:
-
-- A pre-flight check inside the remote payload reads `getenforce` and
-  prints a warning (but does not abort) if SELinux is not currently
-  Enforcing. Re-enable with `setenforce 1` and edit
-  `/etc/selinux/config`.
-- `semanage port -a -t ssh_port_t -p tcp <port>` allows sshd to bind
-  the new port. Without this, `systemctl restart sshd` would fail
-  even though the firewall rule and config look fine.
-- `restorecon` is run on the files the script writes
-  (`authorized_keys` and the sshd drop-in) so they get the correct
-  policy-defined labels (`ssh_home_t` and `sshd_config_t`). Removes
-  the "sometimes mysterious AVC denial" failure mode common when
-  files are created via shell redirection rather than by the
-  expected daemon.
-
-If something fails with a permission-denied error after a clean run,
-on the target check `ausearch -m avc -ts recent` for AVC denials.
+| 1 | `ssh root@host:22` | Run the six remote-payload steps. sshd is restarted onto the new port at the end. The active SSH session keeps running because Linux preserves established connections across a daemon restart. |
+| 2 | Local pause | Print a banner asking to update any external firewall (cloud security group, etc.). User presses Enter. |
+| 3 | `ssh -p <new-port> <user>@host` | Verify connectivity with the new credentials. |
+| 4 | `ssh -p <new-port> <user>@host` (optional) | If accepted, removes the `ssh` service from the host's local firewalld. |
 
 ---
 
@@ -150,9 +126,9 @@ The script uses `set -euo pipefail`, so it stops at the first error.
 | Failure mode | What to check |
 |---|---|
 | `ssh root@<host>` rejects connection | Is the host actually up? Provider firewall blocking your IP from port 22? Wrong root password / key? |
-| dnf install errors | Network reachability **from the target**, EPEL availability for the target's version. |
+| dnf install fails | Network reachability **from the target**, AppStream availability for the target's version. |
 | `visudo -cf` fails | Should never happen with the generated content; if it does, inspect `/etc/sudoers.d/90-<user>` for damage. |
-| `sshd -t` fails | Look at the printed message; the only file the script touched is `/etc/ssh/sshd_config.d/99-bootstrap.conf`. |
+| `sshd -t` fails | The only file the script touched is `/etc/ssh/sshd_config.d/99-bootstrap.conf`. |
 | `systemctl restart sshd` fails after `sshd -t` succeeded | Almost always SELinux — `journalctl -u sshd -n 50` and `ausearch -m avc -ts recent` on the target. |
 | Phase 3 verification fails | External firewall not yet updated, ssh-agent missing the matching private key, or DNS/IP propagation delay. The banner walks through each. Port 22 on the target is still open at this point — you can ssh back in as root and remove `/etc/ssh/sshd_config.d/99-bootstrap.conf` to undo. |
 
@@ -160,6 +136,32 @@ The script keeps **port 22 open in local firewalld** until phase 4 is
 explicitly accepted. That's your safety net: even if the new port
 configuration breaks somehow, you can SSH in via the original port,
 inspect, and fix.
+
+---
+
+## After it finishes
+
+Add a `~/.ssh/config` entry on your laptop:
+
+```
+Host new-server
+  HostName 1.2.3.4
+  User ansible
+  Port 2222
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+Sanity-check Ansible can reach the host:
+
+```bash
+ansible -i inventory/hosts.yml new-server -m ping
+```
+
+Expect `pong`. Then deploy services as usual:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
+```
 
 ---
 
@@ -174,13 +176,11 @@ Some servers will be both — your control machine is also the host
 running services. That's fine; run `setup.sh` and skip the bootstrap
 script.
 
-A typical multi-host topology after running both:
-
 ```
 +--------------+    bootstrap-host.sh    +-------------------+
 | control host |  ─────────────────────► | managed host #1   |
 | (setup.sh)   |    bootstrap-host.sh    | (sshd hardened    |
-|              |  ─────────────────────► | by remote driver) |
+|              |  ─────────────────────► | + ansible user)   |
 |              |                         +-------------------+
 |              |    bootstrap-host.sh    +-------------------+
 |              |  ─────────────────────► | managed host #2   |
@@ -188,26 +188,5 @@ A typical multi-host topology after running both:
                                          +-------------------+
         ↑                                         │
         └─────── ansible playbooks ───────────────┘
-              (ssh -p <new-port> <user>@host)
-```
-
----
-
-## After it finishes
-
-The script ends with a banner that reminds you to add a `~/.ssh/config`
-entry on your laptop and add the new host to your Ansible inventory:
-
-```
-Host new-server
-  HostName 1.2.3.4
-  User myuser
-  Port 2222
-  IdentityFile ~/.ssh/id_ed25519
-```
-
-Then add to `inventory/hosts.yml` and deploy services:
-
-```bash
-ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
+              (ssh -p <new-port> ansible@host)
 ```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -17,11 +17,6 @@ machine, it SSHs to the new host as root, runs the hardening, prompts
 you to update any external firewall, then verifies via the new
 connection.
 
-| Script | Run on | What it does |
-|---|---|---|
-| `setup.sh` | Control machine | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
-| `scripts/bootstrap-host.sh` | Control machine | SSHs to a fresh managed host as root and prepares it for Ansible. |
-
 Idempotent — safe to re-run.
 
 ---
@@ -165,21 +160,12 @@ ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
 
 ---
 
-## When to use this vs setup.sh
-
-- Use **`setup.sh`** to turn a Fedora Server into the Ansible *control
-  machine* (the one that runs `ansible-playbook`).
-- Use **`scripts/bootstrap-host.sh`** to add a new *managed host* the
-  control machine will then reach over SSH.
-
-Some servers will be both — your control machine is also the host
-running services. That's fine; run `setup.sh` and skip the bootstrap
-script.
+## Topology
 
 ```
 +--------------+    bootstrap-host.sh    +-------------------+
 | control host |  ─────────────────────► | managed host #1   |
-| (setup.sh)   |    bootstrap-host.sh    | (sshd hardened    |
+|              |    bootstrap-host.sh    | (sshd hardened    |
 |              |  ─────────────────────► | + ansible user)   |
 |              |                         +-------------------+
 |              |    bootstrap-host.sh    +-------------------+

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -1,0 +1,223 @@
+# Bootstrap a fresh host as an Ansible target
+
+`scripts/bootstrap-host.sh` prepares a freshly-installed AlmaLinux 9
+(or RHEL 9 / Rocky 9) machine to be managed by this project's Ansible
+playbooks. It's the symmetric counterpart to `setup.sh` at the repo
+root:
+
+| Script | Run on | What it does |
+|---|---|---|
+| `setup.sh` | The **control machine** | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
+| `scripts/bootstrap-host.sh` | A **fresh managed host** | Creates the `ds` user, installs your SSH key, hardens sshd, installs Python (for Ansible) and Podman. |
+
+The script is idempotent — safe to re-run.
+
+---
+
+## Prerequisites
+
+- A freshly installed AlmaLinux 9, RHEL 9, or Rocky 9 host with network
+  reachability and root login (typically via the provider's web VNC
+  console for cloud VMs, or via the physical console for self-hosted
+  hardware).
+- Your laptop's SSH **public** key, accessible somehow. Usual options:
+  - GitHub `.keys` endpoint (paste your public key into Settings →
+    SSH and GPG keys, then `curl https://github.com/<user>.keys`).
+  - A public gist (`gh gist create ~/.ssh/id_ed25519.pub --public`)
+    optionally shortened via `is.gd`.
+  - The provider's "send text" feature if VNC clipboard works.
+
+> **Why this matters**: the script disables password authentication
+> on sshd as a hardening step. If your key isn't in place when sshd
+> restarts, you can be locked out. The script always installs the key
+> *before* it disables passwords, but it can only do that if you
+> actually pass it the key.
+
+---
+
+## Quick start (single command)
+
+On the new host, as root:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/scripts/bootstrap-host.sh \
+  | sudo bash -s -- -k "$(curl -fsSL https://github.com/<your-gh-user>.keys | head -1)" \
+                    -n new-server
+```
+
+`bash -s --` reads the script body from stdin and forwards everything
+after `--` as positional arguments to that script.
+
+If you prefer to inspect before running:
+
+```bash
+curl -fsSL -o /tmp/bootstrap.sh https://raw.githubusercontent.com/luckynrslevin/home-server/main/scripts/bootstrap-host.sh
+less /tmp/bootstrap.sh        # optional: read what's about to run
+sudo bash /tmp/bootstrap.sh -k "ssh-ed25519 AAAA... user@laptop"
+```
+
+---
+
+## Options
+
+```
+bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The script installs this in `~<user>/.ssh/authorized_keys` **before** disabling password auth. |
+| `-u <user>` | `ds` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
+| `-p <port>` | `2343` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
+| `-n <hostname>` | (unchanged) | Hostname to set via `hostnamectl`. RFC 1123 charset. Omit to leave the current hostname untouched. |
+| `-h` | — | Show help and exit. |
+
+The console keymap is set to `de` by default. If you want a different
+layout, edit `NEW_KEYMAP` at the top of the script.
+
+---
+
+## What it does (in order)
+
+| # | Step |
+|---|---|
+| 1 | Enables EPEL, runs `dnf -y update`, installs prerequisites: `sudo`, `openssh-server`, `python3`, `python3-pip`, `policycoreutils-python-utils`, `firewalld`, `podman`, `bpytop`. Enables and starts `firewalld`. |
+| 2 | Sets the hostname (only if `-n` was passed). |
+| 3 | Sets the console keymap to `de` via `localectl`. |
+| 4 | Creates the user (default `ds`) with a home directory and bash login shell. |
+| 5 | Drops `/etc/sudoers.d/90-<user>` granting passwordless sudo. Validated with `visudo -cf` before being made effective. |
+| 6 | Creates `~<user>/.ssh/`, installs the public key into `authorized_keys` (idempotent — appended only if not already present), and runs `restorecon -R` on the directory to ensure SELinux labels are correct. |
+| 7 | Opens the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and reloads. **Port 22 stays open** until you manually close it after verifying the new port works. |
+| 8 | Adds the new SSH port to SELinux's `ssh_port_t` set via `semanage`. Skipped if already labeled. |
+| 9 | Writes `/etc/ssh/sshd_config.d/99-bootstrap.conf` with `Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`. Validates with `sshd -t` before restarting `sshd`. Runs `restorecon` on the file to ensure correct SELinux labels. |
+
+The script prints `[N/9]` headers for each step so a partial failure
+is easy to localize.
+
+---
+
+## SELinux notes
+
+This script keeps SELinux **Enforcing** (the AlmaLinux/RHEL default) and
+makes the necessary policy adjustments:
+
+- A pre-flight check reads `getenforce` and prints a warning (but does
+  not abort) if SELinux is not currently Enforcing. Re-enable with
+  `setenforce 1` and edit `/etc/selinux/config`.
+- `semanage port -a -t ssh_port_t -p tcp <port>` allows sshd to bind
+  the new port. Without this, `systemctl restart sshd` would fail
+  even though the firewall rule and config look fine.
+- `restorecon` is run on the files the script writes
+  (`authorized_keys` and the sshd drop-in) so they get the correct
+  policy-defined labels (`ssh_home_t` and `sshd_config_t`). Removes
+  the "sometimes mysterious AVC denial" failure mode common when
+  files are created via shell redirection rather than by the
+  expected daemon.
+
+If something does fail with a permission-denied error after a clean
+run, check `ausearch -m avc -ts recent` for AVC denials.
+
+---
+
+## After it finishes
+
+The script ends with a banner that recaps the verification and
+lockdown steps:
+
+### 1. Verify the new SSH port works
+
+From your laptop (or any other machine that holds the matching
+private key):
+
+```bash
+ssh -p <new-port> <user>@<host>
+```
+
+Test that key auth works and that root login + password auth are both
+refused:
+
+```bash
+ssh -p <new-port> root@<host>            # → refused
+ssh -p <new-port> -o PreferredAuthentications=password <user>@<host>   # → refused
+```
+
+### 2. Close port 22 in the firewall
+
+Once the new port is verified working, on the host:
+
+```bash
+sudo firewall-cmd --permanent --remove-service=ssh
+sudo firewall-cmd --reload
+```
+
+Done. The host is now reachable only via the new port.
+
+### 3. (If applicable) Add a host alias on your laptop
+
+Optional convenience. In `~/.ssh/config`:
+
+```
+Host new-server
+  HostName <ip>
+  User ds
+  Port 2343
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+Then `ssh new-server` works directly.
+
+### 4. Add the host to your inventory
+
+Edit `inventory/hosts.yml` (in your private inventory if you use the
+two-repo split) and add the new host alongside the existing
+`homeserver` / `homeserver-test` entries. Then deploy services:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit <new-host>
+```
+
+---
+
+## Failure recovery
+
+The script uses `set -euo pipefail`, so it stops at the first error.
+If it fails partway through:
+
+| Failure mode | What to check |
+|---|---|
+| dnf install errors | Network reachability, EPEL availability for your version. |
+| `visudo -cf` fails | Should never happen with the generated content; if it does, inspect `/etc/sudoers.d/90-<user>` for damage. |
+| `sshd -t` fails | Look at the printed message; the drop-in file in `/etc/ssh/sshd_config.d/99-bootstrap.conf` is the only file the script touched. |
+| `systemctl restart sshd` fails after `sshd -t` succeeded | Almost always SELinux — `journalctl -u sshd -n 50` and `ausearch -m avc -ts recent`. |
+| `semanage port -a` says port already labeled | Idempotency — already handled, the script continues. |
+
+The fact that the script keeps **port 22 open** until you manually
+close it is your safety net: even a bug that makes the new port
+unreachable still leaves you able to SSH in via the original port.
+Fix from there.
+
+---
+
+## When to use this vs setup.sh
+
+- Use **`setup.sh`** when you want to turn a Fedora Server into the
+  Ansible *control machine* (the one that runs `ansible-playbook`).
+- Use **`scripts/bootstrap-host.sh`** when you want to add a new
+  *managed host* that the control machine will then reach over SSH.
+
+Some servers will be both — your control machine is also the host
+running services. That's fine; run `setup.sh` and skip the bootstrap
+script.
+
+A typical multi-host topology:
+
+```
++--------------+        SSH         +-------------------+
+| control host |  ───────────────►  | managed host #1   |
+| (setup.sh)   |        SSH         | (bootstrap-host)  |
+|              |  ───────────────►  +-------------------+
+|              |        SSH         +-------------------+
+|              |  ───────────────►  | managed host #2   |
++--------------+                    | (bootstrap-host)  |
+                                    +-------------------+
+```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -1,42 +1,16 @@
 # Open an Ansible path to a fresh host
 
-`scripts/bootstrap-host.sh` does the bare minimum needed for Ansible to
-take over on a freshly-installed AlmaLinux 9 / RHEL 9 / Rocky 9 host:
+`scripts/bootstrap-host.sh` runs from your **laptop** and prepares a
+freshly-installed AlmaLinux 9 / RHEL 9 / Rocky 9 host so Ansible can
+take over. It does only what's needed for that handoff:
 
-- Creates an `ansible` user with passwordless sudo
-- Installs your SSH public key for that user
-- Hardens sshd onto a non-default port, disables root login + password auth
-- Opens the new port in firewalld and SELinux
+- creates an `ansible` user with passwordless sudo
+- installs your SSH public key for that user
+- hardens sshd onto a non-default port (no root login, no password auth)
+- opens the new port in firewalld and SELinux
 
-That's it. Everything else (packages, hostname, container runtime,
-services, monitoring) belongs in Ansible roles, where it stays
-idempotent and reviewable. The bootstrap is intentionally a thin wedge.
-
-The script is a **remote driver**: you run it on your laptop / control
-machine, it SSHs to the new host as root, runs the hardening, prompts
-you to update any external firewall, then verifies via the new
-connection.
-
-Idempotent — safe to re-run.
-
----
-
-## Prerequisites
-
-**On the new host** (fresh install):
-
-- Network reachability with sshd listening on port 22
-- Root login enabled with either a password or an SSH key you control
-- `python3` (default on AlmaLinux 9; the script installs it if missing)
-
-**On your laptop**:
-
-- `bash`, `ssh`
-- Your SSH **public** key file at hand (`~/.ssh/id_ed25519.pub`)
-- The matching private key loaded in your ssh-agent (or available at a
-  known path) so the verification step can authenticate
-
----
+Everything else (packages, hostname, services) belongs in Ansible
+roles. Idempotent — safe to re-run.
 
 ## Quick start
 
@@ -44,22 +18,11 @@ Idempotent — safe to re-run.
 bash scripts/bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
 ```
 
-The whole interaction:
-
-1. The script SSHs to root@1.2.3.4 on port 22. If you don't have key
-   auth as root, ssh prompts you for the password (one time).
-2. Hardening runs remotely; the new sshd port (default 2222) is added
-   to the host's local firewalld and SELinux. **Port 22 stays open**
-   as a safety net.
-3. The script pauses with a prompt: "Update any external firewall now
-   (cloud security group, edge router, …) — open the new port,
-   close 22 — then press Enter."
-4. You press Enter. The script SSHs back as `ansible` on the new port
-   and runs `whoami` + `hostnamectl --static` to confirm.
-5. If verification works, the script offers to also close port 22 in
-   the host's **local** firewalld via the new SSH connection.
-
----
+The script SSHs from your laptop to `root@1.2.3.4:22` (password or key
+auth), runs the hardening, pauses for you to update any external
+firewall (cloud security group: open the new port, close 22), then
+SSHs back as `ansible` on the new port to verify. Optionally also
+closes port 22 in the host's local firewalld at the end.
 
 ## Options
 
@@ -69,74 +32,31 @@ bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>]
 
 | Flag | Default | Description |
 |---|---|---|
-| `-H <host>` | (required) | Target hostname or IP. The script connects as `root@<host>:22`. |
-| `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. Installed in `~<user>/.ssh/authorized_keys` **before** sshd is hardened, so the verification step can authenticate. |
-| `-u <user>` | `ansible` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
-| `-p <port>` | `2222` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
-| `-h` | — | Show help and exit. |
+| `-H <host>` | required | Target hostname or IP. |
+| `-k <pubkey>` | required | SSH public key (full string) for the new user. |
+| `-u <user>` | `ansible` | Username to create. |
+| `-p <port>` | `2222` | New SSH port. |
+| `-h` | — | Help. |
 
-Things this script does **not** do (Ansible's job):
+## What runs on the target
 
-- Install `bpytop`, `podman`, or any other application
-- Run `dnf -y update`
-- Set hostname (use Ansible host_vars + a small role)
-- Set console keymap
-
----
-
-## What runs on the target (in order)
-
-The remote payload performs these six steps as root, all in a single
-SSH session, all idempotent:
+Six idempotent steps inside one SSH session as root:
 
 | # | Step |
 |---|---|
-| 1 | Ensure prerequisites: `python3`, `firewalld`, and `policycoreutils-python-utils` (for `semanage`). Conditional install — only the missing ones get fetched. |
+| 1 | Ensure `python3`, `firewalld`, `policycoreutils-python-utils` are installed (only the missing ones). |
 | 2 | Enable + start `firewalld`. |
-| 3 | Create the user (default `ansible`) with home + bash + passwordless sudo via `/etc/sudoers.d/90-<user>` (validated with `visudo -cf`). |
-| 4 | Create `~<user>/.ssh/`, append the public key to `authorized_keys` (idempotent), `restorecon -R`. |
-| 5 | Open the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and label it `ssh_port_t` via `semanage`. Port 22 stays open until phase 4. |
-| 6 | Write `/etc/ssh/sshd_config.d/99-bootstrap.conf` (`Port`, `PermitRootLogin no`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`), `restorecon`, validate with `sshd -t`, restart sshd. |
+| 3 | Create the user with passwordless sudo via `/etc/sudoers.d/90-<user>`. |
+| 4 | Append the public key to `~<user>/.ssh/authorized_keys`, `restorecon -R`. |
+| 5 | Open the new port in firewalld and label it `ssh_port_t` via `semanage`. |
+| 6 | Write `/etc/ssh/sshd_config.d/99-bootstrap.conf` (Port + no root + no password), `sshd -t`, restart. |
 
-Each step prints a `[N/6]` header so a partial failure is easy to
-localize.
-
----
-
-## Phases as the script itself sees them
-
-| Phase | Where | What |
-|---|---|---|
-| 1 | `ssh root@host:22` | Run the six remote-payload steps. sshd is restarted onto the new port at the end. The active SSH session keeps running because Linux preserves established connections across a daemon restart. |
-| 2 | Local pause | Print a banner asking to update any external firewall (cloud security group, etc.). User presses Enter. |
-| 3 | `ssh -p <new-port> <user>@host` | Verify connectivity with the new credentials. |
-| 4 | `ssh -p <new-port> <user>@host` (optional) | If accepted, removes the `ssh` service from the host's local firewalld. |
-
----
-
-## Failure recovery
-
-The script uses `set -euo pipefail`, so it stops at the first error.
-
-| Failure mode | What to check |
-|---|---|
-| `ssh root@<host>` rejects connection | Is the host actually up? Provider firewall blocking your IP from port 22? Wrong root password / key? |
-| dnf install fails | Network reachability **from the target**, AppStream availability for the target's version. |
-| `visudo -cf` fails | Should never happen with the generated content; if it does, inspect `/etc/sudoers.d/90-<user>` for damage. |
-| `sshd -t` fails | The only file the script touched is `/etc/ssh/sshd_config.d/99-bootstrap.conf`. |
-| `systemctl restart sshd` fails after `sshd -t` succeeded | Almost always SELinux — `journalctl -u sshd -n 50` and `ausearch -m avc -ts recent` on the target. |
-| Phase 3 verification fails | External firewall not yet updated, ssh-agent missing the matching private key, or DNS/IP propagation delay. The banner walks through each. Port 22 on the target is still open at this point — you can ssh back in as root and remove `/etc/ssh/sshd_config.d/99-bootstrap.conf` to undo. |
-
-The script keeps **port 22 open in local firewalld** until phase 4 is
-explicitly accepted. That's your safety net: even if the new port
-configuration breaks somehow, you can SSH in via the original port,
-inspect, and fix.
-
----
+Port 22 stays open in local firewalld as a safety net until you
+explicitly accept the close-22 prompt at the end.
 
 ## After it finishes
 
-Add a `~/.ssh/config` entry on your laptop:
+Add to `~/.ssh/config` on your laptop:
 
 ```
 Host new-server
@@ -146,33 +66,22 @@ Host new-server
   IdentityFile ~/.ssh/id_ed25519
 ```
 
-Sanity-check Ansible can reach the host:
+Sanity-check + deploy:
 
 ```bash
 ansible -i inventory/hosts.yml new-server -m ping
-```
-
-Expect `pong`. Then deploy services as usual:
-
-```bash
 ansible-playbook -i inventory/hosts.yml playbooks/site.yml --limit new-server
 ```
-
----
 
 ## Topology
 
 ```
-+--------------+    bootstrap-host.sh    +-------------------+
-| control host |  ─────────────────────► | managed host #1   |
-|              |    bootstrap-host.sh    | (sshd hardened    |
-|              |  ─────────────────────► | + ansible user)   |
-|              |                         +-------------------+
-|              |    bootstrap-host.sh    +-------------------+
-|              |  ─────────────────────► | managed host #2   |
-+--------------+                         | (sshd hardened)   |
-                                         +-------------------+
-        ↑                                         │
-        └─────── ansible playbooks ───────────────┘
-              (ssh -p <new-port> ansible@host)
++----------+   bootstrap-host.sh   +------------------+
+|  laptop  |  ───────────────────► | managed host #1  |
+|          |   bootstrap-host.sh   | (ansible user,   |
+|          |  ───────────────────► |  sshd hardened)  |
++----------+                       +------------------+
+     ↑                                      │
+     └─────── ansible playbooks ────────────┘
+            (ssh -p <port> ansible@host)
 ```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -8,7 +8,7 @@ root:
 | Script | Run on | What it does |
 |---|---|---|
 | `setup.sh` | The **control machine** | Installs Ansible, clones the repo, walks you through inventory + vault + first deploy. |
-| `scripts/bootstrap-host.sh` | A **fresh managed host** | Creates the `ds` user, installs your SSH key, hardens sshd, installs Python (for Ansible) and Podman. |
+| `scripts/bootstrap-host.sh` | A **fresh managed host** | Creates the `myuser` user, installs your SSH key, hardens sshd, installs Python (for Ansible) and Podman. |
 
 The script is idempotent — safe to re-run.
 
@@ -67,7 +67,7 @@ bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
 | Flag | Default | Description |
 |---|---|---|
 | `-k <pubkey>` | (required) | SSH public key (full string) to install for the new user. The script installs this in `~<user>/.ssh/authorized_keys` **before** disabling password auth. |
-| `-u <user>` | `ds` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
+| `-u <user>` | `myuser` | Linux username to create. Validated against `^[a-z_][a-z0-9_-]{0,31}$`. |
 | `-p <port>` | `2222` | SSH port to harden onto. firewalld + SELinux are updated to match. Validated as an integer 1–65535. |
 | `-n <hostname>` | (unchanged) | Hostname to set via `hostnamectl`. RFC 1123 charset. Omit to leave the current hostname untouched. |
 | `-h` | — | Show help and exit. |
@@ -84,7 +84,7 @@ layout, edit `NEW_KEYMAP` at the top of the script.
 | 1 | Enables EPEL, runs `dnf -y update`, installs prerequisites: `sudo`, `openssh-server`, `python3`, `python3-pip`, `policycoreutils-python-utils`, `firewalld`, `podman`, `bpytop`. Enables and starts `firewalld`. |
 | 2 | Sets the hostname (only if `-n` was passed). |
 | 3 | Sets the console keymap to `de` via `localectl`. |
-| 4 | Creates the user (default `ds`) with a home directory and bash login shell. |
+| 4 | Creates the user (default `myuser`) with a home directory and bash login shell. |
 | 5 | Drops `/etc/sudoers.d/90-<user>` granting passwordless sudo. Validated with `visudo -cf` before being made effective. |
 | 6 | Creates `~<user>/.ssh/`, installs the public key into `authorized_keys` (idempotent — appended only if not already present), and runs `restorecon -R` on the directory to ensure SELinux labels are correct. |
 | 7 | Opens the new SSH port in firewalld (`firewall-cmd --permanent --add-port=<port>/tcp`) and reloads. **Port 22 stays open** until you manually close it after verifying the new port works. |
@@ -159,7 +159,7 @@ Optional convenience. In `~/.ssh/config`:
 ```
 Host new-server
   HostName <ip>
-  User ds
+  User myuser
   Port 2222
   IdentityFile ~/.ssh/id_ed25519
 ```

--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -1,8 +1,12 @@
 # Open an Ansible path to a fresh host
 
 `scripts/bootstrap-host.sh` runs from your **laptop** and prepares a
-freshly-installed AlmaLinux 9 / RHEL 9 / Rocky 9 host so Ansible can
-take over. It does only what's needed for that handoff:
+freshly-installed RHEL-family host so Ansible can take over. Supported
+targets: RHEL, AlmaLinux, Rocky, CentOS Stream, Oracle Linux (8 or 9),
+and Fedora. The script checks `/etc/os-release` and refuses to run on
+anything else (Debian/Ubuntu/Arch/…).
+
+It does only what's needed for the handoff:
 
 - creates an `ansible` user with passwordless sudo
 - installs your SSH public key for that user

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -11,7 +11,7 @@
 #   -k <pubkey>      SSH public key (string) to install for the new user
 #
 # Optional:
-#   -u <user>        Linux username to create (default: ds)
+#   -u <user>        Linux username to create (default: myuser)
 #   -p <port>        SSH port to harden onto         (default: 2222)
 #   -n <hostname>    Hostname to set                 (default: leave unchanged)
 #   -h               Show this help and exit
@@ -25,8 +25,8 @@
 #      (Python for Ansible, Podman, firewalld, SELinux tooling, bpytop).
 #   2. Sets the hostname (if a second argument was passed).
 #   3. Sets the console keymap to German (configurable via NEW_KEYMAP).
-#   4. Creates user `ds` with passwordless sudo.
-#   5. Installs your SSH public key for `ds` BEFORE password auth is
+#   4. Creates user `myuser` with passwordless sudo.
+#   5. Installs your SSH public key for `myuser` BEFORE password auth is
 #      disabled — without this you would be locked out.
 #   6. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
 #        - port 2222
@@ -48,7 +48,7 @@
 # What it deliberately does NOT do:
 #   - Close port 22 in the firewall. Test the new port first from a
 #     SECOND terminal:
-#       ssh -p 2222 ds@<this-host>
+#       ssh -p 2222 myuser@<this-host>
 #     If that works, lock down by removing the old port:
 #       sudo firewall-cmd --permanent --remove-service=ssh
 #       sudo firewall-cmd --reload
@@ -63,7 +63,7 @@
 set -euo pipefail
 
 # ---- Defaults --------------------------------------------------------------
-NEW_USER="ds"
+NEW_USER="myuser"
 NEW_SSH_PORT=2222
 NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
 SSH_PUBKEY=""
@@ -77,7 +77,7 @@ Required:
   -k <pubkey>      SSH public key (string) to install for the new user
 
 Optional:
-  -u <user>        Linux username to create  (default: ds)
+  -u <user>        Linux username to create  (default: myuser)
   -p <port>        SSH port to harden onto   (default: 2222)
   -n <hostname>    Hostname to set           (default: leave unchanged)
   -h               Show this help and exit

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -23,6 +23,17 @@
 #        - disables password authentication
 #   6. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
 #
+# SELinux notes:
+#   - AlmaLinux/RHEL 9 ships with SELinux Enforcing by default. The
+#     script keeps it that way — no setenforce/setpermissive — and
+#     prints a warning if the running mode is not Enforcing.
+#   - The new SSH port (2343) gets `semanage port -a -t ssh_port_t -p tcp`
+#     so sshd is allowed to bind it.
+#   - `restorecon` is run on the files we write (authorized_keys and
+#     the sshd drop-in) to ensure the labels match the policy
+#     defaults (ssh_home_t / sshd_config_t). Cheap insurance against
+#     "key auth silently fails" debugging on RHEL family.
+#
 # What it deliberately does NOT do:
 #   - Close port 22 in the firewall. Test the new port first from a
 #     SECOND terminal:
@@ -83,6 +94,23 @@ echo "   ssh port:       $NEW_SSH_PORT"
 echo "   keymap:         $NEW_KEYMAP"
 echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
 echo "=================================================================="
+
+# Sanity-check SELinux mode. We don't fix this — disabling SELinux is
+# a deliberate choice and we don't want to silently change it — but a
+# host running in Permissive (or Disabled) loses a lot of the security
+# the rest of this script assumes.
+if command -v getenforce >/dev/null 2>&1; then
+    selinux_mode=$(getenforce 2>/dev/null || true)
+    if [[ "$selinux_mode" != "Enforcing" ]]; then
+        echo
+        echo "  WARNING: SELinux is '$selinux_mode' (expected Enforcing)."
+        echo "           This script will still work, but the system is"
+        echo "           less protected. Re-enable with:"
+        echo "             setenforce 1"
+        echo "             sed -i 's/^SELINUX=.*/SELINUX=enforcing/' /etc/selinux/config"
+        echo
+    fi
+fi
 
 # ---- 1. System update + prerequisites --------------------------------------
 echo
@@ -147,6 +175,15 @@ fi
 chmod 0600 "$AUTH_KEYS"
 chown "$NEW_USER:$NEW_USER" "$AUTH_KEYS"
 
+# Reset SELinux labels on the .ssh tree to whatever the policy says
+# they should be (ssh_home_t for the dir + authorized_keys). Files
+# created via shell redirection inherit the parent's context, which
+# is usually correct here, but `restorecon` makes failure deterministic
+# instead of "sometimes works, sometimes mysterious AVC denial".
+if command -v restorecon >/dev/null 2>&1; then
+    restorecon -R "$USER_SSH_DIR"
+fi
+
 # ---- 6. Firewalld ----------------------------------------------------------
 echo
 echo "[6/8] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
@@ -175,6 +212,13 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 EOF
 chmod 0600 "$SSHD_DROPIN"
+
+# Same insurance as for authorized_keys — if the policy expects
+# sshd_config_t in /etc/ssh/sshd_config.d/ (it does on RHEL 9),
+# restorecon makes the label deterministic so sshd can read it.
+if command -v restorecon >/dev/null 2>&1; then
+    restorecon "$SSHD_DROPIN"
+fi
 
 # Validate config before restart
 sshd -t

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# ============================================================================
+# Bootstrap a fresh AlmaLinux 9 (or RHEL/Rocky 9) host as an Ansible target.
+#
+# Run as root on a fresh install. Idempotent — safe to re-run.
+#
+# Usage:
+#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
+#
+# Or pass the key directly:
+#   bash scripts/bootstrap-host.sh "ssh-ed25519 AAAA... user@laptop"
+#
+# What it does:
+#   1. Updates the system and installs prerequisites (Python for Ansible,
+#      Podman, firewalld, SELinux tooling).
+#   2. Creates user `ds` with passwordless sudo.
+#   3. Installs your SSH public key for `ds` BEFORE password auth is
+#      disabled — without this you would be locked out.
+#   4. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
+#        - port 2343
+#        - disables root login
+#        - disables password authentication
+#   5. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
+#
+# What it deliberately does NOT do:
+#   - Close port 22 in the firewall. Test the new port first from a
+#     SECOND terminal:
+#       ssh -p 2343 ds@<this-host>
+#     If that works, lock down by removing the old port:
+#       sudo firewall-cmd --permanent --remove-service=ssh
+#       sudo firewall-cmd --reload
+#   - Install Ansible. The control machine runs Ansible; managed
+#     hosts only need Python (already covered above).
+#
+# This is the symmetric counterpart to setup.sh:
+#   - setup.sh   = control machine (runs Ansible against the inventory)
+#   - this script = a managed host (Ansible target)
+# ============================================================================
+
+set -euo pipefail
+
+# ---- Config ----------------------------------------------------------------
+NEW_USER="ds"
+NEW_SSH_PORT=2343
+
+# ---- Args ------------------------------------------------------------------
+SSH_PUBKEY="${1:-}"
+
+if [[ -z "$SSH_PUBKEY" ]]; then
+    cat <<'EOF' >&2
+Error: SSH public key required.
+
+Usage:
+  bash scripts/bootstrap-host.sh "<ssh-public-key-string>"
+
+Example:
+  bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
+
+The key is installed for the new user BEFORE password auth is disabled.
+Without this, you would be locked out as soon as sshd is restarted.
+EOF
+    exit 1
+fi
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "Error: run as root (use sudo)." >&2
+    exit 1
+fi
+
+# Sanity-check that the pubkey looks vaguely like one
+if ! [[ "$SSH_PUBKEY" =~ ^(ssh-(rsa|ed25519|ecdsa-sha2-nistp[0-9]+)|sk-(ssh-ed25519|ecdsa-sha2-nistp[0-9]+))@?[a-z0-9-]*\ [A-Za-z0-9+/=]+ ]]; then
+    echo "Error: SSH_PUBKEY argument does not look like a valid public key." >&2
+    echo "Got: ${SSH_PUBKEY:0:60}..." >&2
+    exit 1
+fi
+
+echo "=================================================================="
+echo " Home-server host bootstrap"
+echo "   user:           $NEW_USER  (passwordless sudo)"
+echo "   ssh port:       $NEW_SSH_PORT"
+echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
+echo "=================================================================="
+
+# ---- 1. System update + prerequisites --------------------------------------
+echo
+echo "[1/7] Updating system and installing prerequisites…"
+dnf -y update
+dnf -y install \
+    sudo openssh-server \
+    python3 python3-pip \
+    policycoreutils-python-utils \
+    firewalld \
+    podman
+
+systemctl enable --now firewalld
+
+# ---- 2. Create user --------------------------------------------------------
+echo
+echo "[2/7] Creating user $NEW_USER…"
+if id "$NEW_USER" >/dev/null 2>&1; then
+    echo "  user $NEW_USER already exists — skipping"
+else
+    useradd -m -s /bin/bash "$NEW_USER"
+fi
+
+# ---- 3. Sudo rights --------------------------------------------------------
+echo
+echo "[3/7] Granting passwordless sudo to $NEW_USER…"
+SUDOERS_FILE="/etc/sudoers.d/90-$NEW_USER"
+cat > "$SUDOERS_FILE" <<EOF
+# Bootstrap-installed: $NEW_USER may run any command without a password.
+# This is intentional for an Ansible-managed host. Replace NOPASSWD:ALL
+# with a more restrictive policy if the host is used interactively.
+$NEW_USER ALL=(ALL) NOPASSWD:ALL
+EOF
+chmod 0440 "$SUDOERS_FILE"
+# visudo -cf bails out non-zero on syntax errors
+visudo -cf "$SUDOERS_FILE" >/dev/null
+
+# ---- 4. SSH public key -----------------------------------------------------
+echo
+echo "[4/7] Installing SSH public key for $NEW_USER…"
+USER_HOME="/home/$NEW_USER"
+USER_SSH_DIR="$USER_HOME/.ssh"
+AUTH_KEYS="$USER_SSH_DIR/authorized_keys"
+
+install -d -m 0700 -o "$NEW_USER" -g "$NEW_USER" "$USER_SSH_DIR"
+touch "$AUTH_KEYS"
+if ! grep -qxF "$SSH_PUBKEY" "$AUTH_KEYS"; then
+    echo "$SSH_PUBKEY" >> "$AUTH_KEYS"
+    echo "  key appended to $AUTH_KEYS"
+else
+    echo "  key already present — skipping"
+fi
+chmod 0600 "$AUTH_KEYS"
+chown "$NEW_USER:$NEW_USER" "$AUTH_KEYS"
+
+# ---- 5. Firewalld ----------------------------------------------------------
+echo
+echo "[5/7] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
+echo "      until you confirm the new port works — see banner at the end)…"
+firewall-cmd --permanent --add-port="$NEW_SSH_PORT/tcp" >/dev/null
+firewall-cmd --reload >/dev/null
+
+# ---- 6. SELinux ssh_port_t label ------------------------------------------
+echo
+echo "[6/7] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
+if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b$NEW_SSH_PORT\b"; then
+    echo "  port $NEW_SSH_PORT already labeled ssh_port_t — skipping"
+else
+    semanage port -a -t ssh_port_t -p tcp "$NEW_SSH_PORT"
+fi
+
+# ---- 7. sshd hardening drop-in --------------------------------------------
+echo
+echo "[7/7] Writing sshd hardening drop-in and restarting sshd…"
+SSHD_DROPIN="/etc/ssh/sshd_config.d/99-bootstrap.conf"
+cat > "$SSHD_DROPIN" <<EOF
+# Bootstrap-installed sshd hardening (see scripts/bootstrap-host.sh).
+Port $NEW_SSH_PORT
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+EOF
+chmod 0600 "$SSHD_DROPIN"
+
+# Validate config before restart
+sshd -t
+
+systemctl restart sshd
+
+# ---- Done ------------------------------------------------------------------
+HOST_IP=$(hostname -I | awk '{print $1}')
+cat <<EOF
+
+==================================================================
+ Done.
+==================================================================
+
+Verify in a SECOND terminal BEFORE closing this session:
+
+    ssh -p $NEW_SSH_PORT $NEW_USER@$HOST_IP
+
+If that works, lock down by removing port 22 from the firewall:
+
+    firewall-cmd --permanent --remove-service=ssh
+    firewall-cmd --reload
+
+If you get locked out (e.g. firewall mistake), this current root
+session stays open; you can fix sshd_config from here.
+
+EOF

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -5,23 +5,28 @@
 # Run as root on a fresh install. Idempotent — safe to re-run.
 #
 # Usage:
-#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
+#   bash scripts/bootstrap-host.sh "<ssh-pubkey>" [hostname]
 #
-# Or pass the key directly:
-#   bash scripts/bootstrap-host.sh "ssh-ed25519 AAAA... user@laptop"
+# Examples:
+#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
+#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)" dnsvserver
+#
+# The hostname argument is optional; if omitted, the current hostname is
+# kept.
 #
 # What it does:
-#   1. Updates the system and installs prerequisites (Python for Ansible,
-#      Podman, firewalld, SELinux tooling).
-#   2. Sets the console keymap to German (configurable via NEW_KEYMAP).
-#   3. Creates user `ds` with passwordless sudo.
-#   4. Installs your SSH public key for `ds` BEFORE password auth is
+#   1. Enables EPEL, updates the system, installs prerequisites
+#      (Python for Ansible, Podman, firewalld, SELinux tooling, bpytop).
+#   2. Sets the hostname (if a second argument was passed).
+#   3. Sets the console keymap to German (configurable via NEW_KEYMAP).
+#   4. Creates user `ds` with passwordless sudo.
+#   5. Installs your SSH public key for `ds` BEFORE password auth is
 #      disabled — without this you would be locked out.
-#   5. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
+#   6. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
 #        - port 2343
 #        - disables root login
 #        - disables password authentication
-#   6. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
+#   7. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
 #
 # SELinux notes:
 #   - AlmaLinux/RHEL 9 ships with SELinux Enforcing by default. The
@@ -58,20 +63,29 @@ NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
 
 # ---- Args ------------------------------------------------------------------
 SSH_PUBKEY="${1:-}"
+NEW_HOSTNAME="${2:-}"
 
 if [[ -z "$SSH_PUBKEY" ]]; then
     cat <<'EOF' >&2
 Error: SSH public key required.
 
 Usage:
-  bash scripts/bootstrap-host.sh "<ssh-public-key-string>"
+  bash scripts/bootstrap-host.sh "<ssh-public-key>" [hostname]
 
-Example:
+Examples:
   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
+  bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)" dnsvserver
 
 The key is installed for the new user BEFORE password auth is disabled.
 Without this, you would be locked out as soon as sshd is restarted.
 EOF
+    exit 1
+fi
+
+# Hostname format: letters, digits, dashes; dots allowed for FQDN-style.
+if [[ -n "$NEW_HOSTNAME" ]] \
+    && ! [[ "$NEW_HOSTNAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]]; then
+    echo "Error: hostname '$NEW_HOSTNAME' contains characters not allowed (RFC 1123)." >&2
     exit 1
 fi
 
@@ -92,6 +106,7 @@ echo " Home-server host bootstrap"
 echo "   user:           $NEW_USER  (passwordless sudo)"
 echo "   ssh port:       $NEW_SSH_PORT"
 echo "   keymap:         $NEW_KEYMAP"
+echo "   hostname:       ${NEW_HOSTNAME:-<unchanged>}"
 echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
 echo "=================================================================="
 
@@ -114,38 +129,54 @@ fi
 
 # ---- 1. System update + prerequisites --------------------------------------
 echo
-echo "[1/8] Updating system and installing prerequisites…"
+echo "[1/9] Enabling EPEL, updating, installing prerequisites…"
+# EPEL provides bpytop (and a few other niceties); harmless to enable
+# even if bpytop is the only package we draw from it.
+dnf -y install epel-release
 dnf -y update
 dnf -y install \
     sudo openssh-server \
     python3 python3-pip \
     policycoreutils-python-utils \
     firewalld \
-    podman
+    podman \
+    bpytop
 
 systemctl enable --now firewalld
 
-# ---- 2. Console keymap -----------------------------------------------------
+# ---- 2. Hostname -----------------------------------------------------------
 echo
-echo "[2/8] Setting console keymap to $NEW_KEYMAP…"
+echo "[2/9] Setting hostname…"
+if [[ -z "$NEW_HOSTNAME" ]]; then
+    echo "  (no hostname argument given — keeping current: $(hostname))"
+elif [[ "$(hostnamectl --static 2>/dev/null)" == "$NEW_HOSTNAME" ]]; then
+    echo "  hostname already $NEW_HOSTNAME — skipping"
+else
+    hostnamectl set-hostname "$NEW_HOSTNAME"
+    echo "  hostname set to $NEW_HOSTNAME"
+fi
+
+# ---- 3. Console keymap -----------------------------------------------------
+echo
+echo "[3/9] Setting console keymap to $NEW_KEYMAP…"
 if localectl status 2>/dev/null | grep -q "^ *VC Keymap: $NEW_KEYMAP$"; then
     echo "  already set to $NEW_KEYMAP — skipping"
 else
     localectl set-keymap "$NEW_KEYMAP"
 fi
 
-# ---- 3. Create user --------------------------------------------------------
+# ---- 4. Create user --------------------------------------------------------
 echo
-echo "[3/8] Creating user $NEW_USER…"
+echo "[4/9] Creating user $NEW_USER…"
 if id "$NEW_USER" >/dev/null 2>&1; then
     echo "  user $NEW_USER already exists — skipping"
 else
     useradd -m -s /bin/bash "$NEW_USER"
 fi
 
-# ---- 4. Sudo rights --------------------------------------------------------
+# ---- 5. Sudo rights --------------------------------------------------------
 echo
-echo "[4/8] Granting passwordless sudo to $NEW_USER…"
+echo "[5/9] Granting passwordless sudo to $NEW_USER…"
 SUDOERS_FILE="/etc/sudoers.d/90-$NEW_USER"
 cat > "$SUDOERS_FILE" <<EOF
 # Bootstrap-installed: $NEW_USER may run any command without a password.
@@ -157,9 +188,9 @@ chmod 0440 "$SUDOERS_FILE"
 # visudo -cf bails out non-zero on syntax errors
 visudo -cf "$SUDOERS_FILE" >/dev/null
 
-# ---- 5. SSH public key -----------------------------------------------------
+# ---- 6. SSH public key -----------------------------------------------------
 echo
-echo "[5/8] Installing SSH public key for $NEW_USER…"
+echo "[6/9] Installing SSH public key for $NEW_USER…"
 USER_HOME="/home/$NEW_USER"
 USER_SSH_DIR="$USER_HOME/.ssh"
 AUTH_KEYS="$USER_SSH_DIR/authorized_keys"
@@ -184,25 +215,25 @@ if command -v restorecon >/dev/null 2>&1; then
     restorecon -R "$USER_SSH_DIR"
 fi
 
-# ---- 6. Firewalld ----------------------------------------------------------
+# ---- 7. Firewalld ----------------------------------------------------------
 echo
-echo "[6/8] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
+echo "[7/9] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
 echo "      until you confirm the new port works — see banner at the end)…"
 firewall-cmd --permanent --add-port="$NEW_SSH_PORT/tcp" >/dev/null
 firewall-cmd --reload >/dev/null
 
-# ---- 7. SELinux ssh_port_t label ------------------------------------------
+# ---- 8. SELinux ssh_port_t label ------------------------------------------
 echo
-echo "[7/8] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
+echo "[8/9] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
 if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b$NEW_SSH_PORT\b"; then
     echo "  port $NEW_SSH_PORT already labeled ssh_port_t — skipping"
 else
     semanage port -a -t ssh_port_t -p tcp "$NEW_SSH_PORT"
 fi
 
-# ---- 8. sshd hardening drop-in --------------------------------------------
+# ---- 9. sshd hardening drop-in --------------------------------------------
 echo
-echo "[8/8] Writing sshd hardening drop-in and restarting sshd…"
+echo "[9/9] Writing sshd hardening drop-in and restarting sshd…"
 SSHD_DROPIN="/etc/ssh/sshd_config.d/99-bootstrap.conf"
 cat > "$SSHD_DROPIN" <<EOF
 # Bootstrap-installed sshd hardening (see scripts/bootstrap-host.sh).

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -12,7 +12,7 @@
 #
 # Optional:
 #   -u <user>        Linux username to create (default: ds)
-#   -p <port>        SSH port to harden onto         (default: 2343)
+#   -p <port>        SSH port to harden onto         (default: 2222)
 #   -n <hostname>    Hostname to set                 (default: leave unchanged)
 #   -h               Show this help and exit
 #
@@ -29,16 +29,16 @@
 #   5. Installs your SSH public key for `ds` BEFORE password auth is
 #      disabled — without this you would be locked out.
 #   6. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
-#        - port 2343
+#        - port 2222
 #        - disables root login
 #        - disables password authentication
-#   7. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
+#   7. Opens port 2222 in firewalld and labels it ssh_port_t in SELinux.
 #
 # SELinux notes:
 #   - AlmaLinux/RHEL 9 ships with SELinux Enforcing by default. The
 #     script keeps it that way — no setenforce/setpermissive — and
 #     prints a warning if the running mode is not Enforcing.
-#   - The new SSH port (2343) gets `semanage port -a -t ssh_port_t -p tcp`
+#   - The new SSH port (2222) gets `semanage port -a -t ssh_port_t -p tcp`
 #     so sshd is allowed to bind it.
 #   - `restorecon` is run on the files we write (authorized_keys and
 #     the sshd drop-in) to ensure the labels match the policy
@@ -48,7 +48,7 @@
 # What it deliberately does NOT do:
 #   - Close port 22 in the firewall. Test the new port first from a
 #     SECOND terminal:
-#       ssh -p 2343 ds@<this-host>
+#       ssh -p 2222 ds@<this-host>
 #     If that works, lock down by removing the old port:
 #       sudo firewall-cmd --permanent --remove-service=ssh
 #       sudo firewall-cmd --reload
@@ -64,7 +64,7 @@ set -euo pipefail
 
 # ---- Defaults --------------------------------------------------------------
 NEW_USER="ds"
-NEW_SSH_PORT=2343
+NEW_SSH_PORT=2222
 NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
 SSH_PUBKEY=""
 NEW_HOSTNAME=""
@@ -78,7 +78,7 @@ Required:
 
 Optional:
   -u <user>        Linux username to create  (default: ds)
-  -p <port>        SSH port to harden onto   (default: 2343)
+  -p <port>        SSH port to harden onto   (default: 2222)
   -n <hostname>    Hostname to set           (default: leave unchanged)
   -h               Show this help and exit
 

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # ============================================================================
-# Open a path for Ansible to reach a fresh AlmaLinux 9 / RHEL 9 / Rocky 9 host.
+# Open a path for Ansible to reach a fresh RHEL-family host.
+#
+# Supported targets: RHEL 8/9, AlmaLinux 8/9, Rocky 8/9, CentOS Stream 8/9,
+# Oracle Linux 8/9, and Fedora (upstream of the family). The script
+# checks `/etc/os-release` on the target and bails out on anything
+# else (Debian/Ubuntu/Arch/etc).
 #
 # Run this from the Ansible control machine. The script SSHs to the target
 # as root on port 22, hardens sshd, creates an `ansible` user with sudo,
@@ -119,6 +124,28 @@ $(cat <<'PAYLOAD'
 set -euo pipefail
 
 [[ "\$EUID" -eq 0 ]] || { echo "Error: must run as root on the target." >&2; exit 1; }
+
+# ---- 0. Distro sanity check ----
+# Accept anything in the RHEL-family tree (rhel/centos/fedora as ID
+# or anywhere in ID_LIKE). dnf, firewalld, SELinux, semanage, and
+# restorecon below all assume that family.
+if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+else
+    echo "Error: /etc/os-release missing — can't identify distro." >&2
+    exit 1
+fi
+case " \${ID:-} \${ID_LIKE:-} " in
+    *" rhel "*|*" centos "*|*" fedora "*|*" rocky "*|*" almalinux "*|*" ol "*) ;;
+    *)
+        echo "Error: unsupported distro." >&2
+        echo "  ID=\${ID:-?} ID_LIKE=\${ID_LIKE:-?}" >&2
+        echo "  This script supports RHEL family only" \
+             "(RHEL/AlmaLinux/Rocky/CentOS Stream/Oracle Linux/Fedora)." >&2
+        exit 1
+        ;;
+esac
+echo "Detected: \${PRETTY_NAME:-\$ID \$VERSION_ID}"
 
 # ---- 1. Prerequisites ----
 # python3, firewalld, and SELinux's `semanage` are the bare minimum to do

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -2,95 +2,82 @@
 # ============================================================================
 # Bootstrap a fresh AlmaLinux 9 (or RHEL/Rocky 9) host as an Ansible target.
 #
-# Run as root on a fresh install. Idempotent — safe to re-run.
+# Run this script from your LAPTOP (or any Ansible-control machine).
+# It SSHs to the target as root on port 22 and performs all hardening
+# remotely. You never need to log into the host's console manually.
+#
+# Prerequisites on the target:
+#   - Fresh OS install with sshd listening on port 22
+#   - Root login enabled with either a password or a key you control
+#
+# Prerequisites on this machine:
+#   - bash, ssh
 #
 # Usage:
-#   bash scripts/bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+#   bash scripts/bootstrap-host.sh -H <host> -k <ssh-pubkey> \
+#        [-u <user>] [-p <port>] [-n <hostname>]
 #
 # Required:
-#   -k <pubkey>      SSH public key (string) to install for the new user
+#   -H <host>        Target hostname or IP (the new server)
+#   -k <pubkey>      SSH public key to install for the new user
 #
 # Optional:
-#   -u <user>        Linux username to create (default: myuser)
-#   -p <port>        SSH port to harden onto         (default: 2222)
-#   -n <hostname>    Hostname to set                 (default: leave unchanged)
+#   -u <user>        Linux username to create  (default: myuser)
+#   -p <port>        SSH port to harden onto   (default: 2222)
+#   -n <hostname>    Hostname to set on target (default: leave unchanged)
 #   -h               Show this help and exit
 #
 # Examples:
-#   bash scripts/bootstrap-host.sh -k "$(cat ~/.ssh/id_ed25519.pub)"
-#   bash scripts/bootstrap-host.sh -k "$(cat key.pub)" -u admin -p 2222 -n dnsvserver
+#   bash bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
+#   bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" \
+#                          -u admin -p 2200 -n dnsvserver
 #
-# What it does:
-#   1. Enables EPEL, updates the system, installs prerequisites
-#      (Python for Ansible, Podman, firewalld, SELinux tooling, bpytop).
-#   2. Sets the hostname (if a second argument was passed).
-#   3. Sets the console keymap to German (configurable via NEW_KEYMAP).
-#   4. Creates user `myuser` with passwordless sudo.
-#   5. Installs your SSH public key for `myuser` BEFORE password auth is
-#      disabled — without this you would be locked out.
-#   6. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
-#        - port 2222
-#        - disables root login
-#        - disables password authentication
-#   7. Opens port 2222 in firewalld and labels it ssh_port_t in SELinux.
-#
-# SELinux notes:
-#   - AlmaLinux/RHEL 9 ships with SELinux Enforcing by default. The
-#     script keeps it that way — no setenforce/setpermissive — and
-#     prints a warning if the running mode is not Enforcing.
-#   - The new SSH port (2222) gets `semanage port -a -t ssh_port_t -p tcp`
-#     so sshd is allowed to bind it.
-#   - `restorecon` is run on the files we write (authorized_keys and
-#     the sshd drop-in) to ensure the labels match the policy
-#     defaults (ssh_home_t / sshd_config_t). Cheap insurance against
-#     "key auth silently fails" debugging on RHEL family.
-#
-# What it deliberately does NOT do:
-#   - Close port 22 in the firewall. Test the new port first from a
-#     SECOND terminal:
-#       ssh -p 2222 myuser@<this-host>
-#     If that works, lock down by removing the old port:
-#       sudo firewall-cmd --permanent --remove-service=ssh
-#       sudo firewall-cmd --reload
-#   - Install Ansible. The control machine runs Ansible; managed
-#     hosts only need Python (already covered above).
-#
-# This is the symmetric counterpart to setup.sh:
-#   - setup.sh   = control machine (runs Ansible against the inventory)
-#   - this script = a managed host (Ansible target)
+# Flow:
+#   1. ssh root@<host>:22 → run hardening payload (system update,
+#      EPEL+bpytop, hostname, keymap, user+sudo, key install, firewalld
+#      open new port, SELinux port label, sshd hardening drop-in,
+#      restart sshd).
+#   2. Local prompt: "Update any external/provider firewall now —
+#      open <new-port>, close 22 — then press Enter."
+#   3. ssh -p <new-port> <user>@<host> → verify the hardened
+#      configuration works.
+#   4. Optionally close port 22 in the target's local firewalld.
 # ============================================================================
 
 set -euo pipefail
 
 # ---- Defaults --------------------------------------------------------------
+TARGET_HOST=""
+SSH_PUBKEY=""
 NEW_USER="myuser"
 NEW_SSH_PORT=2222
-NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
-SSH_PUBKEY=""
+NEW_KEYMAP="de"
 NEW_HOSTNAME=""
 
 usage() {
     cat <<'EOF'
-Usage: bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+Usage: bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
 
 Required:
+  -H <host>        Target hostname or IP (the new server)
   -k <pubkey>      SSH public key (string) to install for the new user
 
 Optional:
   -u <user>        Linux username to create  (default: myuser)
   -p <port>        SSH port to harden onto   (default: 2222)
-  -n <hostname>    Hostname to set           (default: leave unchanged)
+  -n <hostname>    Hostname to set on target (default: leave unchanged)
   -h               Show this help and exit
 
 Examples:
-  bash bootstrap-host.sh -k "$(cat ~/.ssh/id_ed25519.pub)"
-  bash bootstrap-host.sh -k "$(cat key.pub)" -u admin -p 2222 -n dnsvserver
+  bash bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
+  bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" -u admin -p 2200 -n dnsvserver
 EOF
 }
 
 # ---- Args ------------------------------------------------------------------
-while getopts ":k:u:p:n:h" opt; do
+while getopts ":H:k:u:p:n:h" opt; do
     case "$opt" in
+        H) TARGET_HOST="$OPTARG" ;;
         k) SSH_PUBKEY="$OPTARG" ;;
         u) NEW_USER="$OPTARG" ;;
         p) NEW_SSH_PORT="$OPTARG" ;;
@@ -107,7 +94,13 @@ if [[ $# -gt 0 ]]; then
     exit 1
 fi
 
-# Required: pubkey
+# Required
+if [[ -z "$TARGET_HOST" ]]; then
+    echo "Error: -H <host> is required." >&2
+    echo
+    usage >&2
+    exit 1
+fi
 if [[ -z "$SSH_PUBKEY" ]]; then
     echo "Error: -k <ssh-pubkey> is required." >&2
     echo
@@ -115,15 +108,13 @@ if [[ -z "$SSH_PUBKEY" ]]; then
     exit 1
 fi
 
-# Validate username (POSIX/RHEL-friendly subset)
+# Validate username
 if ! [[ "$NEW_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then
-    echo "Error: invalid username '$NEW_USER'." >&2
-    echo "       Must start with a lowercase letter or underscore," >&2
-    echo "       contain only [a-z0-9_-], and be 1-32 characters." >&2
+    echo "Error: invalid username '$NEW_USER' (must match ^[a-z_][a-z0-9_-]{0,31}\$)." >&2
     exit 1
 fi
 
-# Validate SSH port (integer 1-65535)
+# Validate SSH port
 if ! [[ "$NEW_SSH_PORT" =~ ^[0-9]+$ ]] \
     || [[ "$NEW_SSH_PORT" -lt 1 || "$NEW_SSH_PORT" -gt 65535 ]]; then
     echo "Error: invalid SSH port '$NEW_SSH_PORT' (must be 1-65535)." >&2
@@ -137,49 +128,69 @@ if [[ -n "$NEW_HOSTNAME" ]] \
     exit 1
 fi
 
-if [[ "$EUID" -ne 0 ]]; then
-    echo "Error: run as root (use sudo)." >&2
-    exit 1
-fi
-
-# Sanity-check that the pubkey looks vaguely like one
+# Sanity-check the pubkey looks like one
 if ! [[ "$SSH_PUBKEY" =~ ^(ssh-(rsa|ed25519|ecdsa-sha2-nistp[0-9]+)|sk-(ssh-ed25519|ecdsa-sha2-nistp[0-9]+))@?[a-z0-9-]*\ [A-Za-z0-9+/=]+ ]]; then
-    echo "Error: SSH_PUBKEY argument does not look like a valid public key." >&2
-    echo "Got: ${SSH_PUBKEY:0:60}..." >&2
+    echo "Error: SSH_PUBKEY does not look like a valid public key." >&2
+    echo "       Got: ${SSH_PUBKEY:0:60}..." >&2
     exit 1
 fi
 
 echo "=================================================================="
-echo " Home-server host bootstrap"
-echo "   user:           $NEW_USER  (passwordless sudo)"
-echo "   ssh port:       $NEW_SSH_PORT"
+echo " Home-server host bootstrap (remote driver)"
+echo "   target:         root@$TARGET_HOST:22"
+echo "   new user:       $NEW_USER  (passwordless sudo)"
+echo "   new ssh port:   $NEW_SSH_PORT"
 echo "   keymap:         $NEW_KEYMAP"
 echo "   hostname:       ${NEW_HOSTNAME:-<unchanged>}"
 echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
 echo "=================================================================="
 
-# Sanity-check SELinux mode. We don't fix this — disabling SELinux is
-# a deliberate choice and we don't want to silently change it — but a
-# host running in Permissive (or Disabled) loses a lot of the security
-# the rest of this script assumes.
+# ---- Phase 1: connect to root@host:22 and run the payload ------------------
+SSH_OPTS=(
+    -p 22
+    -o ConnectTimeout=10
+    -o StrictHostKeyChecking=accept-new
+    -o ServerAliveInterval=15
+)
+
+echo
+echo "Phase 1 — connecting to root@$TARGET_HOST:22 to run the hardening payload."
+echo "(If you don't have key auth as root, you'll be prompted for the password."
+echo " sshd is restarted onto port $NEW_SSH_PORT at the end of phase 1; the"
+echo " existing connection on port 22 stays alive even after the restart.)"
+echo
+
+# The remote payload uses these variables, set as a preamble. We use
+# printf %q to safely quote the values so any whitespace, quotes, or
+# special characters in the pubkey survive intact across SSH.
+ssh "${SSH_OPTS[@]}" "root@$TARGET_HOST" bash -s <<EOF
+SSH_PUBKEY=$(printf %q "$SSH_PUBKEY")
+NEW_USER=$(printf %q "$NEW_USER")
+NEW_SSH_PORT=$NEW_SSH_PORT
+NEW_HOSTNAME=$(printf %q "$NEW_HOSTNAME")
+NEW_KEYMAP=$(printf %q "$NEW_KEYMAP")
+$(cat <<'PAYLOAD'
+set -euo pipefail
+
+if [[ "\$EUID" -ne 0 ]]; then
+    echo "Error: must run as root on the target." >&2
+    exit 1
+fi
+
+# SELinux pre-flight (warn-only)
 if command -v getenforce >/dev/null 2>&1; then
-    selinux_mode=$(getenforce 2>/dev/null || true)
-    if [[ "$selinux_mode" != "Enforcing" ]]; then
+    selinux_mode=\$(getenforce 2>/dev/null || true)
+    if [[ "\$selinux_mode" != "Enforcing" ]]; then
         echo
-        echo "  WARNING: SELinux is '$selinux_mode' (expected Enforcing)."
-        echo "           This script will still work, but the system is"
-        echo "           less protected. Re-enable with:"
-        echo "             setenforce 1"
-        echo "             sed -i 's/^SELINUX=.*/SELINUX=enforcing/' /etc/selinux/config"
+        echo "  WARNING: SELinux is '\$selinux_mode' (expected Enforcing)."
+        echo "           Continuing anyway, but the system is less protected."
         echo
     fi
 fi
 
-# ---- 1. System update + prerequisites --------------------------------------
+# ---- 1. System update + prerequisites ----
 echo
 echo "[1/9] Enabling EPEL, updating, installing prerequisites…"
-# EPEL provides bpytop (and a few other niceties); harmless to enable
-# even if bpytop is the only package we draw from it.
 dnf -y install epel-release
 dnf -y update
 dnf -y install \
@@ -189,139 +200,201 @@ dnf -y install \
     firewalld \
     podman \
     bpytop
-
 systemctl enable --now firewalld
 
-# ---- 2. Hostname -----------------------------------------------------------
+# ---- 2. Hostname ----
 echo
 echo "[2/9] Setting hostname…"
-if [[ -z "$NEW_HOSTNAME" ]]; then
-    echo "  (no hostname argument given — keeping current: $(hostname))"
-elif [[ "$(hostnamectl --static 2>/dev/null)" == "$NEW_HOSTNAME" ]]; then
-    echo "  hostname already $NEW_HOSTNAME — skipping"
+if [[ -z "\$NEW_HOSTNAME" ]]; then
+    echo "  (no hostname argument given — keeping current: \$(hostname))"
+elif [[ "\$(hostnamectl --static 2>/dev/null)" == "\$NEW_HOSTNAME" ]]; then
+    echo "  hostname already \$NEW_HOSTNAME — skipping"
 else
-    hostnamectl set-hostname "$NEW_HOSTNAME"
-    echo "  hostname set to $NEW_HOSTNAME"
+    hostnamectl set-hostname "\$NEW_HOSTNAME"
+    echo "  hostname set to \$NEW_HOSTNAME"
 fi
 
-# ---- 3. Console keymap -----------------------------------------------------
+# ---- 3. Console keymap ----
 echo
-echo "[3/9] Setting console keymap to $NEW_KEYMAP…"
-if localectl status 2>/dev/null | grep -q "^ *VC Keymap: $NEW_KEYMAP$"; then
-    echo "  already set to $NEW_KEYMAP — skipping"
+echo "[3/9] Setting console keymap to \$NEW_KEYMAP…"
+if localectl status 2>/dev/null | grep -q "^ *VC Keymap: \$NEW_KEYMAP\$"; then
+    echo "  already set to \$NEW_KEYMAP — skipping"
 else
-    localectl set-keymap "$NEW_KEYMAP"
+    localectl set-keymap "\$NEW_KEYMAP"
 fi
 
-# ---- 4. Create user --------------------------------------------------------
+# ---- 4. Create user ----
 echo
-echo "[4/9] Creating user $NEW_USER…"
-if id "$NEW_USER" >/dev/null 2>&1; then
-    echo "  user $NEW_USER already exists — skipping"
+echo "[4/9] Creating user \$NEW_USER…"
+if id "\$NEW_USER" >/dev/null 2>&1; then
+    echo "  user \$NEW_USER already exists — skipping"
 else
-    useradd -m -s /bin/bash "$NEW_USER"
+    useradd -m -s /bin/bash "\$NEW_USER"
 fi
 
-# ---- 5. Sudo rights --------------------------------------------------------
+# ---- 5. Sudo rights ----
 echo
-echo "[5/9] Granting passwordless sudo to $NEW_USER…"
-SUDOERS_FILE="/etc/sudoers.d/90-$NEW_USER"
-cat > "$SUDOERS_FILE" <<EOF
-# Bootstrap-installed: $NEW_USER may run any command without a password.
-# This is intentional for an Ansible-managed host. Replace NOPASSWD:ALL
-# with a more restrictive policy if the host is used interactively.
-$NEW_USER ALL=(ALL) NOPASSWD:ALL
-EOF
-chmod 0440 "$SUDOERS_FILE"
-# visudo -cf bails out non-zero on syntax errors
-visudo -cf "$SUDOERS_FILE" >/dev/null
+echo "[5/9] Granting passwordless sudo to \$NEW_USER…"
+SUDOERS_FILE="/etc/sudoers.d/90-\$NEW_USER"
+cat > "\$SUDOERS_FILE" <<SUDOEOF
+# Bootstrap-installed: \$NEW_USER may run any command without a password.
+\$NEW_USER ALL=(ALL) NOPASSWD:ALL
+SUDOEOF
+chmod 0440 "\$SUDOERS_FILE"
+visudo -cf "\$SUDOERS_FILE" >/dev/null
 
-# ---- 6. SSH public key -----------------------------------------------------
+# ---- 6. SSH public key ----
 echo
-echo "[6/9] Installing SSH public key for $NEW_USER…"
-USER_HOME="/home/$NEW_USER"
-USER_SSH_DIR="$USER_HOME/.ssh"
-AUTH_KEYS="$USER_SSH_DIR/authorized_keys"
-
-install -d -m 0700 -o "$NEW_USER" -g "$NEW_USER" "$USER_SSH_DIR"
-touch "$AUTH_KEYS"
-if ! grep -qxF "$SSH_PUBKEY" "$AUTH_KEYS"; then
-    echo "$SSH_PUBKEY" >> "$AUTH_KEYS"
-    echo "  key appended to $AUTH_KEYS"
+echo "[6/9] Installing SSH public key for \$NEW_USER…"
+USER_SSH_DIR="/home/\$NEW_USER/.ssh"
+AUTH_KEYS="\$USER_SSH_DIR/authorized_keys"
+install -d -m 0700 -o "\$NEW_USER" -g "\$NEW_USER" "\$USER_SSH_DIR"
+touch "\$AUTH_KEYS"
+if ! grep -qxF "\$SSH_PUBKEY" "\$AUTH_KEYS"; then
+    echo "\$SSH_PUBKEY" >> "\$AUTH_KEYS"
+    echo "  key appended to \$AUTH_KEYS"
 else
     echo "  key already present — skipping"
 fi
-chmod 0600 "$AUTH_KEYS"
-chown "$NEW_USER:$NEW_USER" "$AUTH_KEYS"
-
-# Reset SELinux labels on the .ssh tree to whatever the policy says
-# they should be (ssh_home_t for the dir + authorized_keys). Files
-# created via shell redirection inherit the parent's context, which
-# is usually correct here, but `restorecon` makes failure deterministic
-# instead of "sometimes works, sometimes mysterious AVC denial".
+chmod 0600 "\$AUTH_KEYS"
+chown "\$NEW_USER:\$NEW_USER" "\$AUTH_KEYS"
 if command -v restorecon >/dev/null 2>&1; then
-    restorecon -R "$USER_SSH_DIR"
+    restorecon -R "\$USER_SSH_DIR"
 fi
 
-# ---- 7. Firewalld ----------------------------------------------------------
+# ---- 7. Firewalld ----
 echo
-echo "[7/9] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
-echo "      until you confirm the new port works — see banner at the end)…"
-firewall-cmd --permanent --add-port="$NEW_SSH_PORT/tcp" >/dev/null
+echo "[7/9] Opening firewall port \$NEW_SSH_PORT/tcp (port 22 stays open as a"
+echo "      safety net until you verify the new port works)…"
+firewall-cmd --permanent --add-port="\$NEW_SSH_PORT/tcp" >/dev/null
 firewall-cmd --reload >/dev/null
 
-# ---- 8. SELinux ssh_port_t label ------------------------------------------
+# ---- 8. SELinux ssh_port_t label ----
 echo
-echo "[8/9] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
-if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b$NEW_SSH_PORT\b"; then
-    echo "  port $NEW_SSH_PORT already labeled ssh_port_t — skipping"
+echo "[8/9] Labeling port \$NEW_SSH_PORT as ssh_port_t in SELinux…"
+if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b\$NEW_SSH_PORT\b"; then
+    echo "  port \$NEW_SSH_PORT already labeled ssh_port_t — skipping"
 else
-    semanage port -a -t ssh_port_t -p tcp "$NEW_SSH_PORT"
+    semanage port -a -t ssh_port_t -p tcp "\$NEW_SSH_PORT"
 fi
 
-# ---- 9. sshd hardening drop-in --------------------------------------------
+# ---- 9. sshd hardening drop-in ----
 echo
 echo "[9/9] Writing sshd hardening drop-in and restarting sshd…"
 SSHD_DROPIN="/etc/ssh/sshd_config.d/99-bootstrap.conf"
-cat > "$SSHD_DROPIN" <<EOF
+cat > "\$SSHD_DROPIN" <<SSHDEOF
 # Bootstrap-installed sshd hardening (see scripts/bootstrap-host.sh).
-Port $NEW_SSH_PORT
+Port \$NEW_SSH_PORT
 PermitRootLogin no
 PasswordAuthentication no
 KbdInteractiveAuthentication no
-EOF
-chmod 0600 "$SSHD_DROPIN"
-
-# Same insurance as for authorized_keys — if the policy expects
-# sshd_config_t in /etc/ssh/sshd_config.d/ (it does on RHEL 9),
-# restorecon makes the label deterministic so sshd can read it.
+SSHDEOF
+chmod 0600 "\$SSHD_DROPIN"
 if command -v restorecon >/dev/null 2>&1; then
-    restorecon "$SSHD_DROPIN"
+    restorecon "\$SSHD_DROPIN"
 fi
-
-# Validate config before restart
 sshd -t
-
 systemctl restart sshd
 
-# ---- Done ------------------------------------------------------------------
-HOST_IP=$(hostname -I | awk '{print $1}')
+echo
+echo "Remote hardening complete."
+PAYLOAD
+)
+EOF
+
+# ---- Phase 2: prompt user about external firewall --------------------------
 cat <<EOF
 
 ==================================================================
- Done.
+ Phase 2 — external firewall
 ==================================================================
 
-Verify in a SECOND terminal BEFORE closing this session:
+ sshd on $TARGET_HOST is now listening on port $NEW_SSH_PORT.
+ Local firewalld already has the new port open.
 
-    ssh -p $NEW_SSH_PORT $NEW_USER@$HOST_IP
+ If your host has an EXTERNAL firewall (cloud provider security
+ group, edge router rules, hosting-panel firewall, etc.):
 
-If that works, lock down by removing port 22 from the firewall:
+     • OPEN  port $NEW_SSH_PORT/tcp
+     • CLOSE port 22/tcp
 
-    firewall-cmd --permanent --remove-service=ssh
-    firewall-cmd --reload
+ If you have no external firewall, just press Enter — local
+ firewalld already covers port $NEW_SSH_PORT, and you can close
+ port 22 in local firewalld in phase 4.
 
-If you get locked out (e.g. firewall mistake), this current root
-session stays open; you can fix sshd_config from here.
+EOF
+
+read -r -p "Press Enter to continue with verification (Ctrl-C to abort)... " _
+
+# ---- Phase 3: verify new port works as the new user -----------------------
+echo
+echo "Phase 3 — verifying SSH on port $NEW_SSH_PORT as $NEW_USER@$TARGET_HOST …"
+if ssh -p "$NEW_SSH_PORT" \
+       -o ConnectTimeout=10 \
+       -o StrictHostKeyChecking=accept-new \
+       -o BatchMode=yes \
+       "$NEW_USER@$TARGET_HOST" \
+       'echo OK; hostnamectl --static 2>/dev/null | head -1' 2>&1 \
+    | sed 's/^/  /'; then
+    verified=true
+else
+    verified=false
+fi
+
+if ! "$verified"; then
+    cat <<EOF
+
+==================================================================
+ ✗ Verification failed.
+==================================================================
+
+ Couldn't connect to $NEW_USER@$TARGET_HOST on port $NEW_SSH_PORT.
+
+ Possible causes:
+   - External firewall not yet open on port $NEW_SSH_PORT
+   - Routing not yet propagated; wait a few seconds and retry
+   - Your private key isn't loaded; try: ssh-add -l
+
+ Try manually:
+     ssh -p $NEW_SSH_PORT $NEW_USER@$TARGET_HOST
+
+ Port 22 on the target is still open as a fallback. If everything
+ is broken, SSH back as root@$TARGET_HOST:22 and remove
+ /etc/ssh/sshd_config.d/99-bootstrap.conf.
+EOF
+    exit 1
+fi
+
+# ---- Phase 4: optionally close port 22 in local firewalld -----------------
+echo
+read -r -p "Close port 22 in the target's LOCAL firewalld now? [y/N] " close22
+if [[ "$close22" =~ ^[Yy]$ ]]; then
+    echo "  Closing port 22 via $NEW_USER@$TARGET_HOST:$NEW_SSH_PORT …"
+    ssh -p "$NEW_SSH_PORT" "$NEW_USER@$TARGET_HOST" \
+        'sudo firewall-cmd --permanent --remove-service=ssh && sudo firewall-cmd --reload' \
+        | sed 's/^/  /'
+    echo "  Port 22 removed from local firewalld."
+else
+    echo "  Skipped. Close it later with:"
+    echo "    ssh -p $NEW_SSH_PORT $NEW_USER@$TARGET_HOST 'sudo firewall-cmd --permanent --remove-service=ssh && sudo firewall-cmd --reload'"
+fi
+
+cat <<EOF
+
+==================================================================
+ ✓ Done.
+==================================================================
+
+ The host is now ready as an Ansible target.
+
+ Suggested ~/.ssh/config entry on this machine:
+
+   Host $TARGET_HOST
+     HostName $TARGET_HOST
+     User $NEW_USER
+     Port $NEW_SSH_PORT
+     IdentityFile ~/.ssh/id_ed25519
+
+ Then add to your inventory and deploy services with ansible-playbook.
 
 EOF

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -13,14 +13,15 @@
 # What it does:
 #   1. Updates the system and installs prerequisites (Python for Ansible,
 #      Podman, firewalld, SELinux tooling).
-#   2. Creates user `ds` with passwordless sudo.
-#   3. Installs your SSH public key for `ds` BEFORE password auth is
+#   2. Sets the console keymap to German (configurable via NEW_KEYMAP).
+#   3. Creates user `ds` with passwordless sudo.
+#   4. Installs your SSH public key for `ds` BEFORE password auth is
 #      disabled — without this you would be locked out.
-#   4. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
+#   5. Hardens sshd via /etc/ssh/sshd_config.d/ drop-in:
 #        - port 2343
 #        - disables root login
 #        - disables password authentication
-#   5. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
+#   6. Opens port 2343 in firewalld and labels it ssh_port_t in SELinux.
 #
 # What it deliberately does NOT do:
 #   - Close port 22 in the firewall. Test the new port first from a
@@ -42,6 +43,7 @@ set -euo pipefail
 # ---- Config ----------------------------------------------------------------
 NEW_USER="ds"
 NEW_SSH_PORT=2343
+NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
 
 # ---- Args ------------------------------------------------------------------
 SSH_PUBKEY="${1:-}"
@@ -78,12 +80,13 @@ echo "=================================================================="
 echo " Home-server host bootstrap"
 echo "   user:           $NEW_USER  (passwordless sudo)"
 echo "   ssh port:       $NEW_SSH_PORT"
+echo "   keymap:         $NEW_KEYMAP"
 echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
 echo "=================================================================="
 
 # ---- 1. System update + prerequisites --------------------------------------
 echo
-echo "[1/7] Updating system and installing prerequisites…"
+echo "[1/8] Updating system and installing prerequisites…"
 dnf -y update
 dnf -y install \
     sudo openssh-server \
@@ -94,18 +97,27 @@ dnf -y install \
 
 systemctl enable --now firewalld
 
-# ---- 2. Create user --------------------------------------------------------
+# ---- 2. Console keymap -----------------------------------------------------
 echo
-echo "[2/7] Creating user $NEW_USER…"
+echo "[2/8] Setting console keymap to $NEW_KEYMAP…"
+if localectl status 2>/dev/null | grep -q "^ *VC Keymap: $NEW_KEYMAP$"; then
+    echo "  already set to $NEW_KEYMAP — skipping"
+else
+    localectl set-keymap "$NEW_KEYMAP"
+fi
+
+# ---- 3. Create user --------------------------------------------------------
+echo
+echo "[3/8] Creating user $NEW_USER…"
 if id "$NEW_USER" >/dev/null 2>&1; then
     echo "  user $NEW_USER already exists — skipping"
 else
     useradd -m -s /bin/bash "$NEW_USER"
 fi
 
-# ---- 3. Sudo rights --------------------------------------------------------
+# ---- 4. Sudo rights --------------------------------------------------------
 echo
-echo "[3/7] Granting passwordless sudo to $NEW_USER…"
+echo "[4/8] Granting passwordless sudo to $NEW_USER…"
 SUDOERS_FILE="/etc/sudoers.d/90-$NEW_USER"
 cat > "$SUDOERS_FILE" <<EOF
 # Bootstrap-installed: $NEW_USER may run any command without a password.
@@ -117,9 +129,9 @@ chmod 0440 "$SUDOERS_FILE"
 # visudo -cf bails out non-zero on syntax errors
 visudo -cf "$SUDOERS_FILE" >/dev/null
 
-# ---- 4. SSH public key -----------------------------------------------------
+# ---- 5. SSH public key -----------------------------------------------------
 echo
-echo "[4/7] Installing SSH public key for $NEW_USER…"
+echo "[5/8] Installing SSH public key for $NEW_USER…"
 USER_HOME="/home/$NEW_USER"
 USER_SSH_DIR="$USER_HOME/.ssh"
 AUTH_KEYS="$USER_SSH_DIR/authorized_keys"
@@ -135,25 +147,25 @@ fi
 chmod 0600 "$AUTH_KEYS"
 chown "$NEW_USER:$NEW_USER" "$AUTH_KEYS"
 
-# ---- 5. Firewalld ----------------------------------------------------------
+# ---- 6. Firewalld ----------------------------------------------------------
 echo
-echo "[5/7] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
+echo "[6/8] Opening firewall port $NEW_SSH_PORT/tcp (port 22 is left open"
 echo "      until you confirm the new port works — see banner at the end)…"
 firewall-cmd --permanent --add-port="$NEW_SSH_PORT/tcp" >/dev/null
 firewall-cmd --reload >/dev/null
 
-# ---- 6. SELinux ssh_port_t label ------------------------------------------
+# ---- 7. SELinux ssh_port_t label ------------------------------------------
 echo
-echo "[6/7] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
+echo "[7/8] Labeling port $NEW_SSH_PORT as ssh_port_t in SELinux…"
 if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b$NEW_SSH_PORT\b"; then
     echo "  port $NEW_SSH_PORT already labeled ssh_port_t — skipping"
 else
     semanage port -a -t ssh_port_t -p tcp "$NEW_SSH_PORT"
 fi
 
-# ---- 7. sshd hardening drop-in --------------------------------------------
+# ---- 8. sshd hardening drop-in --------------------------------------------
 echo
-echo "[7/7] Writing sshd hardening drop-in and restarting sshd…"
+echo "[8/8] Writing sshd hardening drop-in and restarting sshd…"
 SSHD_DROPIN="/etc/ssh/sshd_config.d/99-bootstrap.conf"
 cat > "$SSHD_DROPIN" <<EOF
 # Bootstrap-installed sshd hardening (see scripts/bootstrap-host.sh).

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,47 +1,37 @@
 #!/bin/bash
 # ============================================================================
-# Bootstrap a fresh AlmaLinux 9 (or RHEL/Rocky 9) host as an Ansible target.
+# Open a path for Ansible to reach a fresh AlmaLinux 9 / RHEL 9 / Rocky 9 host.
 #
-# Run this script from your LAPTOP (or any Ansible-control machine).
-# It SSHs to the target as root on port 22 and performs all hardening
-# remotely. You never need to log into the host's console manually.
+# Run this from the Ansible control machine. The script SSHs to the target
+# as root on port 22, hardens sshd, creates an `ansible` user with sudo,
+# installs your SSH key, then verifies the new connection. Everything else
+# (packages, hostname, services) is the Ansible playbook's job from there.
 #
 # Prerequisites on the target:
 #   - Fresh OS install with sshd listening on port 22
-#   - Root login enabled with either a password or a key you control
+#   - Root login enabled (password or key — the script handles both)
+#   - python3 in /usr/bin (default on AlmaLinux 9; the script installs it
+#     if missing)
 #
 # Prerequisites on this machine:
 #   - bash, ssh
 #
 # Usage:
 #   bash scripts/bootstrap-host.sh -H <host> -k <ssh-pubkey> \
-#        [-u <user>] [-p <port>] [-n <hostname>]
-#
-# Required:
-#   -H <host>        Target hostname or IP (the new server)
-#   -k <pubkey>      SSH public key to install for the new user
-#
-# Optional:
-#   -u <user>        Linux username to create  (default: myuser)
-#   -p <port>        SSH port to harden onto   (default: 2222)
-#   -n <hostname>    Hostname to set on target (default: leave unchanged)
-#   -h               Show this help and exit
+#        [-u <user>] [-p <port>]
 #
 # Examples:
 #   bash bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
-#   bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" \
-#                          -u admin -p 2200 -n dnsvserver
+#   bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" -p 2200
 #
 # Flow:
-#   1. ssh root@<host>:22 → run hardening payload (system update,
-#      EPEL+bpytop, hostname, keymap, user+sudo, key install, firewalld
-#      open new port, SELinux port label, sshd hardening drop-in,
-#      restart sshd).
-#   2. Local prompt: "Update any external/provider firewall now —
-#      open <new-port>, close 22 — then press Enter."
-#   3. ssh -p <new-port> <user>@<host> → verify the hardened
-#      configuration works.
-#   4. Optionally close port 22 in the target's local firewalld.
+#   Phase 1: ssh root@<host>:22 → run the six-step hardening payload
+#            (ensure prereqs, create user+sudoers, install key, open port
+#            in firewalld+SELinux, write sshd drop-in, restart sshd).
+#   Phase 2: local prompt — update any EXTERNAL firewall (cloud security
+#            group, edge router, …) — open new port, close 22 — Enter.
+#   Phase 3: ssh -p <new-port> <user>@<host> → verify.
+#   Phase 4: optional — close port 22 in the target's local firewalld.
 # ============================================================================
 
 set -euo pipefail
@@ -49,86 +39,56 @@ set -euo pipefail
 # ---- Defaults --------------------------------------------------------------
 TARGET_HOST=""
 SSH_PUBKEY=""
-NEW_USER="myuser"
+NEW_USER="ansible"
 NEW_SSH_PORT=2222
-NEW_KEYMAP="de"
-NEW_HOSTNAME=""
 
 usage() {
     cat <<'EOF'
-Usage: bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+Usage: bootstrap-host.sh -H <host> -k <ssh-pubkey> [-u <user>] [-p <port>]
 
 Required:
-  -H <host>        Target hostname or IP (the new server)
-  -k <pubkey>      SSH public key (string) to install for the new user
+  -H <host>      Target hostname or IP
+  -k <pubkey>    SSH public key (string) to install for the new user
 
 Optional:
-  -u <user>        Linux username to create  (default: myuser)
-  -p <port>        SSH port to harden onto   (default: 2222)
-  -n <hostname>    Hostname to set on target (default: leave unchanged)
-  -h               Show this help and exit
+  -u <user>      Linux username to create  (default: ansible)
+  -p <port>      SSH port to harden onto   (default: 2222)
+  -h             Show this help and exit
 
 Examples:
   bash bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)"
-  bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" -u admin -p 2200 -n dnsvserver
+  bash bootstrap-host.sh -H new.example.com -k "$(cat key.pub)" -p 2200
 EOF
 }
 
 # ---- Args ------------------------------------------------------------------
-while getopts ":H:k:u:p:n:h" opt; do
+while getopts ":H:k:u:p:h" opt; do
     case "$opt" in
         H) TARGET_HOST="$OPTARG" ;;
         k) SSH_PUBKEY="$OPTARG" ;;
         u) NEW_USER="$OPTARG" ;;
         p) NEW_SSH_PORT="$OPTARG" ;;
-        n) NEW_HOSTNAME="$OPTARG" ;;
         h) usage; exit 0 ;;
         \?) echo "Error: invalid option -$OPTARG" >&2; usage >&2; exit 1 ;;
         :)  echo "Error: option -$OPTARG requires an argument" >&2; exit 1 ;;
     esac
 done
 shift $((OPTIND - 1))
-if [[ $# -gt 0 ]]; then
-    echo "Error: unexpected positional arguments: $*" >&2
-    usage >&2
-    exit 1
-fi
+[[ $# -gt 0 ]] && {
+    echo "Error: unexpected positional arguments: $*" >&2; usage >&2; exit 1
+}
 
-# Required
-if [[ -z "$TARGET_HOST" ]]; then
-    echo "Error: -H <host> is required." >&2
-    echo
-    usage >&2
-    exit 1
-fi
-if [[ -z "$SSH_PUBKEY" ]]; then
-    echo "Error: -k <ssh-pubkey> is required." >&2
-    echo
-    usage >&2
-    exit 1
-fi
+# ---- Validation ------------------------------------------------------------
+[[ -z "$TARGET_HOST" ]] && { echo "Error: -H <host> is required." >&2; usage >&2; exit 1; }
+[[ -z "$SSH_PUBKEY"  ]] && { echo "Error: -k <ssh-pubkey> is required." >&2; usage >&2; exit 1; }
 
-# Validate username
 if ! [[ "$NEW_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then
     echo "Error: invalid username '$NEW_USER' (must match ^[a-z_][a-z0-9_-]{0,31}\$)." >&2
     exit 1
 fi
-
-# Validate SSH port
-if ! [[ "$NEW_SSH_PORT" =~ ^[0-9]+$ ]] \
-    || [[ "$NEW_SSH_PORT" -lt 1 || "$NEW_SSH_PORT" -gt 65535 ]]; then
-    echo "Error: invalid SSH port '$NEW_SSH_PORT' (must be 1-65535)." >&2
-    exit 1
+if ! [[ "$NEW_SSH_PORT" =~ ^[0-9]+$ ]] || (( NEW_SSH_PORT < 1 || NEW_SSH_PORT > 65535 )); then
+    echo "Error: invalid SSH port '$NEW_SSH_PORT' (must be 1-65535)." >&2; exit 1
 fi
-
-# Validate hostname (RFC 1123) if one was provided
-if [[ -n "$NEW_HOSTNAME" ]] \
-    && ! [[ "$NEW_HOSTNAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]]; then
-    echo "Error: hostname '$NEW_HOSTNAME' contains characters not allowed (RFC 1123)." >&2
-    exit 1
-fi
-
-# Sanity-check the pubkey looks like one
 if ! [[ "$SSH_PUBKEY" =~ ^(ssh-(rsa|ed25519|ecdsa-sha2-nistp[0-9]+)|sk-(ssh-ed25519|ecdsa-sha2-nistp[0-9]+))@?[a-z0-9-]*\ [A-Za-z0-9+/=]+ ]]; then
     echo "Error: SSH_PUBKEY does not look like a valid public key." >&2
     echo "       Got: ${SSH_PUBKEY:0:60}..." >&2
@@ -136,168 +96,107 @@ if ! [[ "$SSH_PUBKEY" =~ ^(ssh-(rsa|ed25519|ecdsa-sha2-nistp[0-9]+)|sk-(ssh-ed25
 fi
 
 echo "=================================================================="
-echo " Home-server host bootstrap (remote driver)"
+echo " Open Ansible path on a fresh host"
 echo "   target:         root@$TARGET_HOST:22"
 echo "   new user:       $NEW_USER  (passwordless sudo)"
 echo "   new ssh port:   $NEW_SSH_PORT"
-echo "   keymap:         $NEW_KEYMAP"
-echo "   hostname:       ${NEW_HOSTNAME:-<unchanged>}"
 echo "   pubkey:         ${SSH_PUBKEY:0:50}…"
 echo "=================================================================="
 
-# ---- Phase 1: connect to root@host:22 and run the payload ------------------
-SSH_OPTS=(
-    -p 22
-    -o ConnectTimeout=10
-    -o StrictHostKeyChecking=accept-new
-    -o ServerAliveInterval=15
-)
+# ---- Phase 1: SSH root@host:22 and run the hardening payload ---------------
+SSH_OPTS=(-p 22 -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15)
 
 echo
 echo "Phase 1 — connecting to root@$TARGET_HOST:22 to run the hardening payload."
-echo "(If you don't have key auth as root, you'll be prompted for the password."
-echo " sshd is restarted onto port $NEW_SSH_PORT at the end of phase 1; the"
-echo " existing connection on port 22 stays alive even after the restart.)"
+echo "(If you don't have key auth as root, you'll be prompted for the password.)"
 echo
 
-# The remote payload uses these variables, set as a preamble. We use
-# printf %q to safely quote the values so any whitespace, quotes, or
-# special characters in the pubkey survive intact across SSH.
 ssh "${SSH_OPTS[@]}" "root@$TARGET_HOST" bash -s <<EOF
 SSH_PUBKEY=$(printf %q "$SSH_PUBKEY")
 NEW_USER=$(printf %q "$NEW_USER")
 NEW_SSH_PORT=$NEW_SSH_PORT
-NEW_HOSTNAME=$(printf %q "$NEW_HOSTNAME")
-NEW_KEYMAP=$(printf %q "$NEW_KEYMAP")
 $(cat <<'PAYLOAD'
 set -euo pipefail
 
-if [[ "\$EUID" -ne 0 ]]; then
-    echo "Error: must run as root on the target." >&2
-    exit 1
+[[ "\$EUID" -eq 0 ]] || { echo "Error: must run as root on the target." >&2; exit 1; }
+
+# ---- 1. Prerequisites ----
+# python3, firewalld, and SELinux's `semanage` are the bare minimum to do
+# the rest of the steps below and let Ansible take over from here.
+echo "[1/6] Ensuring prerequisites (python3, firewalld, semanage) are installed…"
+missing=()
+command -v python3       >/dev/null 2>&1 || missing+=(python3)
+command -v firewall-cmd  >/dev/null 2>&1 || missing+=(firewalld)
+command -v semanage      >/dev/null 2>&1 || missing+=(policycoreutils-python-utils)
+if (( \${#missing[@]} )); then
+    echo "  installing: \${missing[*]}"
+    dnf -y install "\${missing[@]}"
+else
+    echo "  all prerequisites present"
 fi
 
-# SELinux pre-flight (warn-only)
-if command -v getenforce >/dev/null 2>&1; then
-    selinux_mode=\$(getenforce 2>/dev/null || true)
-    if [[ "\$selinux_mode" != "Enforcing" ]]; then
-        echo
-        echo "  WARNING: SELinux is '\$selinux_mode' (expected Enforcing)."
-        echo "           Continuing anyway, but the system is less protected."
-        echo
-    fi
-fi
-
-# ---- 1. System update + prerequisites ----
-echo
-echo "[1/9] Enabling EPEL, updating, installing prerequisites…"
-dnf -y install epel-release
-dnf -y update
-dnf -y install \
-    sudo openssh-server \
-    python3 python3-pip \
-    policycoreutils-python-utils \
-    firewalld \
-    podman \
-    bpytop
+# ---- 2. firewalld active ----
+echo "[2/6] Ensuring firewalld is enabled and running…"
 systemctl enable --now firewalld
 
-# ---- 2. Hostname ----
-echo
-echo "[2/9] Setting hostname…"
-if [[ -z "\$NEW_HOSTNAME" ]]; then
-    echo "  (no hostname argument given — keeping current: \$(hostname))"
-elif [[ "\$(hostnamectl --static 2>/dev/null)" == "\$NEW_HOSTNAME" ]]; then
-    echo "  hostname already \$NEW_HOSTNAME — skipping"
-else
-    hostnamectl set-hostname "\$NEW_HOSTNAME"
-    echo "  hostname set to \$NEW_HOSTNAME"
-fi
-
-# ---- 3. Console keymap ----
-echo
-echo "[3/9] Setting console keymap to \$NEW_KEYMAP…"
-if localectl status 2>/dev/null | grep -q "^ *VC Keymap: \$NEW_KEYMAP\$"; then
-    echo "  already set to \$NEW_KEYMAP — skipping"
-else
-    localectl set-keymap "\$NEW_KEYMAP"
-fi
-
-# ---- 4. Create user ----
-echo
-echo "[4/9] Creating user \$NEW_USER…"
+# ---- 3. User + sudoers ----
+echo "[3/6] Creating user \$NEW_USER with passwordless sudo…"
 if id "\$NEW_USER" >/dev/null 2>&1; then
-    echo "  user \$NEW_USER already exists — skipping"
+    echo "  user \$NEW_USER already exists — skipping useradd"
 else
     useradd -m -s /bin/bash "\$NEW_USER"
 fi
-
-# ---- 5. Sudo rights ----
-echo
-echo "[5/9] Granting passwordless sudo to \$NEW_USER…"
 SUDOERS_FILE="/etc/sudoers.d/90-\$NEW_USER"
-cat > "\$SUDOERS_FILE" <<SUDOEOF
+cat > "\$SUDOERS_FILE" <<SUDO
 # Bootstrap-installed: \$NEW_USER may run any command without a password.
 \$NEW_USER ALL=(ALL) NOPASSWD:ALL
-SUDOEOF
+SUDO
 chmod 0440 "\$SUDOERS_FILE"
 visudo -cf "\$SUDOERS_FILE" >/dev/null
 
-# ---- 6. SSH public key ----
-echo
-echo "[6/9] Installing SSH public key for \$NEW_USER…"
+# ---- 4. SSH public key ----
+echo "[4/6] Installing SSH public key…"
 USER_SSH_DIR="/home/\$NEW_USER/.ssh"
 AUTH_KEYS="\$USER_SSH_DIR/authorized_keys"
 install -d -m 0700 -o "\$NEW_USER" -g "\$NEW_USER" "\$USER_SSH_DIR"
 touch "\$AUTH_KEYS"
-if ! grep -qxF "\$SSH_PUBKEY" "\$AUTH_KEYS"; then
+if grep -qxF "\$SSH_PUBKEY" "\$AUTH_KEYS"; then
+    echo "  key already present — skipping"
+else
     echo "\$SSH_PUBKEY" >> "\$AUTH_KEYS"
     echo "  key appended to \$AUTH_KEYS"
-else
-    echo "  key already present — skipping"
 fi
 chmod 0600 "\$AUTH_KEYS"
 chown "\$NEW_USER:\$NEW_USER" "\$AUTH_KEYS"
-if command -v restorecon >/dev/null 2>&1; then
-    restorecon -R "\$USER_SSH_DIR"
-fi
+command -v restorecon >/dev/null && restorecon -R "\$USER_SSH_DIR"
 
-# ---- 7. Firewalld ----
-echo
-echo "[7/9] Opening firewall port \$NEW_SSH_PORT/tcp (port 22 stays open as a"
-echo "      safety net until you verify the new port works)…"
+# ---- 5. Open new SSH port (firewalld + SELinux) ----
+echo "[5/6] Opening port \$NEW_SSH_PORT/tcp in firewalld and labeling ssh_port_t in SELinux…"
 firewall-cmd --permanent --add-port="\$NEW_SSH_PORT/tcp" >/dev/null
 firewall-cmd --reload >/dev/null
-
-# ---- 8. SELinux ssh_port_t label ----
-echo
-echo "[8/9] Labeling port \$NEW_SSH_PORT as ssh_port_t in SELinux…"
 if semanage port -l | grep -qE "ssh_port_t\s+tcp\s+.*\b\$NEW_SSH_PORT\b"; then
     echo "  port \$NEW_SSH_PORT already labeled ssh_port_t — skipping"
 else
     semanage port -a -t ssh_port_t -p tcp "\$NEW_SSH_PORT"
 fi
 
-# ---- 9. sshd hardening drop-in ----
-echo
-echo "[9/9] Writing sshd hardening drop-in and restarting sshd…"
+# ---- 6. sshd drop-in + restart ----
+echo "[6/6] Writing sshd hardening drop-in and restarting sshd…"
 SSHD_DROPIN="/etc/ssh/sshd_config.d/99-bootstrap.conf"
-cat > "\$SSHD_DROPIN" <<SSHDEOF
+cat > "\$SSHD_DROPIN" <<SSHD
 # Bootstrap-installed sshd hardening (see scripts/bootstrap-host.sh).
 Port \$NEW_SSH_PORT
 PermitRootLogin no
 PasswordAuthentication no
 KbdInteractiveAuthentication no
-SSHDEOF
+SSHD
 chmod 0600 "\$SSHD_DROPIN"
-if command -v restorecon >/dev/null 2>&1; then
-    restorecon "\$SSHD_DROPIN"
-fi
+command -v restorecon >/dev/null && restorecon "\$SSHD_DROPIN"
 sshd -t
 systemctl restart sshd
 
 echo
-echo "Remote hardening complete."
+echo "Remote hardening complete. Port 22 in local firewalld stays open as a fallback."
 PAYLOAD
 )
 EOF
@@ -310,38 +209,28 @@ cat <<EOF
 ==================================================================
 
  sshd on $TARGET_HOST is now listening on port $NEW_SSH_PORT.
- Local firewalld already has the new port open.
+ The host's local firewalld already has the new port open.
 
- If your host has an EXTERNAL firewall (cloud provider security
- group, edge router rules, hosting-panel firewall, etc.):
+ If the host has an EXTERNAL firewall (cloud provider security
+ group, edge router, hosting-panel firewall):
 
      • OPEN  port $NEW_SSH_PORT/tcp
      • CLOSE port 22/tcp
 
- If you have no external firewall, just press Enter — local
- firewalld already covers port $NEW_SSH_PORT, and you can close
- port 22 in local firewalld in phase 4.
+ If you have no external firewall, just press Enter — port 22 in
+ local firewalld stays open until phase 4.
 
 EOF
-
 read -r -p "Press Enter to continue with verification (Ctrl-C to abort)... " _
 
-# ---- Phase 3: verify new port works as the new user -----------------------
+# ---- Phase 3: verify -------------------------------------------------------
 echo
-echo "Phase 3 — verifying SSH on port $NEW_SSH_PORT as $NEW_USER@$TARGET_HOST …"
-if ssh -p "$NEW_SSH_PORT" \
-       -o ConnectTimeout=10 \
-       -o StrictHostKeyChecking=accept-new \
-       -o BatchMode=yes \
-       "$NEW_USER@$TARGET_HOST" \
-       'echo OK; hostnamectl --static 2>/dev/null | head -1' 2>&1 \
-    | sed 's/^/  /'; then
-    verified=true
+echo "Phase 3 — verifying ssh -p $NEW_SSH_PORT $NEW_USER@$TARGET_HOST…"
+if ssh -p "$NEW_SSH_PORT" -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
+       -o BatchMode=yes "$NEW_USER@$TARGET_HOST" \
+       'echo "  OK as $(whoami) on $(hostnamectl --static 2>/dev/null || hostname)"' 2>&1; then
+    :
 else
-    verified=false
-fi
-
-if ! "$verified"; then
     cat <<EOF
 
 ==================================================================
@@ -350,17 +239,17 @@ if ! "$verified"; then
 
  Couldn't connect to $NEW_USER@$TARGET_HOST on port $NEW_SSH_PORT.
 
- Possible causes:
+ Likely causes:
    - External firewall not yet open on port $NEW_SSH_PORT
-   - Routing not yet propagated; wait a few seconds and retry
-   - Your private key isn't loaded; try: ssh-add -l
+   - Your private key isn't in your ssh-agent (try: ssh-add -l)
+   - Routing/IP propagation delay; wait and retry
 
  Try manually:
      ssh -p $NEW_SSH_PORT $NEW_USER@$TARGET_HOST
 
- Port 22 on the target is still open as a fallback. If everything
- is broken, SSH back as root@$TARGET_HOST:22 and remove
- /etc/ssh/sshd_config.d/99-bootstrap.conf.
+ Port 22 on the target is still open as a fallback. SSH back as
+ root@$TARGET_HOST:22 and remove /etc/ssh/sshd_config.d/99-bootstrap.conf
+ to undo if needed.
 EOF
     exit 1
 fi
@@ -369,7 +258,7 @@ fi
 echo
 read -r -p "Close port 22 in the target's LOCAL firewalld now? [y/N] " close22
 if [[ "$close22" =~ ^[Yy]$ ]]; then
-    echo "  Closing port 22 via $NEW_USER@$TARGET_HOST:$NEW_SSH_PORT …"
+    echo "  Closing port 22 via $NEW_USER@$TARGET_HOST:$NEW_SSH_PORT…"
     ssh -p "$NEW_SSH_PORT" "$NEW_USER@$TARGET_HOST" \
         'sudo firewall-cmd --permanent --remove-service=ssh && sudo firewall-cmd --reload' \
         | sed 's/^/  /'
@@ -382,10 +271,8 @@ fi
 cat <<EOF
 
 ==================================================================
- ✓ Done.
+ ✓ Done. Hand off to Ansible from here.
 ==================================================================
-
- The host is now ready as an Ansible target.
 
  Suggested ~/.ssh/config entry on this machine:
 
@@ -395,6 +282,8 @@ cat <<EOF
      Port $NEW_SSH_PORT
      IdentityFile ~/.ssh/id_ed25519
 
- Then add to your inventory and deploy services with ansible-playbook.
+ Sanity check:
+   ansible -i <inventory> -m ping <host>
 
+ Then deploy with ansible-playbook.
 EOF

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -5,14 +5,20 @@
 # Run as root on a fresh install. Idempotent — safe to re-run.
 #
 # Usage:
-#   bash scripts/bootstrap-host.sh "<ssh-pubkey>" [hostname]
+#   bash scripts/bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
+#
+# Required:
+#   -k <pubkey>      SSH public key (string) to install for the new user
+#
+# Optional:
+#   -u <user>        Linux username to create (default: ds)
+#   -p <port>        SSH port to harden onto         (default: 2343)
+#   -n <hostname>    Hostname to set                 (default: leave unchanged)
+#   -h               Show this help and exit
 #
 # Examples:
-#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
-#   bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)" dnsvserver
-#
-# The hostname argument is optional; if omitted, the current hostname is
-# kept.
+#   bash scripts/bootstrap-host.sh -k "$(cat ~/.ssh/id_ed25519.pub)"
+#   bash scripts/bootstrap-host.sh -k "$(cat key.pub)" -u admin -p 2222 -n dnsvserver
 #
 # What it does:
 #   1. Enables EPEL, updates the system, installs prerequisites
@@ -56,33 +62,75 @@
 
 set -euo pipefail
 
-# ---- Config ----------------------------------------------------------------
+# ---- Defaults --------------------------------------------------------------
 NEW_USER="ds"
 NEW_SSH_PORT=2343
 NEW_KEYMAP="de"   # console (TTY) keymap — see `localectl list-keymaps`
+SSH_PUBKEY=""
+NEW_HOSTNAME=""
 
-# ---- Args ------------------------------------------------------------------
-SSH_PUBKEY="${1:-}"
-NEW_HOSTNAME="${2:-}"
+usage() {
+    cat <<'EOF'
+Usage: bootstrap-host.sh -k <ssh-pubkey> [-u <user>] [-p <port>] [-n <hostname>]
 
-if [[ -z "$SSH_PUBKEY" ]]; then
-    cat <<'EOF' >&2
-Error: SSH public key required.
+Required:
+  -k <pubkey>      SSH public key (string) to install for the new user
 
-Usage:
-  bash scripts/bootstrap-host.sh "<ssh-public-key>" [hostname]
+Optional:
+  -u <user>        Linux username to create  (default: ds)
+  -p <port>        SSH port to harden onto   (default: 2343)
+  -n <hostname>    Hostname to set           (default: leave unchanged)
+  -h               Show this help and exit
 
 Examples:
-  bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
-  bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)" dnsvserver
-
-The key is installed for the new user BEFORE password auth is disabled.
-Without this, you would be locked out as soon as sshd is restarted.
+  bash bootstrap-host.sh -k "$(cat ~/.ssh/id_ed25519.pub)"
+  bash bootstrap-host.sh -k "$(cat key.pub)" -u admin -p 2222 -n dnsvserver
 EOF
+}
+
+# ---- Args ------------------------------------------------------------------
+while getopts ":k:u:p:n:h" opt; do
+    case "$opt" in
+        k) SSH_PUBKEY="$OPTARG" ;;
+        u) NEW_USER="$OPTARG" ;;
+        p) NEW_SSH_PORT="$OPTARG" ;;
+        n) NEW_HOSTNAME="$OPTARG" ;;
+        h) usage; exit 0 ;;
+        \?) echo "Error: invalid option -$OPTARG" >&2; usage >&2; exit 1 ;;
+        :)  echo "Error: option -$OPTARG requires an argument" >&2; exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+if [[ $# -gt 0 ]]; then
+    echo "Error: unexpected positional arguments: $*" >&2
+    usage >&2
     exit 1
 fi
 
-# Hostname format: letters, digits, dashes; dots allowed for FQDN-style.
+# Required: pubkey
+if [[ -z "$SSH_PUBKEY" ]]; then
+    echo "Error: -k <ssh-pubkey> is required." >&2
+    echo
+    usage >&2
+    exit 1
+fi
+
+# Validate username (POSIX/RHEL-friendly subset)
+if ! [[ "$NEW_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then
+    echo "Error: invalid username '$NEW_USER'." >&2
+    echo "       Must start with a lowercase letter or underscore," >&2
+    echo "       contain only [a-z0-9_-], and be 1-32 characters." >&2
+    exit 1
+fi
+
+# Validate SSH port (integer 1-65535)
+if ! [[ "$NEW_SSH_PORT" =~ ^[0-9]+$ ]] \
+    || [[ "$NEW_SSH_PORT" -lt 1 || "$NEW_SSH_PORT" -gt 65535 ]]; then
+    echo "Error: invalid SSH port '$NEW_SSH_PORT' (must be 1-65535)." >&2
+    exit 1
+fi
+
+# Validate hostname (RFC 1123) if one was provided
 if [[ -n "$NEW_HOSTNAME" ]] \
     && ! [[ "$NEW_HOSTNAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]]; then
     echo "Error: hostname '$NEW_HOSTNAME' contains characters not allowed (RFC 1123)." >&2


### PR DESCRIPTION
## Summary
- New helper script `scripts/bootstrap-host.sh` that prepares a fresh AlmaLinux 9 (or RHEL/Rocky 9) install to be managed by this project's Ansible.
- Symmetric to the existing `setup.sh` (which sets up the control machine).

## What it does

1. Installs prerequisites — Python (Ansible deps), Podman, firewalld, SELinux tooling, sudo, openssh-server.
2. Creates the `ds` user with passwordless sudo (matches project convention for Ansible-managed hosts).
3. Installs the caller's SSH public key for `ds` **before** password auth is disabled.
4. Hardens sshd via a `/etc/ssh/sshd_config.d/` drop-in: port 2343, no root login, no password auth.
5. Opens port 2343 in firewalld and labels it `ssh_port_t` in SELinux.

Deliberately does **not** close port 22 — leaves that as a manual step after the user verifies `ssh -p 2343` works from a second terminal. Same belt-and-braces pattern as the rest of this project.

## Usage

```bash
# On the fresh AlmaLinux host, as root:
bash scripts/bootstrap-host.sh "$(cat ~/.ssh/id_ed25519.pub)"
```

## Test plan
- [x] `bash -n scripts/bootstrap-host.sh` syntax-clean (verified locally)
- [x] Run on a freshly-installed AlmaLinux 9 VM with a known pubkey arg
- [x] Verify `ssh -p 2343 ds@<host>` works with key auth, password auth refused
- [x] Verify root SSH refused
- [x] Re-run the script; confirms idempotency (skips existing user/key/sudoers/port)
- [x] `firewall-cmd --list-all` shows port 2343/tcp open
- [x] `semanage port -l | grep ssh_port_t` shows 2343 listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)