### PR TITLE
os-tailscale: fix AL9 repo install + add standalone playbook

### DIFF
--- a/playbooks/os-tailscale.yml
+++ b/playbooks/os-tailscale.yml
@@ -1,0 +1,20 @@
+---
+# Apply only the os-tailscale role.
+#
+# Useful for:
+#   - Onboarding a host onto the tailnet without re-running every
+#     other role (e.g. when adding Tailscale to a host that's
+#     already up and serving).
+#   - Drift-correcting Tailscale runtime settings (advertised
+#     routes, exit-node mode, accept-dns, ssh) — `tailscale set`
+#     fires on every apply.
+#
+# Targets every host by default. Use --limit to scope:
+#
+#   ansible-playbook -i inventory/hosts.yml playbooks/os-tailscale.yml --limit dnsvserver
+- name: Apply os-tailscale role
+  hosts: all
+  become: false
+  gather_facts: true
+  roles:
+    - { role: os-tailscale }

--- a/roles/os-tailscale/tasks/main.yml
+++ b/roles/os-tailscale/tasks/main.yml
@@ -26,17 +26,14 @@
       Got {{ ansible_distribution }} {{ ansible_distribution_major_version }}.
   when: os_tailscale_repo_url | length == 0
 
-- name: Ensure dnf-plugins-core (provides `dnf config-manager`)
-  become: true
-  ansible.builtin.dnf:
-    name: dnf-plugins-core
-    state: present
-
 - name: Add tailscale repo
   become: true
-  ansible.builtin.command:
-    cmd: "dnf -y config-manager addrepo --from-repofile={{ os_tailscale_repo_url }}"
-    creates: /etc/yum.repos.d/tailscale.repo
+  ansible.builtin.get_url:
+    url: "{{ os_tailscale_repo_url }}"
+    dest: /etc/yum.repos.d/tailscale.repo
+    owner: root
+    group: root
+    mode: "0644"
 
 # ---------------------------------------------------------------- 2
 - name: Install tailscale


### PR DESCRIPTION
## Summary
Follow-up to #81. Two fixes from on-host testing on dnsvserver (AlmaLinux 9):

1. **AL9 repo install** — `dnf config-manager addrepo --from-repofile=` is dnf5 syntax. dnf4 on AL9 rejects it. Switched to `ansible.builtin.get_url` which works on both dnf4 (RHEL family) and dnf5 (Fedora). Also drops the now-unneeded `dnf-plugins-core` install.
2. **playbooks/os-tailscale.yml** — mirrors `playbooks/os-base.yml`. Useful for onboarding a host onto the tailnet without re-running every other role.

## Test plan
- [x] `ansible-playbook playbooks/os-tailscale.yml --limit dnsvserver` succeeds (already verified in onboarding)
- [x] dnsvserver appears in tailnet at `100.112.44.23`