### PR TITLE
music-assistant: add player_enabled toggle for headless hosts

### DIFF
--- a/roles/music-assistant/defaults/main.yml
+++ b/roles/music-assistant/defaults/main.yml
@@ -4,9 +4,17 @@
 # pull rate limit (unlike Docker Hub).
 music_assistant_server_image: "ghcr.io/music-assistant/server:latest"
 
-# Squeezelite player image — same as the jukebox role uses for LMS.
-# Music Assistant has a built-in SlimProto server, so this player
-# connects to MA over the pod-local network.
+# Whether to deploy the local Squeezelite player container alongside
+# the MA server. Squeezelite needs a real ALSA device on the host
+# (USB DAC, on-board audio, …); on a headless box without any sound
+# card the container starts and exits immediately ("no soundcards
+# found"). Set to false on hosts that should only run the MA server
+# and drive *external* players (AirPlay / Cast / UPnP / other
+# Squeezelite devices on the LAN).
+music_assistant_player_enabled: true
+
+# Squeezelite player image. Music Assistant has a built-in SlimProto
+# server, so this player connects to MA over the pod-local network.
 music_assistant_player_image: "docker.io/giof71/squeezelite"
 
 # Squeezelite preset selecting the audio output device. The

--- a/roles/music-assistant/tasks/main.yml
+++ b/roles/music-assistant/tasks/main.yml
@@ -94,12 +94,20 @@
     podman_quadlet_app_name: "music-assistant-pod"
     podman_quadlet_rootless_user_name: music-assistant
     podman_quadlet_files_templates_src_path: "{{ music_assistant_role_path }}"
-    podman_quadlet_file_names:
-      - music-assistant-server.container.j2
-      - music-assistant-player.container.j2
-      - music-assistant.pod.j2
-      - music-assistant.network
-      - music-assistant-data.volume
+    # Player container is only included when music_assistant_player_enabled
+    # is true (host actually has audio hardware). On headless boxes the
+    # MA server runs alone and drives external players over the LAN.
+    podman_quadlet_file_names: >-
+      {{
+        [
+          'music-assistant-server.container.j2',
+          'music-assistant.pod.j2',
+          'music-assistant.network',
+          'music-assistant-data.volume',
+        ] +
+        (['music-assistant-player.container.j2']
+          if music_assistant_player_enabled | bool else [])
+      }}
     # Music Assistant web UI is reverse-proxied by Caddy at
     # https://music.<caddy_domain> — direct LAN access on
     # {{ music_assistant_web_port }} intentionally not exposed.


### PR DESCRIPTION
## Summary

The squeezelite player container needs a real ALSA device. On a host without any soundcard (e.g. a VM or test box without a USB DAC), the container starts and exits within ~250 ms with "no soundcards found"; \`music-assistant-player.service\` ends up permanently inactive. The MA server itself is unaffected.

Add \`music_assistant_player_enabled\` (bool, default: \`true\`). When \`false\`, the player \`.container.j2\` is omitted from the quadlet file list — only the MA server is deployed. The server is fully functional and can drive external players (AirPlay / Cast / UPnP / external Squeezelite on the LAN); it just lacks a local playback sink.

Caught on homeserver2, which is headless. After this lands, set \`music_assistant_player_enabled: false\` in that host's host_vars (private overlay).

## Test plan

- [x] On homeserver2, re-run \`ansible-playbook playbooks/music-assistant.yml --limit homeserver2\` after setting the var to false → only \`music-assistant-server.service\` exists; the player service is absent.
- [ ] On production (homeserver), the role runs unchanged (default \`true\`) → both server and player still deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)