### PR TITLE
os-audio: respect ansible_port in post-reboot SSH wait

### DIFF
--- a/roles/os-audio/tasks/main.yml
+++ b/roles/os-audio/tasks/main.yml
@@ -82,11 +82,10 @@
     - blacklist_result.changed
     - ansible_connection == "local"
 
-# Wait for the system to be online after reboot
 - name: Wait for the system to be online after reboot
   ansible.builtin.wait_for:
     host: "{{ ansible_host | default(inventory_hostname) }}"
-    port: 22
+    port: "{{ ansible_port | default(22) }}"
     timeout: 600
     state: started
   when:


### PR DESCRIPTION
## Summary

- \`roles/os-audio/tasks/main.yml:89\` hard-coded \`port: 22\` in the post-reboot \`wait_for\` task. On hosts whose sshd has been hardened onto a non-default port via \`scripts/bootstrap-host.sh\` (the standard project flow — homeserver, dnsvserver, homeserver2 all run sshd on port 2343), the task waits indefinitely for a connection that will never come and times out after 10 minutes, failing the play before subsequent roles can run.
- Switch to \`{{ ansible_port | default(22) }}\` so the wait targets whatever port the inventory says ssh actually listens on, with a sane fallback for hosts where it isn't set.

Caught during the first \`site.yml\` deploy on homeserver2.

## Test plan

- [x] Re-run \`ansible-playbook playbooks/site.yml --limit homeserver2\` and confirm os-audio's reboot wait succeeds against \`ansible_port: 2343\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)