### PR TITLE
docs: router DHCP reservation as network prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ The guiding principle is **rebuild over repair**: if the system drifts, it shoul
 
 ## Getting Started
 
+### Network prerequisites
+
+Several roles assume specific LAN IPs are stable: `backup_nas_ip`
+pins the NAS IP into `/etc/hosts`, `pihole_local_dns_records` map
+hostnames to per-host IPs, and any service the dashboard links to
+sits at the home-server's address. None of this survives DHCP lease
+drift.
+
+**Pin each device's IP via a router-side DHCP reservation** (admin
+UI → DHCP → "Address reservation" / "Static lease" — exact menu
+varies by vendor). Bind each device's MAC to the IP it currently
+holds. Two devices need this:
+
+- **The home server** — IP referenced as `caddy_domain`'s
+  resolution target and as the host every Caddy reverse-proxy
+  hostname points at.
+- **The NAS** (if you back up to one) — IP referenced as
+  `backup_nas_ip` in the backup role.
+
+The host stays on DHCP; the router always answers with the same
+address. Single source of truth, survives NIC swaps. If you'd
+rather not use your router for this, Pi-hole can also act as the
+DHCP server; the project doesn't require it either way.
+
+Without reservations, lease drift will eventually break backups,
+Pi-hole local DNS, and any service that hardcodes a LAN IP.
+
 ### Repository structure
 
 This repo is designed to be used alongside a **private overlay** that holds

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -24,6 +24,10 @@ rootless container volumes via `podman unshare`.
 
 Override all NAS variables per-host in inventory.
 
+> **`backup_nas_ip` must be a reserved address** — pin it on your
+> router (DHCP reservation by MAC). Lease drift will silently
+> break the NFS mount and abort the backup at the first volume.
+
 ## Secrets
 
 None.

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -40,6 +40,10 @@ Pi-hole is mirrored on GHCR to sidestep Docker Hub's anonymous-pull rate limit. 
 | `pihole_adlists`           | one Turtlecute list                  | **Extra** lists. StevenBlack is auto-added by Pi-hole on first run.    |
 | `pihole_local_dns_records` | `[]`                                 | Custom A records (`{ip, hostname}` dicts) written to `pihole.toml`.    |
 
+> Pin every IP listed in `pihole_local_dns_records` via a router
+> DHCP reservation. Lease drift will silently leave Pi-hole
+> answering with stale IPs.
+
 ## Secrets
 
 | Variable              | Purpose                              |


### PR DESCRIPTION
## Summary
Today's backup outage (ds9 leased `.185` instead of `.184` while offline) is a recurring class of issue any time the IPs hardcoded in host_vars drift. Documents the router-side DHCP reservation pattern as a network prerequisite, with short reminders next to `backup_nas_ip` and `pihole_local_dns_records` where the assumption is most load-bearing.

No code changes. Vendor-neutral guidance — works for FRITZ!Box, OpenWrt, UniFi, etc., or via Pi-hole's own DHCP if the user prefers.

## Test plan
- [ ] Render the README in GitHub web UI; confirm the "Network prerequisites" section reads cleanly between Getting Started and Repository structure.
- [ ] User configures their router reservations (out-of-band manual step).