### PR TITLE
README: add work-in-progress banner at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Accelerate your journey to privacy and owning your data <br>Build your own private ecosystem.
 
+> [!WARNING]
+> **Work in progress — not ready for production use yet.**
+> The project is under active development. The architecture, role
+> contracts, inventory layout, and even the deploy_services list
+> still change without warning between commits. Read the README and
+> the [Quickstart](docs/Quickstart.md) to follow along, but expect
+> rough edges and don't trust the current state with data you can't
+> afford to lose.
+
 ## Objective
 
 There are plenty of homeserver projects already. Why another one?


### PR DESCRIPTION
## Summary

Add a GitHub \`[!WARNING]\` callout immediately under the title so visitors landing on the repo immediately see that the project is under active development and not ready for production use.

> **Work in progress — not ready for production use yet.**
> The project is under active development. The architecture, role contracts, inventory layout, and even the deploy_services list still change without warning between commits. Read the README and the Quickstart to follow along, but expect rough edges and don't trust the current state with data you can't afford to lose.

## Test plan

- [ ] Render on GitHub and confirm the yellow warning callout displays as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)