### PR TITLE
Rename NAS hostname ds9 → nas (jellyfin example)

### DIFF
--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -58,7 +58,7 @@ jellyfin_extra_media_mounts: []
 #
 # Example (in host_vars):
 #   jellyfin_nas_mounts:
-#     - { src: "ds9:/volume1/video", path: /srv/jellyfin-video,
+#     - { src: "nas:/volume1/video", path: /srv/jellyfin-video,
 #         opts: "ro,noatime,vers=4,_netdev" }
 jellyfin_nas_mounts: []
 


### PR DESCRIPTION
Single-line follow-up to the homeserver rename. Updates the example NFS mount source in jellyfin's defaults from `ds9:/volume1/video` to `nas:/volume1/video`.