### PR TITLE
README: drop "Home Server" prefix, split headline onto two lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Server — Accelerate your journey to privacy and owning your data — build your own private ecosystem.
+# Accelerate your journey to privacy and owning your data <br>Build your own private ecosystem.
 
 ## Objective
 


### PR DESCRIPTION
## Summary

Headline tightening. Drop the \`Home Server —\` prefix (the GitHub URL/repo name already conveys it) and split the headline onto two lines via an inline \`<br>\`, so the value proposition leads and the "build your own private ecosystem" tagline sits underneath.

## Test plan

- [ ] Render on GitHub and confirm the H1 displays as two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)