### PR TITLE
gitignore: ignore the homeserver2 host_vars symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ inventory/host_vars/homeserver.yml
 # Local symlinks into the private repo
 inventory/host_vars/homeserver
 inventory/host_vars/homeserver-test
+inventory/host_vars/homeserver2
 
 # Syncthing personal config (device IDs, private key)
 roles/syncthing/files/volumes/syncthing-config/config/key.pem


### PR DESCRIPTION
## Summary

Adds \`inventory/host_vars/homeserver2\` to \`.gitignore\`, matching the existing pattern for \`homeserver\` and \`homeserver-test\`. The actual host_vars (including vault-encrypted secrets) live in the \`home-server-private\` overlay; the public repo only carries a symlink that must never be committed.

Surfaced when adding the new homeserver2 test box — its symlink showed up as untracked in \`git status\` because the gitignore was missing the entry.

## Test plan

- [x] \`git status\` no longer reports \`inventory/host_vars/homeserver2\` as untracked.
- [ ] Re-clone test: clone the repo fresh, follow the README symlink steps for homeserver2, confirm \`git status\` stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)