### PR TITLE
os-base: pin NAS hostname in /etc/hosts for all consumers

### DIFF
--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -213,6 +213,22 @@
   ansible.builtin.hostname:
     name: "{{ os_base_hostname | default(inventory_hostname) }}"
 
+# Pin the NAS hostname in /etc/hosts so consumers (jellyfin NFS
+# media mounts, backup role, restore playbook) can resolve it
+# without depending on whatever DNS the host happens to be using.
+# Only the backup-related vars define this; vservers without a NAS
+# will just skip.
+- name: Pin NAS hostname in /etc/hosts
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '\s{{ backup_nas_hostname }}$'
+    line: "{{ backup_nas_ip }} {{ backup_nas_hostname }}"
+    state: present
+  when:
+    - backup_nas_hostname is defined
+    - backup_nas_ip is defined
+
 # ---------------------------------------------------------------- 8
 # System-level (rootful) podman-auto-update timer. Service roles still
 # install their own per-rootless-user timer; this one covers any


### PR DESCRIPTION
## Summary

- Multiple roles need to resolve the NAS hostname: jellyfin (NFS media mounts), backup (NFS backup target), and the restore playbook (mounts NAS shares for tar/rsync/pgdump restore). Relying on DNS is fragile — systemd-resolved on a freshly-deployed host may have a global resolver (Mullvad in our setup) configured before the LAN's pihole, and search-domain expansion can rewrite \`nas\` to \`nas.lan\` which pihole doesn't have a record for.
- Move the \`/etc/hosts\` pinning that previously lived in \`roles/backup/tasks/main.yml\` (removed in #93) into \`os-base\`, so it applies to every host with \`backup_nas_hostname\` + \`backup_nas_ip\` set in inventory. Hosts without those vars (vservers) skip via the when-guard.

Caught when jellyfin's NFS mount on homeserver2 (which deploys jellyfin but not backup, since it's a restore-only test box) failed with \`mount.nfs: Failed to resolve server nas: Name or service not known\`.

## Test plan

- [x] Re-run \`ansible-playbook playbooks/site.yml --limit homeserver2\` and confirm jellyfin's NFS mount succeeds.
- [ ] Re-run on production homeserver — \`/etc/hosts\` already has the line; lineinfile reports ok, no change.
- [ ] dnsvserver doesn't define \`backup_nas_hostname\` — task is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)