### PR TITLE
bootstrap-host: fix missing-sudo error message + consolidate docs

### DIFF
--- a/docs/Bootstrap.md
+++ b/docs/Bootstrap.md
@@ -34,17 +34,16 @@ Run without sudo and the script bails fast with an error.
 SSH (or console) into the fresh target first, then on the target:
 
 ```bash
-# Cloud image (you're logged in as e.g. fedora/almalinux with sudo):
 curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/refs/heads/main/scripts/bootstrap-host.sh \
-  | sudo bash -s -- -k "$(cat ~/.ssh/id_ed25519.pub)"
-
-# Bare-metal install where you logged in as root with the root password:
-curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/refs/heads/main/scripts/bootstrap-host.sh \
-  | bash -s -- -k "ssh-ed25519 AAAA... you@laptop"
+  | sudo bash -s -- -k "ssh-ed25519 AAAA... you@laptop"
 ```
 
-(The `-k` value is your **laptop's** public key — paste it as a string,
-or `cat` it on the laptop and copy/paste the result.)
+Always pipe through `sudo bash` — the script needs root and `sudo` is
+a harmless no-op when you're already root. If you forget it, the
+script exits with a clear error pointing you at this exact command.
+
+The `-k` value is your **laptop's** public key — paste it as a string,
+or `cat ~/.ssh/id_ed25519.pub` on the laptop and copy the output.
 
 ## Options
 

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -108,8 +108,22 @@ fi
 #   - $SUDO_USER unset (or 'root')   → mode=root, create a new user
 #   - $SUDO_USER set to a non-root   → mode=sudo, that user is the target
 if (( EUID != 0 )); then
-    echo "Error: must run as root. Re-run with sudo, e.g.:" >&2
-    echo "  sudo bash $0 $*" >&2
+    # Detect curl|bash invocation: $0 is the interpreter name (e.g.
+    # "bash") because the script came in over stdin, not from a real
+    # path on disk. In that case `sudo bash $0` is meaningless — point
+    # the user at `curl … | sudo bash -s -- …` instead.
+    cat >&2 <<EOF
+Error: must run as root. Re-run with sudo:
+
+EOF
+    if [[ -f "$0" ]]; then
+        echo "  sudo bash $0 $*" >&2
+    else
+        cat >&2 <<EOF
+  curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/refs/heads/main/scripts/bootstrap-host.sh \\
+    | sudo bash -s -- -k "<your-ssh-pubkey>" [-u <user>] [-p <port>]
+EOF
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- The "must run as root" error printed \`sudo bash bash\` when invoked via \`curl | bash\` — because \`\$0\` is the interpreter name (\`bash\`) when the script comes in over stdin, and getopts had already consumed the args. Fix: detect the curl-pipe case (\`! -f \$0\`) and print the correct \`curl … | sudo bash -s -- …\` re-run command. Local-file invocations still get \`sudo bash <path>\`.
- Collapse \`docs/Bootstrap.md\` Quick start to a single \`| sudo bash -s -- …\` example. \`sudo\` is a no-op for root, so one universal command is safer than two — the no-sudo bare-metal example only invited the same mistake the error fix is meant to catch.

## Test plan

- [x] \`bash scripts/bootstrap-host.sh -k …\` as non-root → suggests \`sudo bash scripts/bootstrap-host.sh\`.
- [x] \`cat scripts/bootstrap-host.sh | bash -s -- -k …\` as non-root → suggests the curl-pipe form.
- [x] \`shellcheck\` clean.
- [ ] Re-run the actual failing invocation from the user report and confirm the new message points at the right command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)