### PR TITLE
pihole: verify against the local resolver directly, not via NSS

### DIFF
--- a/roles/os-base/defaults/main.yml
+++ b/roles/os-base/defaults/main.yml
@@ -22,6 +22,12 @@ os_base_packages:
   # mounts and by the backup role to mount the NAS share. Stock on
   # Fedora Server, not on AlmaLinux 9. Cheap to ship everywhere.
   - nfs-utils
+  # Provides `dig` / `nslookup` / `host`. Used by the pihole role's
+  # verify.yml to query the local pihole directly (bypassing the
+  # host's NSS / systemd-resolved stack so per-link DNS servers
+  # advertised by DHCP don't poison the result), and generally
+  # essential for any DNS troubleshooting on a pihole host.
+  - bind-utils
   - wget
   - curl
   - rsync

--- a/roles/pihole/tasks/verify.yml
+++ b/roles/pihole/tasks/verify.yml
@@ -44,22 +44,28 @@
       Adlist download likely failed — check `pihole -g` output and the
       addresses in pihole_adlists.
 
-- name: Verify legitimate canary ({{ pihole_verify_canary_legit }}) resolves to a real address
-  ansible.builtin.command: "getent ahosts {{ pihole_verify_canary_legit }}"
+# Query the *local* Pi-hole directly via dig instead of going through
+# the host's NSS / systemd-resolved stack. On a host with multiple DNS
+# servers configured (e.g. the LAN's DHCP-advertised resolver visible
+# on a per-link basis), getent/resolved may answer from a different
+# server entirely and tell us nothing about whether *this* Pi-hole is
+# blocking. dig @127.0.0.1:1053 always asks the local instance.
+- name: Verify legitimate canary ({{ pihole_verify_canary_legit }}) resolves to a real address (via local Pi-hole)
+  ansible.builtin.command: "dig @127.0.0.1 -p 1053 +short +time=3 +tries=2 {{ pihole_verify_canary_legit }} A"
   register: _pihole_verify_legit
   changed_when: false
   failed_when: >-
     _pihole_verify_legit.rc != 0 or
     _pihole_verify_legit.stdout | length == 0 or
-    (_pihole_verify_legit.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is not none
+    (_pihole_verify_legit.stdout_lines | first | default('') == '0.0.0.0')
 
-- name: Verify blocked canary ({{ pihole_verify_canary_blocked }}) is sinkholed
-  ansible.builtin.command: "getent ahosts {{ pihole_verify_canary_blocked }}"
+- name: Verify blocked canary ({{ pihole_verify_canary_blocked }}) is sinkholed (via local Pi-hole)
+  ansible.builtin.command: "dig @127.0.0.1 -p 1053 +short +time=3 +tries=2 {{ pihole_verify_canary_blocked }} A"
   register: _pihole_verify_blocked
   changed_when: false
   failed_when: >-
-    _pihole_verify_blocked.rc == 0 and
-    (_pihole_verify_blocked.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is none
+    _pihole_verify_blocked.rc != 0 or
+    (_pihole_verify_blocked.stdout_lines | first | default('') != '0.0.0.0')
 
 - name: Sample {{ pihole_verify_random_count }} random domains from gravity
   become: true
@@ -71,14 +77,14 @@
   register: _pihole_verify_random_sample
   changed_when: false
 
-- name: Verify each random sample is sinkholed (no upstream leaks)
-  ansible.builtin.command: "getent ahosts {{ item }}"
+- name: Verify each random sample is sinkholed by local Pi-hole
+  ansible.builtin.command: "dig @127.0.0.1 -p 1053 +short +time=3 +tries=2 {{ item }} A"
   register: _pihole_verify_random_check
   changed_when: false
   loop: "{{ _pihole_verify_random_sample.stdout_lines }}"
   failed_when: >-
-    _pihole_verify_random_check.rc == 0 and
-    (_pihole_verify_random_check.stdout_lines | first | default('') | regex_search('^(0\.0\.0\.0|::)\s')) is none
+    _pihole_verify_random_check.rc != 0 or
+    (_pihole_verify_random_check.stdout_lines | first | default('') != '0.0.0.0')
 
 # --- Unbound path (only when pihole_enable_unbound is true) ---
 


### PR DESCRIPTION
## Summary

- \`roles/pihole/tasks/verify.yml\` ran \`getent ahosts <domain>\` for the canary checks and the random-sample sinkhole probe. That goes through the host's NSS → systemd-resolved → whichever per-link DNS server resolved picks. On a host where the LAN's DHCP advertises another resolver (e.g. a production Pi-hole at 192.168.1.231 on a sibling test box), resolved may answer from that server instead of the local Pi-hole on \`127.0.0.1:1053\`. Verify then passes or fails based on what *some other* Pi-hole's gravity blocks — meaningless for this Pi-hole.
- Switch all three checks (legit canary, blocked canary, random sample) to \`dig @127.0.0.1 -p 1053\` so the queries always hit the local Pi-hole.
- Add \`bind-utils\` to \`os_base_packages\` so \`dig\` is universally available — also a prerequisite for any DNS troubleshooting on a Pi-hole host.

Caught when homeserver2's verify.yml flagged \`www.binsenusa.com\` and \`www.milkyfan.com\` as "leaked". Direct \`dig @127.0.0.1 -p 1053\` to local Pi-hole returned \`0.0.0.0\` for both; \`resolvectl query\` showed the queries were going to production homeserver's Pi-hole instead, which doesn't block those specific entries.

## Test plan

- [ ] Re-run \`ansible-playbook playbooks/pihole.yml --limit homeserver2\` (without \`--skip-tags verify\`) and confirm the verify block passes.
- [ ] Re-run on production homeserver and confirm verify still passes there (no regression on the working case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)