### PR TITLE
os-base: ship nfs-utils so jellyfin and backup can mount NFS

### DIFF
--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -2,12 +2,6 @@
 # Deploy standalone backup script and systemd timer.
 # After deployment, backups run autonomously — no Ansible needed.
 
-- name: Ensure nfs-utils is installed (needed for NFS backup target)
-  become: true
-  ansible.builtin.package:
-    name: nfs-utils
-    state: present
-
 - name: Ensure NAS hostname resolves via /etc/hosts
   become: true
   ansible.builtin.lineinfile:

--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -18,6 +18,10 @@ os_base_packages:
   - tmux
   - tree
   - jq
+  # Provides /sbin/mount.nfs — used by the jellyfin role for media
+  # mounts and by the backup role to mount the NAS share. Stock on
+  # Fedora Server, not on AlmaLinux 9. Cheap to ship everywhere.
+  - nfs-utils
   - wget
   - curl
   - rsync


### PR DESCRIPTION
## Summary

- The jellyfin role uses \`ansible.posix.mount\` with \`fstype: nfs\` for NAS-backed media but never installed \`nfs-utils\` (which provides \`/sbin/mount.nfs\`). Works on Fedora Server (nfs-utils gets pulled transitively); fails on a fresh AlmaLinux 9 install with \`bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program\`.
- The backup role had its own \`Ensure nfs-utils is installed\` task for the same reason. Now redundant.
- Add \`nfs-utils\` to \`os_base_packages\` instead — every host runs \`os-base\` first via \`playbooks/site.yml\`, so a single shared install covers all consumers. Drop the duplicate from the backup role.

Caught during the homeserver2 first deploy on AlmaLinux 9.7.

## Test plan

- [x] Re-run \`ansible-playbook playbooks/site.yml --limit homeserver2\` and confirm jellyfin mounts succeed.
- [ ] Re-run on production homeserver — \`os-base\` reports nfs-utils as already-installed (no-op); \`backup\` no longer asserts the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)