### PR TITLE
Add os-tailscale role

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -40,6 +40,10 @@
 
   roles:
     - { role: os-base }
+    - role: os-tailscale
+      when: >-
+        (os_tailscale_auth_key | default('') | length > 0)
+        or ('os-tailscale' in (deploy_services | default([])))
     - { role: caddy }
     - { role: dashboard,     when: "'dashboard' in (deploy_services | default([]))" }
     - { role: pihole,        when: "'pihole' in (deploy_services | default([]))" }

--- a/roles/os-tailscale/README.md
+++ b/roles/os-tailscale/README.md
@@ -1,0 +1,117 @@
+# os-tailscale
+
+Install and join [Tailscale](https://tailscale.com) — a mesh VPN that
+gives every node a stable IP and DNS name on a private overlay,
+without router config, NAT punching, or per-network setup. Free for
+small tailnets (up to 100 devices, 3 users on the personal plan;
+generous limits for self-hosting).
+
+Use this role when you want a host reachable from your other
+Tailscale-connected devices anywhere in the world, or to extend the
+home LAN to roaming Macs / iPhones / Linux laptops.
+
+## Supported distros
+
+| Distro | Source |
+|---|---|
+| Fedora (any current release) | `pkgs.tailscale.com/stable/fedora` |
+| AlmaLinux 9 / Rocky 9 / CentOS Stream 9 / RHEL 9 | `pkgs.tailscale.com/stable/rhel/9` |
+
+Other distros: the role refuses to run. Tailscale ships its own RPMs
+so no COPR / EPEL is involved.
+
+## What it does
+
+1. Adds the Tailscale repo (Fedora or RHEL-9 path picked
+   automatically).
+2. `dnf install tailscale`.
+3. Enables and starts `tailscaled`.
+4. Reads `tailscale status --json` to detect login state.
+5. **First run** — if not yet logged in:
+   - With `os_tailscale_auth_key` set → runs `tailscale up
+     --auth-key=… --hostname=… [--advertise-routes …] …`
+     unattended.
+   - Without an auth key → emits a debug line telling you to run
+     `sudo tailscale up` manually, then re-apply the role.
+6. **Subsequent runs** — applies route / exit-node / accept-dns /
+   accept-routes / ssh settings via `tailscale set`. Lets you flip
+   knobs without re-authenticating. Tag changes still need a manual
+   `tailscale up --reset`.
+
+## Variables
+
+See `defaults/main.yml`. Common knobs:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `os_tailscale_auth_key` | `""` | Vault-encrypted reusable / single-use auth key from the admin console. Empty = manual login. |
+| `os_tailscale_hostname` | `inventory_hostname` | The label that appears in the admin console. |
+| `os_tailscale_advertise_routes` | `[]` | List of CIDRs to advertise as subnet routes (e.g. `["192.168.1.0/24"]`). Routes also need approval in the admin console. |
+| `os_tailscale_tags` | `[]` | Tags to apply at first login, e.g. `["tag:server"]`. Must be pre-declared in the tailnet ACL. |
+| `os_tailscale_advertise_exit_node` | `false` | Set true to offer this node as an exit node. |
+| `os_tailscale_accept_dns` | `true` | Accept the tailnet's DNS push (MagicDNS, override resolvers). Lets eddie-hosted Pi-hole serve the whole tailnet when configured in admin DNS settings. |
+| `os_tailscale_accept_routes` | `true` | Accept routes advertised by other nodes. Required if you want to reach LANs subnet-routed through other tailnet nodes. |
+| `os_tailscale_ssh` | `false` | Enable Tailscale-mediated SSH (replaces public-key auth with tailnet identity). Off by default — opt in per host. |
+
+## First-time setup
+
+1. **Generate an auth key** in the
+   [admin console](https://login.tailscale.com/admin/settings/keys)
+   — Reusable + Ephemeral or single-use, your call. Optionally
+   pre-tag it (`tag:server`) so the node lands with that tag.
+2. **Stash it in vault**:
+   ```bash
+   ansible-vault encrypt_string '<paste-key>' --name vault_os_tailscale_auth_key
+   ```
+3. **Set host_vars**:
+   ```yaml
+   os_tailscale_auth_key: "{{ vault_os_tailscale_auth_key }}"
+   os_tailscale_advertise_routes: ["192.168.1.0/24"]   # optional
+   ```
+4. **Apply** as part of `playbooks/site.yml` (this role is in the
+   default role list once added) or with a one-off:
+   ```bash
+   ansible-playbook -i ../home-server-private/inventory/hosts.yml \
+     playbooks/site.yml --limit eddie --tags os-tailscale
+   ```
+5. **Approve routes** in the admin console under Machines → eddie →
+   Edit route settings (subnet routes don't enable themselves).
+
+## Manual login (no auth key)
+
+If you'd rather not put an auth key in vault, leave the variable
+empty and complete login interactively after the role applies:
+
+```bash
+ssh eddie sudo tailscale up
+```
+
+The command prints a `https://login.tailscale.com/a/...` URL — open
+on any device already logged into your tailnet, click Connect.
+Re-run the role afterwards to push the runtime settings.
+
+## Verification
+
+```bash
+ssh eddie tailscale status      # node listed, status "active"
+ssh eddie tailscale ip          # prints the 100.x.y.z IP
+# from any other tailnet device:
+tailscale ping eddie            # round-trip succeeds
+ssh user@eddie                  # if --ssh enabled, no password prompt
+```
+
+If Tailscale's MagicDNS is enabled in the admin console, the node is
+also reachable as `eddie.<your-tailnet>.ts.net` from every tailnet
+device.
+
+## Common follow-ups
+
+- **Use eddie's Pi-hole as the tailnet resolver** — admin console →
+  DNS → add eddie's Tailscale IP → "Override local DNS." Now
+  `*.eddie.lan` resolves on every tailnet device, anywhere.
+- **Subnet routing for the home LAN** — set
+  `os_tailscale_advertise_routes: ["192.168.1.0/24"]`, run the
+  role, approve in admin console. Mac/iPhone via Tailscale can
+  then reach `192.168.1.x` directly.
+- **Replace `caddy_domain: eddie.lan` with a real public name** —
+  not required, just an option once tailnet covers all clients.

--- a/roles/os-tailscale/defaults/main.yml
+++ b/roles/os-tailscale/defaults/main.yml
@@ -1,0 +1,43 @@
+---
+# Authentication key for unattended `tailscale up`. When set (typically
+# from vault), the role will run `tailscale up --auth-key=...` once if
+# the host isn't already logged in. When empty, complete login
+# interactively after the role applies:
+#
+#   ssh <host> sudo tailscale up
+#
+# (the command prints a URL to authenticate from any browser).
+os_tailscale_auth_key: ""
+
+# Hostname this node advertises inside the tailnet. Defaults to the
+# inventory hostname; override only if you want a different label
+# in the admin console.
+os_tailscale_hostname: "{{ inventory_hostname }}"
+
+# Subnet routes this node advertises. Empty list = node-only mode.
+# Example for a home-LAN router: ["192.168.1.0/24"]. Routes also need
+# to be approved manually in the Tailscale admin console after the
+# first connect.
+os_tailscale_advertise_routes: []
+
+# Tags applied to the node, e.g. ["tag:server"]. Tags must be
+# pre-declared in the tailnet ACL. Empty = untagged. Tags are only
+# applied at first `tailscale up`; changing them later requires
+# `tailscale up --reset` (potentially disruptive — do it manually).
+os_tailscale_tags: []
+
+# Advertise this node as an exit node. Off by default.
+os_tailscale_advertise_exit_node: false
+
+# Accept the tailnet's MagicDNS / global DNS push. Default: yes — lets
+# the admin-console DNS config propagate to this node so e.g. an
+# eddie-hosted Pi-hole becomes the tailnet resolver.
+os_tailscale_accept_dns: true
+
+# Accept routes advertised by other tailnet nodes. Default: yes —
+# required for nodes that want to reach subnet-routed LANs.
+os_tailscale_accept_routes: true
+
+# SSH-via-Tailscale (Tailscale SSH). Off by default — opt in per host
+# if you want to drop authorized_keys management for this node.
+os_tailscale_ssh: false

--- a/roles/os-tailscale/tasks/main.yml
+++ b/roles/os-tailscale/tasks/main.yml
@@ -1,0 +1,139 @@
+---
+# os-tailscale — install Tailscale and join the tailnet. Idempotent:
+# on re-runs, only `tailscale set` flags drift through, so changes to
+# advertised routes / exit-node / accept-dns are picked up without
+# disconnecting the host.
+
+# ---------------------------------------------------------------- 1
+# Pick the right tailscale repo for the distro. Tailscale publishes
+# RPMs for Fedora and the RHEL-9 family at the same hostname, with
+# distinct paths.
+- name: Decide tailscale repo URL
+  ansible.builtin.set_fact:
+    os_tailscale_repo_url: >-
+      {%- if ansible_distribution == 'Fedora' -%}
+      https://pkgs.tailscale.com/stable/fedora/tailscale.repo
+      {%- elif ansible_distribution in ['AlmaLinux', 'Rocky', 'CentOS', 'RedHat']
+              and ansible_distribution_major_version == '9' -%}
+      https://pkgs.tailscale.com/stable/rhel/9/tailscale.repo
+      {%- else -%}
+      {%- endif -%}
+
+- name: Fail when distro is not supported
+  ansible.builtin.fail:
+    msg: >-
+      os-tailscale supports Fedora and RHEL-9-family hosts only.
+      Got {{ ansible_distribution }} {{ ansible_distribution_major_version }}.
+  when: os_tailscale_repo_url | length == 0
+
+- name: Ensure dnf-plugins-core (provides `dnf config-manager`)
+  become: true
+  ansible.builtin.dnf:
+    name: dnf-plugins-core
+    state: present
+
+- name: Add tailscale repo
+  become: true
+  ansible.builtin.command:
+    cmd: "dnf -y config-manager addrepo --from-repofile={{ os_tailscale_repo_url }}"
+    creates: /etc/yum.repos.d/tailscale.repo
+
+# ---------------------------------------------------------------- 2
+- name: Install tailscale
+  become: true
+  ansible.builtin.dnf:
+    name: tailscale
+    state: present
+
+- name: Enable and start tailscaled
+  become: true
+  ansible.builtin.systemd_service:
+    name: tailscaled
+    enabled: true
+    state: started
+
+# ---------------------------------------------------------------- 3
+# Detect login state. `tailscale status --json` returns BackendState
+# "Running" when authenticated, "NeedsLogin" or "Stopped" otherwise.
+- name: Read current tailscale state
+  become: true
+  ansible.builtin.command:
+    cmd: tailscale status --json
+  register: os_tailscale_status_raw
+  changed_when: false
+  failed_when: false
+
+- name: Parse tailscale state
+  ansible.builtin.set_fact:
+    os_tailscale_backend_state: >-
+      {{ (os_tailscale_status_raw.stdout | from_json).BackendState
+         if os_tailscale_status_raw.rc == 0 else 'Unknown' }}
+
+- name: Decide whether to perform initial `tailscale up`
+  ansible.builtin.set_fact:
+    os_tailscale_needs_up: >-
+      {{ os_tailscale_backend_state in ['NeedsLogin', 'Stopped', 'NoState', 'Unknown'] }}
+
+# ---------------------------------------------------------------- 4
+# Initial login. Requires an auth key from vault. Without one, the
+# role stops short and prints instructions for interactive login.
+- name: Warn when login is required but no auth key is set
+  ansible.builtin.debug:
+    msg: >-
+      Tailscale is not logged in on {{ inventory_hostname }} and
+      `os_tailscale_auth_key` is empty. Complete login manually:
+        ssh {{ inventory_hostname }} sudo tailscale up
+      then re-run this role to apply route / DNS / tag settings.
+  when:
+    - os_tailscale_needs_up
+    - os_tailscale_auth_key | length == 0
+
+- name: Run `tailscale up` (initial login with auth key)
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      tailscale up
+      --auth-key={{ os_tailscale_auth_key }}
+      --hostname={{ os_tailscale_hostname }}
+      {% if os_tailscale_advertise_routes | length > 0 %}
+      --advertise-routes={{ os_tailscale_advertise_routes | join(',') }}
+      {% endif %}
+      {% if os_tailscale_tags | length > 0 %}
+      --advertise-tags={{ os_tailscale_tags | join(',') }}
+      {% endif %}
+      {% if os_tailscale_advertise_exit_node %}
+      --advertise-exit-node
+      {% endif %}
+      --accept-dns={{ 'true' if os_tailscale_accept_dns else 'false' }}
+      --accept-routes={{ 'true' if os_tailscale_accept_routes else 'false' }}
+      --ssh={{ 'true' if os_tailscale_ssh else 'false' }}
+  no_log: true                       # keep the auth key out of logs
+  changed_when: true
+  when:
+    - os_tailscale_needs_up
+    - os_tailscale_auth_key | length > 0
+
+# ---------------------------------------------------------------- 5
+# Drift correction on subsequent runs. `tailscale set` adjusts the
+# running daemon without re-authenticating. Tags can't be changed via
+# `set` — they need `up --reset`, which we leave manual.
+- name: Apply runtime settings via `tailscale set`
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      tailscale set
+      {% if os_tailscale_advertise_routes | length > 0 %}
+      --advertise-routes={{ os_tailscale_advertise_routes | join(',') }}
+      {% else %}
+      --advertise-routes=
+      {% endif %}
+      {% if os_tailscale_advertise_exit_node %}
+      --advertise-exit-node=true
+      {% else %}
+      --advertise-exit-node=false
+      {% endif %}
+      --accept-dns={{ 'true' if os_tailscale_accept_dns else 'false' }}
+      --accept-routes={{ 'true' if os_tailscale_accept_routes else 'false' }}
+      --ssh={{ 'true' if os_tailscale_ssh else 'false' }}
+  changed_when: false                # `tailscale set` is idempotent server-side
+  when: not os_tailscale_needs_up


### PR DESCRIPTION
## Summary
- New `roles/os-tailscale/` (defaults + tasks + README), modelled on `roles/os-audio/`'s small-focused pattern.
- Installs the official Tailscale RPM via `pkgs.tailscale.com` (Fedora and RHEL-9 family supported, distro detected at apply-time).
- First-run logic: with `os_tailscale_auth_key` set → unattended `tailscale up`; without → role emits a debug line telling you to run `sudo tailscale up` manually, then re-apply for runtime settings.
- Subsequent runs use `tailscale set` to drift-correct routes, exit-node mode, MagicDNS acceptance, route acceptance, and SSH-via-Tailscale — no re-auth, no daemon restart.
- Wired into `playbooks/site.yml` between `os-base` and `caddy`. Guard: runs when `os_tailscale_auth_key` is set OR `'os-tailscale'` is in `deploy_services`. Hosts without either are untouched.

## Why
Public-name-with-Let's-Encrypt and self-signed-trust-on-every-device are both painful. Tailscale fixes the "reach my home services from anywhere" problem in 2 minutes per device, free for personal tailnets, no port-forwards, no DDNS.

## Test plan
- [ ] `ansible-playbook --syntax-check playbooks/site.yml` (already green)
- [ ] Apply on eddie with `os_tailscale_auth_key` set → `tailscale status` shows it as Connected, admin console lists eddie
- [ ] Re-apply → 0 changes (idempotency)
- [ ] Set `os_tailscale_advertise_routes: ["192.168.1.0/24"]`, re-apply → `tailscale set` fires, route appears in admin console (pending approval)
- [ ] Apply on dnsvserver (RHEL-9 path) → install succeeds via the rhel/9 repo