### PR TITLE
Add os-base role for OS-baseline configuration

### DIFF
--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -19,7 +19,7 @@ roles. Idempotent — safe to re-run.
 ## Quick start
 
 ```bash
-bash scripts/bootstrap-host.sh -H 1.2.3.4 -k "$(cat ~/.ssh/id_ed25519.pub)" -p 2222
+curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/refs/heads/main/scripts/bootstrap-host.sh | bash -s -- -H 1.2.3.4 -p 2222 -k "$(cat ~/.ssh/id_ed25519.pub)"
 ```
 
 The script SSHs from your laptop to `root@1.2.3.4:22` (password or key

--- a/playbooks/os-base.yml
+++ b/playbooks/os-base.yml
@@ -1,0 +1,18 @@
+---
+# Apply only the os-base role.
+#
+# Useful for:
+#   - First-touch on a freshly-bootstrapped host before any service
+#     roles get involved
+#   - Re-running just the baseline (security updates config, common
+#     packages, system DNS, locale) without touching service state
+#
+# Targets every host in inventory by default. Use --limit to scope:
+#
+#   ansible-playbook -i inventory/hosts.yml playbooks/os-base.yml --limit dnsvserver
+- name: Apply os-base baseline
+  hosts: all
+  become: false
+  gather_facts: true
+  roles:
+    - { role: os-base }

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -39,6 +39,7 @@
           web UI becomes unreachable.
 
   roles:
+    - { role: os-base }
     - { role: caddy }
     - { role: dashboard,     when: "'dashboard' in (deploy_services | default([]))" }
     - { role: pihole,        when: "'pihole' in (deploy_services | default([]))" }

--- a/roles/os-base/README.md
+++ b/roles/os-base/README.md
@@ -17,12 +17,14 @@ guarantee.
 | Distro | Notes |
 |---|---|
 | **Fedora Server** (any current release) | Default repo already ships podman 5; nothing extra needed. |
-| **AlmaLinux 9 / Rocky 9 / CentOS Stream 9 / RHEL 9** | Default repo only has podman 4.x. Role enables the upstream `rhcontainerbot/podman-next` COPR so `dnf install podman` resolves to 5.x — keeps quadlet / AutoUpdate behavior consistent with Fedora hosts. |
+| **AlmaLinux 9 / Rocky 9 / CentOS Stream 9 / RHEL 9** | 9.4+ ships podman 5.x in stock `appstream`. No extra repo needed by default. Set `os_base_podman_extra_repo: "rhcontainerbot/podman-next"` only if you want the upstream pre-release COPR (currently 6.0.0-dev). |
 
 ## Tasks (in order, all idempotent)
 
-1. **podman 5 source** — enable `rhcontainerbot/podman-next` COPR on
-   AlmaLinux/Rocky/CentOS 9. Skipped on Fedora.
+1. **podman 5 source** — only when `os_base_podman_extra_repo` is
+   set. Off by default (AL9.4+ stock repo already has 5.x). Set
+   the variable to e.g. `rhcontainerbot/podman-next` to opt into
+   the upstream pre-release COPR.
 2. **Common packages** — `bash-completion`, `vim-enhanced`, `tmux`,
    `tree`, `jq`, `wget`, `curl`, `rsync`, `git`, `podman`.
    Configurable list. (`bpytop` lives in EPEL; intentionally not in
@@ -49,7 +51,7 @@ See `defaults/main.yml`. Notable knobs:
 | Variable | Default | Purpose |
 |---|---|---|
 | `os_base_packages` | listed above | Override or extend in host_vars. |
-| `os_base_podman_extra_repo` | `rhcontainerbot/podman-next` | Set to `""` to skip COPR on RHEL-family (stay on podman 4.x). |
+| `os_base_podman_extra_repo` | `""` | Set to e.g. `rhcontainerbot/podman-next` to enable the upstream pre-release COPR on RHEL-family. Stock repo on AL9.4+ already has podman 5.x. |
 | `os_base_dnf_automatic_enabled` | `true` | Set to `false` per-host to opt out of auto security updates. |
 | `os_base_dnf_automatic_apply` | `security` | Or `default` for everything. |
 | `os_base_dns_servers` | Mullvad base IPv4+IPv6 | Set to `[]` to skip the resolved drop-in. |

--- a/roles/os-base/README.md
+++ b/roles/os-base/README.md
@@ -1,0 +1,88 @@
+# os-base
+
+Universal OS-baseline configuration for every host this project
+manages. Runs unconditionally as the **first** role in
+`playbooks/site.yml`.
+
+The bootstrap script (`scripts/bootstrap-host.sh`) just opens an
+Ansible path; this role is the next layer down: common tools,
+security updates, podman 5, system DNS, locale, hostname.
+
+Service roles (caddy, pihole, jellyfin, …) assume podman and the
+common tools are present once they run — `os-base` provides that
+guarantee.
+
+## Supported distros
+
+| Distro | Notes |
+|---|---|
+| **Fedora Server** (any current release) | Default repo already ships podman 5; nothing extra needed. |
+| **AlmaLinux 9 / Rocky 9 / CentOS Stream 9 / RHEL 9** | Default repo only has podman 4.x. Role enables the upstream `rhcontainerbot/podman-next` COPR so `dnf install podman` resolves to 5.x — keeps quadlet / AutoUpdate behavior consistent with Fedora hosts. |
+
+## Tasks (in order, all idempotent)
+
+1. **podman 5 source** — enable `rhcontainerbot/podman-next` COPR on
+   AlmaLinux/Rocky/CentOS 9. Skipped on Fedora.
+2. **Common packages** — `bash-completion`, `vim-enhanced`, `tmux`,
+   `bpytop`, `tree`, `jq`, `wget`, `curl`, `rsync`, `git`, `podman`.
+   Configurable list.
+3. **dnf-automatic** — installs and enables, configured for
+   security-only updates, log to journal.
+4. **Shell aliases** — `/etc/profile.d/zz-aliases.sh` (ll, la, ..,
+   colors, systemd shortcuts).
+5. **Timezone** — default `Europe/Berlin`.
+6. **Console keymap** — default `de`.
+7. **Hostname** — defaults to `inventory_hostname`.
+8. **Rootful `podman-auto-update.timer`** — enabled.
+9. **System DNS via systemd-resolved** — Mullvad base DNS
+   (`base.dns.mullvad.net`, `194.242.2.4` / `2a07:e340::4`) with
+   DoT. Pi-hole hosts get a higher-priority `20-pihole.conf`
+   drop-in from the pihole role that supersedes this — net
+   effect on those hosts is unchanged.
+
+## Variables
+
+See `defaults/main.yml`. Notable knobs:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `os_base_packages` | listed above | Override or extend in host_vars. |
+| `os_base_podman_extra_repo` | `rhcontainerbot/podman-next` | Set to `""` to skip COPR on RHEL-family (stay on podman 4.x). |
+| `os_base_dnf_automatic_enabled` | `true` | Set to `false` per-host to opt out of auto security updates. |
+| `os_base_dnf_automatic_apply` | `security` | Or `default` for everything. |
+| `os_base_dns_servers` | Mullvad base IPv4+IPv6 | Set to `[]` to skip the resolved drop-in. |
+| `os_base_dns_hostname` | `base.dns.mullvad.net` | DoT SNI hostname. |
+| `os_base_dns_over_tls` | `true` | Set to `false` for plain DNS. |
+| `os_base_aliases_enabled` | `true` | Set to `false` to skip the profile.d drop. |
+| `os_base_timezone` | `Europe/Berlin` | Any tz database name. |
+| `os_base_keymap` | `de` | Any keymap from `localectl list-keymaps`. |
+| `os_base_hostname` | `inventory_hostname` | Override only when OS hostname must differ from Ansible inventory name. |
+
+## Verifying the host
+
+After a deploy:
+
+```bash
+systemctl is-enabled dnf-automatic-install.timer    # → enabled
+podman --version                                    # → podman version 5.x.x
+timedatectl | grep "Time zone"                      # → Europe/Berlin
+localectl status | grep "VC Keymap"                 # → VC Keymap: de
+hostnamectl --static                                # matches inventory
+resolvectl status | grep "DNS Servers"              # Mullvad on non-Pi-hole hosts
+ll                                                  # alias works in fresh shell
+```
+
+To confirm DNS is actually hitting Mullvad on a non-Pi-hole host:
+
+```bash
+resolvectl query --type=TXT id.dns.mullvad.net
+```
+
+## Deferred work (separate PRs)
+
+- Refactor the 7 service roles that duplicate the rootless-user +
+  linger + per-user `podman-auto-update.timer` block. Move that
+  pattern into a reusable `tasks/create_rootless_user.yml` here and
+  have service roles `include_tasks` it.
+- Add Debian/Ubuntu support (alternate task file gated on
+  `ansible_os_family`). Not needed yet — every host runs RHEL family.

--- a/roles/os-base/README.md
+++ b/roles/os-base/README.md
@@ -24,8 +24,10 @@ guarantee.
 1. **podman 5 source** — enable `rhcontainerbot/podman-next` COPR on
    AlmaLinux/Rocky/CentOS 9. Skipped on Fedora.
 2. **Common packages** — `bash-completion`, `vim-enhanced`, `tmux`,
-   `bpytop`, `tree`, `jq`, `wget`, `curl`, `rsync`, `git`, `podman`.
-   Configurable list.
+   `tree`, `jq`, `wget`, `curl`, `rsync`, `git`, `podman`.
+   Configurable list. (`bpytop` lives in EPEL; intentionally not in
+   the default set so this role doesn't drag EPEL onto every host.
+   Add it per-host via `os_base_packages: ["{{ os_base_packages | default([]) }} + ['bpytop']" }}` after enabling EPEL yourself if you want it.)
 3. **dnf-automatic** — installs and enables, configured for
    security-only updates, log to journal.
 4. **Shell aliases** — `/etc/profile.d/zz-aliases.sh` (ll, la, ..,

--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -24,12 +24,12 @@ os_base_packages:
   - git
   - podman
 
-# Source for podman 5 on AlmaLinux/Rocky/CentOS 9. Default repo on
-# those distros only ships podman 4.x; this COPR (run by the upstream
-# Podman team) provides 5.x. Skipped on Fedora (already 5.x). Set
-# to empty string to disable (e.g. host has podman 5 from elsewhere,
-# or you want to stay on 4.x).
-os_base_podman_extra_repo: "rhcontainerbot/podman-next"
+# Extra podman repo on AlmaLinux/Rocky/CentOS 9. Empty by default:
+# AL9.4+ ships podman 5.x in stock `appstream`, so no COPR needed.
+# Set to e.g. "rhcontainerbot/podman-next" only if you specifically
+# want pre-release builds — note that COPR ships 6.0.0-dev now, not
+# stable 5.x. Skipped on Fedora regardless (already has podman 5).
+os_base_podman_extra_repo: ""
 
 # Automatic security updates via dnf-automatic.
 os_base_dnf_automatic_enabled: true

--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -1,0 +1,55 @@
+---
+# Common packages to install on every host. Override / extend in
+# host_vars to add or remove. The defaults aim for "useful CLI tools
+# any homelab host would want."
+os_base_packages:
+  - bash-completion
+  - vim-enhanced
+  - tmux
+  - bpytop
+  - tree
+  - jq
+  - wget
+  - curl
+  - rsync
+  - git
+  - podman
+
+# Source for podman 5 on AlmaLinux/Rocky/CentOS 9. Default repo on
+# those distros only ships podman 4.x; this COPR (run by the upstream
+# Podman team) provides 5.x. Skipped on Fedora (already 5.x). Set
+# to empty string to disable (e.g. host has podman 5 from elsewhere,
+# or you want to stay on 4.x).
+os_base_podman_extra_repo: "rhcontainerbot/podman-next"
+
+# Automatic security updates via dnf-automatic.
+os_base_dnf_automatic_enabled: true
+os_base_dnf_automatic_apply: security        # vs default which includes everything
+os_base_dnf_automatic_email: ""              # empty -> log to journal only
+
+# System DNS via systemd-resolved. Default: Mullvad base DNS (privacy +
+# basic ad-blocking, DoT-capable). The pihole role overrides this with
+# a higher-priority drop-in pointing at 127.0.0.1:1053 wherever Pi-hole
+# is deployed. Set to [] to skip the drop-in (host then uses whatever
+# DHCP / NetworkManager pushed).
+os_base_dns_servers:
+  - "194.242.2.4"           # base.dns.mullvad.net (IPv4)
+  - "2a07:e340::4"          # base.dns.mullvad.net (IPv6)
+os_base_dns_hostname: "base.dns.mullvad.net"   # for DoT SNI
+os_base_dns_over_tls: true                     # set false to skip DoT
+
+# Drop /etc/profile.d/zz-aliases.sh with a small set of sensible
+# defaults (ll, la, .., ls/grep colors).
+os_base_aliases_enabled: true
+
+# Timezone. Override per-host if a server lives in a different region.
+os_base_timezone: "Europe/Berlin"
+
+# Console keymap. Cosmetic on headless servers but matches the
+# bootstrap script's default for consistency.
+os_base_keymap: "de"
+
+# Hostname to set via hostnamectl. Leave unset to fall back to
+# `inventory_hostname` (most hosts). Override in host_vars when the
+# OS hostname should differ from the Ansible inventory name.
+# os_base_hostname: ""

--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -32,6 +32,10 @@ os_base_packages:
 os_base_podman_extra_repo: ""
 
 # Automatic security updates via dnf-automatic.
+# Number of kernels to keep installed. Default in dnf is 3 (current
+# + 2 fallbacks). Set lower on disk-tight hosts; 0 disables the cap.
+os_base_installonly_limit: 2
+
 os_base_dnf_automatic_enabled: true
 os_base_dnf_automatic_apply: security        # vs default which includes everything
 os_base_dnf_automatic_email: ""              # empty -> log to journal only

--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -2,11 +2,20 @@
 # Common packages to install on every host. Override / extend in
 # host_vars to add or remove. The defaults aim for "useful CLI tools
 # any homelab host would want."
+# Swap. On small vservers (~1 GB RAM) dnf transactions and podman
+# can spike RAM and trigger the OOM-killer, taking out sshd or other
+# essential services. Ensure a swap file at `os_base_swap_file` of at
+# least `os_base_swap_size_mb` MB. Set the size to 0 to skip swap
+# management entirely (recommended for hosts with plenty of RAM where
+# you'd prefer no swap at all).
+os_base_swap_size_mb: 512
+os_base_swap_file: /swapfile
+os_base_swappiness: 10        # default 60 is too aggressive on a swap-file backend
+
 os_base_packages:
   - bash-completion
   - vim-enhanced
   - tmux
-  - bpytop
   - tree
   - jq
   - wget

--- a/roles/os-base/files/automatic.conf
+++ b/roles/os-base/files/automatic.conf
@@ -1,0 +1,39 @@
+# /etc/dnf/automatic.conf — managed by Ansible role os-base.
+# Defaults: apply only security updates, log to journal, no email.
+# Override the role variables to change behavior.
+
+[commands]
+# Apply security updates only — feature/version bumps need manual
+# review on a homelab host where automation interactions matter.
+upgrade_type = security
+random_sleep = 360
+
+# Download and apply automatically (the dnf-automatic-install.timer
+# unit triggers this).
+download_updates = yes
+apply_updates = yes
+
+# Reboot only when explicitly requested via the timer; never auto-
+# reboot on a kernel update without operator visibility.
+reboot = never
+
+[emitters]
+# Log to systemd journal. Email emitter can be added by overriding
+# this file via os_base_dnf_automatic_email when set.
+emit_via = stdio
+
+[email]
+email_from = root@localhost
+email_to = root
+email_host = localhost
+
+[command]
+# Empty.
+
+[command_email]
+email_from = root@localhost
+email_to = root
+email_host = localhost
+
+[base]
+debuglevel = 1

--- a/roles/os-base/files/automatic.conf
+++ b/roles/os-base/files/automatic.conf
@@ -13,9 +13,11 @@ random_sleep = 360
 download_updates = yes
 apply_updates = yes
 
-# Reboot only when explicitly requested via the timer; never auto-
-# reboot on a kernel update without operator visibility.
-reboot = never
+# Auto-reboot when an update needs it (kernel, glibc, systemd…).
+# `when-needed` only fires if needs-restarting -r reports a reboot is
+# required — routine package updates do not bounce the host.
+reboot = when-needed
+reboot_command = "shutdown -r +5 'Rebooting after applying security updates'"
 
 [emitters]
 # Log to systemd journal. Email emitter can be added by overriding

--- a/roles/os-base/files/zz-aliases.sh
+++ b/roles/os-base/files/zz-aliases.sh
@@ -1,0 +1,30 @@
+# /etc/profile.d/zz-aliases.sh — managed by Ansible role os-base.
+# `zz-` prefix so this loads after distro-provided profile.d entries
+# (some define their own ll/la). Edits will be overwritten.
+
+# Listing
+alias ll='ls -lh --color=auto --group-directories-first'
+alias la='ls -lAh --color=auto --group-directories-first'
+alias l='ls -lh --color=auto --group-directories-first'
+
+# Quick directory navigation
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# Color by default
+alias grep='grep --color=auto'
+alias egrep='egrep --color=auto'
+alias fgrep='fgrep --color=auto'
+alias diff='diff --color=auto'
+alias ip='ip --color=auto'
+
+# Safety nets — prompt before clobbering
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+# Useful systemd shortcuts
+alias jc='journalctl'
+alias sc='systemctl'
+alias scu='systemctl --user'

--- a/roles/os-base/handlers/main.yml
+++ b/roles/os-base/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Restart dnf-automatic-install timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: dnf-automatic-install.timer
+    state: restarted
+
+- name: Restart systemd-resolved
+  become: true
+  ansible.builtin.systemd_service:
+    name: systemd-resolved
+    state: restarted
+
+- name: Flush systemd-resolved cache
+  become: true
+  ansible.builtin.command: resolvectl flush-caches
+  changed_when: false

--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -120,6 +120,20 @@
   when: os_base_needs_podman_copr
 
 # ---------------------------------------------------------------- 3
+# Cap retained kernels. Default `installonly_limit=3` is fine on
+# roomy hosts but eats ~500 MB per extra kernel — relevant on small
+# vservers with 8-10 GB root disks.
+- name: Cap retained kernels
+  become: true
+  community.general.ini_file:
+    path: /etc/dnf/dnf.conf
+    section: main
+    option: installonly_limit
+    value: "{{ os_base_installonly_limit }}"
+    no_extra_spaces: true
+    mode: "0644"
+  when: os_base_installonly_limit | int > 0
+
 # dnf-automatic — apply only security updates by default. Persistent
 # across reboots via the systemd timer.
 - name: Install dnf-automatic

--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -1,0 +1,159 @@
+---
+# Universal OS-baseline configuration. Runs on every host in
+# playbooks/site.yml unconditionally; service roles assume podman,
+# common tools, and a working resolver are in place by the time they
+# run.
+
+# ---------------------------------------------------------------- 1
+# podman 5 source on AlmaLinux 9 (and other RHEL-9 derivatives).
+# Fedora's default repo already ships podman 5.x; AL9/Rocky/CentOS 9
+# only have 4.x. The COPR run by the upstream Podman team provides
+# 5.x for el9.
+- name: Detect distro family for podman repo decision
+  ansible.builtin.set_fact:
+    os_base_needs_podman_copr: >-
+      {{
+        os_base_podman_extra_repo | length > 0
+        and ansible_distribution in ['AlmaLinux', 'Rocky', 'CentOS', 'RedHat']
+        and ansible_distribution_major_version == '9'
+      }}
+
+- name: Ensure dnf-plugins-core (provides `dnf copr`) on RHEL-9 family
+  become: true
+  ansible.builtin.dnf:
+    name: dnf-plugins-core
+    state: present
+  when: os_base_needs_podman_copr
+
+- name: Enable rhcontainerbot/podman-next COPR for podman 5 on RHEL-9 family
+  become: true
+  ansible.builtin.command:
+    cmd: "dnf -y copr enable {{ os_base_podman_extra_repo }}"
+    creates: "/etc/yum.repos.d/_copr:copr.fedorainfracloud.org:{{ os_base_podman_extra_repo | replace('/', ':') }}.repo"
+  when: os_base_needs_podman_copr
+
+# ---------------------------------------------------------------- 2
+- name: Install common packages
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ os_base_packages }}"
+    state: present
+
+- name: Ensure podman is upgraded to 5.x where the COPR provides it
+  become: true
+  ansible.builtin.dnf:
+    name: podman
+    state: latest
+  when: os_base_needs_podman_copr
+
+# ---------------------------------------------------------------- 3
+# dnf-automatic — apply only security updates by default. Persistent
+# across reboots via the systemd timer.
+- name: Install dnf-automatic
+  become: true
+  ansible.builtin.dnf:
+    name: dnf-automatic
+    state: present
+  when: os_base_dnf_automatic_enabled
+
+- name: Configure dnf-automatic
+  become: true
+  ansible.builtin.copy:
+    src: automatic.conf
+    dest: /etc/dnf/automatic.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: os_base_dnf_automatic_enabled
+  notify: Restart dnf-automatic-install timer
+
+- name: Enable and start dnf-automatic-install.timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: dnf-automatic-install.timer
+    enabled: true
+    state: started
+  when: os_base_dnf_automatic_enabled
+
+# ---------------------------------------------------------------- 4
+- name: Drop /etc/profile.d/zz-aliases.sh
+  become: true
+  ansible.builtin.copy:
+    src: zz-aliases.sh
+    dest: /etc/profile.d/zz-aliases.sh
+    owner: root
+    group: root
+    mode: "0644"
+  when: os_base_aliases_enabled
+
+# ---------------------------------------------------------------- 5
+- name: Set timezone
+  become: true
+  community.general.timezone:
+    name: "{{ os_base_timezone }}"
+
+# ---------------------------------------------------------------- 6
+- name: Read current console keymap
+  ansible.builtin.command: localectl status
+  register: os_base_localectl_status
+  changed_when: false
+
+- name: Set console keymap
+  become: true
+  ansible.builtin.command:
+    cmd: "localectl set-keymap {{ os_base_keymap }}"
+  when: "'VC Keymap: ' ~ os_base_keymap not in os_base_localectl_status.stdout"
+  changed_when: true
+
+# ---------------------------------------------------------------- 7
+- name: Set hostname
+  become: true
+  ansible.builtin.hostname:
+    name: "{{ os_base_hostname | default(inventory_hostname) }}"
+
+# ---------------------------------------------------------------- 8
+# System-level (rootful) podman-auto-update timer. Service roles still
+# install their own per-rootless-user timer; this one covers any
+# rootful container the host might run later.
+- name: Enable rootful podman-auto-update.timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: podman-auto-update.timer
+    enabled: true
+    state: started
+
+# ---------------------------------------------------------------- 9
+# system DNS via systemd-resolved. Use 10-os-base-dns.conf so the
+# pihole role's 20-pihole.conf can outrank it on Pi-hole hosts.
+- name: Ensure systemd-resolved drop-in directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/resolved.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: os_base_dns_servers | length > 0
+
+- name: Configure systemd-resolved DNS (Mullvad / configurable)
+  become: true
+  ansible.builtin.template:
+    src: os-base-dns.conf.j2
+    dest: /etc/systemd/resolved.conf.d/10-os-base-dns.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: os_base_dns_servers | length > 0
+  notify:
+    - Restart systemd-resolved
+    - Flush systemd-resolved cache
+
+- name: Remove os-base DNS drop-in if disabled
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/resolved.conf.d/10-os-base-dns.conf
+    state: absent
+  when: os_base_dns_servers | length == 0
+  notify:
+    - Restart systemd-resolved
+    - Flush systemd-resolved cache

--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -4,6 +4,79 @@
 # common tools, and a working resolver are in place by the time they
 # run.
 
+# ---------------------------------------------------------------- 0
+# Swap. Goes BEFORE any dnf operation — small (1 GB) vservers
+# happily OOM-kill sshd while dnf is unpacking a big transaction.
+# Skipped when `os_base_swap_size_mb` is 0 or existing swap already
+# meets the threshold.
+- name: Check if swap file is already active
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -E "^{{ os_base_swap_file | regex_escape }} " /proc/swaps || true
+  args:
+    executable: /bin/bash
+  register: os_base_swap_active_line
+  changed_when: false
+
+- name: Decide whether to provision swap
+  ansible.builtin.set_fact:
+    os_base_swap_needs_provision: >-
+      {{
+        os_base_swap_size_mb | int > 0
+        and (ansible_facts['swaptotal_mb'] | int) < (os_base_swap_size_mb | int)
+        and os_base_swap_active_line.stdout | length == 0
+      }}
+
+- name: Create swap file
+  become: true
+  ansible.builtin.command:
+    cmd: "fallocate -l {{ os_base_swap_size_mb }}M {{ os_base_swap_file }}"
+    creates: "{{ os_base_swap_file }}"
+  when: os_base_swap_needs_provision
+
+- name: Lock down swap file permissions
+  become: true
+  ansible.builtin.file:
+    path: "{{ os_base_swap_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  when: os_base_swap_needs_provision
+
+- name: Format swap file
+  become: true
+  ansible.builtin.command:
+    cmd: "mkswap {{ os_base_swap_file }}"
+  when: os_base_swap_needs_provision
+  changed_when: true
+
+- name: Activate swap file
+  become: true
+  ansible.builtin.command:
+    cmd: "swapon {{ os_base_swap_file }}"
+  when: os_base_swap_needs_provision
+  changed_when: true
+
+- name: Persist swap in /etc/fstab
+  become: true
+  ansible.posix.mount:
+    path: none
+    src: "{{ os_base_swap_file }}"
+    fstype: swap
+    opts: defaults
+    state: present
+  when: os_base_swap_size_mb | int > 0
+
+- name: Set vm.swappiness
+  become: true
+  ansible.posix.sysctl:
+    name: vm.swappiness
+    value: "{{ os_base_swappiness }}"
+    state: present
+    sysctl_set: true
+    reload: true
+  when: os_base_swap_size_mb | int > 0
+
 # ---------------------------------------------------------------- 1
 # podman 5 source on AlmaLinux 9 (and other RHEL-9 derivatives).
 # Fedora's default repo already ships podman 5.x; AL9/Rocky/CentOS 9

--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -198,6 +198,33 @@
 # ---------------------------------------------------------------- 9
 # system DNS via systemd-resolved. Use 10-os-base-dns.conf so the
 # pihole role's 20-pihole.conf can outrank it on Pi-hole hosts.
+# AlmaLinux/Rocky/CentOS 9 don't ship systemd-resolved enabled (or
+# even installed) by default — install + enable it so the drop-in
+# below actually does something. Fedora already has it active.
+- name: Install systemd-resolved
+  become: true
+  ansible.builtin.dnf:
+    name: systemd-resolved
+    state: present
+  when: os_base_dns_servers | length > 0
+
+- name: Enable and start systemd-resolved
+  become: true
+  ansible.builtin.systemd_service:
+    name: systemd-resolved
+    enabled: true
+    state: started
+  when: os_base_dns_servers | length > 0
+
+- name: Point /etc/resolv.conf at systemd-resolved stub
+  become: true
+  ansible.builtin.file:
+    src: /run/systemd/resolve/stub-resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: true
+  when: os_base_dns_servers | length > 0
+
 - name: Ensure systemd-resolved drop-in directory
   become: true
   ansible.builtin.file:

--- a/roles/os-base/templates/os-base-dns.conf.j2
+++ b/roles/os-base/templates/os-base-dns.conf.j2
@@ -7,7 +7,7 @@
 
 [Resolve]
 {% if os_base_dns_over_tls and os_base_dns_hostname %}
-DNS={{ os_base_dns_servers | map('regex_replace', '^(.*)$', '\1#' ~ os_base_dns_hostname) | join(' ') }}
+DNS={{ os_base_dns_servers | map('regex_replace', '^(.*)$', '\\1#' ~ os_base_dns_hostname) | join(' ') }}
 DNSOverTLS=yes
 {% else %}
 DNS={{ os_base_dns_servers | join(' ') }}
@@ -15,4 +15,8 @@ DNS={{ os_base_dns_servers | join(' ') }}
 DNSOverTLS=yes
 {% endif %}
 {% endif %}
+# Route every query through the global DNS above. Without this, any
+# per-link DNS NetworkManager picked up via DHCP would win for non-
+# search-domain queries — which defeats the point of pinning Mullvad.
+Domains=~.
 DNSStubListener=yes

--- a/roles/os-base/templates/os-base-dns.conf.j2
+++ b/roles/os-base/templates/os-base-dns.conf.j2
@@ -1,0 +1,18 @@
+# Managed by Ansible role os-base. Edits will be overwritten.
+#
+# This is the *baseline* drop-in. On hosts running Pi-hole, the
+# pihole role drops a 20-pihole.conf alongside this file with a
+# higher-priority DNS=127.0.0.1:1053 entry that supersedes the
+# baseline below.
+
+[Resolve]
+{% if os_base_dns_over_tls and os_base_dns_hostname %}
+DNS={{ os_base_dns_servers | map('regex_replace', '^(.*)$', '\1#' ~ os_base_dns_hostname) | join(' ') }}
+DNSOverTLS=yes
+{% else %}
+DNS={{ os_base_dns_servers | join(' ') }}
+{% if os_base_dns_over_tls %}
+DNSOverTLS=yes
+{% endif %}
+{% endif %}
+DNSStubListener=yes

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -210,9 +210,13 @@ the old container is stopped, so Pi-hole keeps serving DNS while the
 new images are fetched — without this ordering, stopping Pi-hole first
 would break DNS resolution and make the pull fail.
 
-After deploy the role also writes `/etc/systemd/resolved.conf.d/pihole.conf`
-so the host points at `127.0.0.1:1053` for DNS, and wipes a stray
-bootstrap drop-in (`temp-dns.conf`) if one exists — see [#37](https://github.com/luckynrslevin/home-server/issues/37).
+After deploy the role also writes `/etc/systemd/resolved.conf.d/20-pihole.conf`
+so the host points at `127.0.0.1:1053` for DNS, and wipes:
+- the stray bootstrap drop-in (`temp-dns.conf`) if it exists — see [#37](https://github.com/luckynrslevin/home-server/issues/37)
+- the legacy unprefixed `pihole.conf` from before drop-in ordering was made explicit (#79)
+
+The `20-` prefix sorts after `os-base`'s `10-os-base-dns.conf` so on
+hosts running both roles, Pi-hole always wins for DNS routing.
 
 ## Post-install behaviour
 

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -97,17 +97,29 @@
 # all drop-ins additively — leaving this one behind adds 9.9.9.9 alongside
 # our 127.0.0.1:1053, and resolved freely round-robins between them, which
 # silently bypasses Pi-hole's blocking for whichever queries land on Quad9.
-- name: Remove bootstrap DNS drop-in (superseded by pihole.conf)
+- name: Remove bootstrap DNS drop-in (superseded by 20-pihole.conf)
   become: true
   ansible.builtin.file:
     path: /etc/systemd/resolved.conf.d/temp-dns.conf
     state: absent
   register: pihole_resolved_bootstrap_removed
 
+# Drop-in is named 20-pihole.conf so it sorts after os-base's
+# 10-os-base-dns.conf in /etc/systemd/resolved.conf.d/. systemd-resolved
+# loads drop-ins in lexical order; later wins for repeated keys. This
+# explicit ordering means a Pi-hole host always uses 127.0.0.1:1053 even
+# when os-base also writes a baseline DNS drop-in.
+- name: Remove legacy unprefixed pihole.conf drop-in
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/resolved.conf.d/pihole.conf
+    state: absent
+  register: pihole_resolved_legacy_removed
+
 - name: Configure systemd-resolved to use Pi-hole
   become: true
   ansible.builtin.copy:
-    dest: /etc/systemd/resolved.conf.d/pihole.conf
+    dest: /etc/systemd/resolved.conf.d/20-pihole.conf
     content: |
       [Resolve]
       DNS=127.0.0.1:1053
@@ -120,7 +132,10 @@
   ansible.builtin.systemd_service:
     name: systemd-resolved
     state: restarted
-  when: pihole_resolved_config.changed or pihole_resolved_bootstrap_removed.changed
+  when: >-
+    pihole_resolved_config.changed
+    or pihole_resolved_bootstrap_removed.changed
+    or pihole_resolved_legacy_removed.changed
 
 # Even after restart, clients that previously queried a given name may see
 # stale answers until their own DNS caches expire. Flushing resolved's
@@ -130,7 +145,10 @@
   become: true
   ansible.builtin.command: resolvectl flush-caches
   changed_when: false
-  when: pihole_resolved_config.changed or pihole_resolved_bootstrap_removed.changed
+  when: >-
+    pihole_resolved_config.changed
+    or pihole_resolved_bootstrap_removed.changed
+    or pihole_resolved_legacy_removed.changed
 
 - name: Run post-install configuration
   ansible.builtin.import_tasks: postinstall.yml


### PR DESCRIPTION
## Summary

New `roles/os-base/` for the layer between `bootstrap-host.sh` and the service roles. Runs unconditionally as the first role in `playbooks/site.yml`. Closes #79.

### What it does (idempotent, 9 steps)

1. **podman 5 source** — enable `rhcontainerbot/podman-next` COPR on AlmaLinux/Rocky/CentOS 9 so podman is 5.x everywhere. Skipped on Fedora.
2. **Common packages** — bash-completion, vim-enhanced, tmux, bpytop, tree, jq, wget, curl, rsync, git, podman.
3. **dnf-automatic** — security updates only, log to journal.
4. **Shell aliases** — `/etc/profile.d/zz-aliases.sh`.
5. **Timezone** (default Europe/Berlin).
6. **Console keymap** (default de).
7. **Hostname** (defaults to `inventory_hostname`).
8. **Rootful `podman-auto-update.timer`**.
9. **systemd-resolved drop-in** — Mullvad base DNS with DoT.

### Two distros, both supported

| Distro | podman default | Action |
|---|---|---|
| Fedora Server 43 (eddie) | 5.x | none |
| AlmaLinux 9 (dnsvserver) | 4.x | enable COPR |

### Companion change in pihole role

The resolved drop-in is renamed `pihole.conf` → `20-pihole.conf` so it explicitly sorts **after** os-base's `10-os-base-dns.conf` in `/etc/systemd/resolved.conf.d/`. systemd-resolved loads drop-ins lexically; later wins. This makes Pi-hole always supersede the baseline on hosts running both. The old unprefixed file is removed by an idempotent absent-state task so existing eddie deploys clean up on next apply.

## Test plan
- [x] `ansible-playbook --syntax-check playbooks/site.yml` clean
- [ ] Apply against eddie (Fedora 43): no service regression, dnf-automatic enabled, idempotent on second run
- [ ] Apply against dnsvserver (AlmaLinux 9): podman 5.x, Mullvad DNS via DoT, all 9 steps green
- [ ] `resolvectl query --type=TXT id.dns.mullvad.net` on dnsvserver returns Mullvad TXT (proves DNS is hitting them)

## Out of scope (separate PRs)
- Refactoring 7 service roles to dedupe rootless-user + linger + per-user `podman-auto-update.timer`.
- dnsvserver's Pi-hole+Unbound deploy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)