### PR TITLE
docs: rewrite Quickstart for AL9 + add 4 install-method docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 > [!WARNING]
 > **Work in progress — not ready for production use yet.**
-> The project is under active development. The architecture, role
+> The project is under active development and as of now it's not
+> exactly working as described. The architecture, role
 > contracts, inventory layout, and even the deploy_services list
-> still change without warning between commits. Read the README and
-> the [Quickstart](docs/Quickstart.md) to follow along, but expect
-> rough edges and don't trust the current state with data you can't
-> afford to lose.
+> still change without warning between commits.
 
 ## Objective
 

--- a/docs/Install-CloudInit.md
+++ b/docs/Install-CloudInit.md
@@ -1,0 +1,52 @@
+# Install method: cloud-init self-provisioning
+
+Use this when:
+
+- You're deploying on a **cloud VPS** that supports `cloud-init`
+  (Hetzner, DigitalOcean, OVH, Linode, Vultr, Scaleway, AWS
+  Lightsail, Google Cloud, …).
+- You want **zero-touch provisioning** — paste a `user-data` blob
+  into the provider's "Create VM" form and walk away.
+
+End state: AlmaLinux 9 booted *and the entire homeserver stack
+deployed*. No SSH session opened.
+
+> [!WARNING]
+> **Coming soon — not implemented yet.** The full design is in
+> [`CloudInit-Self-Provision-Plan.md`](CloudInit-Self-Provision-Plan.md)
+> and tracked in [issue #106](https://github.com/luckynrslevin/home-server/issues/106).
+>
+> Today, you can still *manually* use AlmaLinux 9 cloud images and
+> configure SSH access via cloud-init — see
+> [Install-VPS.md](Install-VPS.md). The future cloud-init route
+> will collapse the bootstrap + ansible-playbook steps into a
+> single user-data paste.
+
+## When this lands, the flow will be
+
+1. Pick AlmaLinux 9 cloud image at your provider.
+2. Paste a prepared `user-data` blob into the "Cloud-init" /
+   "User data" / "Custom script" field. The blob includes:
+   - Your SSH public key.
+   - The git URL of your `home-server-private` overlay (with a
+     deploy-key token, ideally fetched from a one-shot signed URL
+     for security).
+   - Your vault password.
+   - Hostname + chosen SSH port.
+   - Which `deploy_services` preset to use (e.g.
+     `cloud-vserver-dns`, `cloud-vserver-files`, `cloud-vserver-full`).
+3. Click "Create VM".
+4. Wait 15–30 minutes.
+5. `https://<hostname>` returns the dashboard.
+
+No bootstrap-host.sh run, no Ansible-from-laptop step — the box
+provisions itself end-to-end.
+
+## Until then, the alternatives
+
+If you need to deploy on a cloud VPS *today*:
+
+- **[Install-VPS.md](Install-VPS.md)** — get an AlmaLinux 9 VPS
+  with SSH access set up via the provider's UI (or cloud-init for
+  just the SSH key bit), then continue with
+  [Quickstart](Quickstart.md).

--- a/docs/Install-Kickstart.md
+++ b/docs/Install-Kickstart.md
@@ -1,0 +1,95 @@
+# Install method: Kickstart (unattended bare-metal install)
+
+Use this when:
+
+- You have a physical machine in front of you (mini-PC, NUC,
+  repurposed laptop, …).
+- You want a **reproducible**, unattended OS install — no clicking
+  through the Anaconda installer, every install identical.
+- You'll likely re-install this box more than once (testing,
+  hardware swap, recovery from a bad state).
+
+End state: AlmaLinux 9 booted, your SSH key authorized for a
+non-root user, that user has passwordless sudo. Ready for the
+[Quickstart](Quickstart.md).
+
+## What's included
+
+The repo ships an example kickstart at
+[`!Linux-kickstart/ks.cfg`](../!Linux-kickstart/ks.cfg). Copy and
+adapt it to your hardware:
+
+| Setting | Where to change |
+|---|---|
+| Network device name | `network --device=enp1s0` (likely `eno1`, `eth0`, `enp2s0`, … on your hardware) |
+| Hostname | `network --hostname=homeserver` |
+| Disk device | `ignoredisk --only-use=nvme0n1` (or `sda`, `sdb`, …) and the matching `clearpart` line |
+| Partition sizes | the `part` lines further down |
+| User account | the `user` line — set username, group, password hash |
+| SSH public key | `sshkey --username=...` line |
+| Timezone | `timezone Europe/Berlin` |
+
+> [!IMPORTANT]
+> The kickstart wipes the target disk. Double-check the disk
+> device name (`nvme0n1` vs `sda`) before booting it against your
+> hardware.
+
+## Step 1 — Prepare the install media
+
+1. Download the **AlmaLinux 9 boot ISO** from
+   [almalinux.org/get-almalinux](https://almalinux.org/get-almalinux/).
+2. Flash it to a USB stick:
+   ```bash
+   sudo dd if=AlmaLinux-9.x-x86_64-boot.iso of=/dev/sdX bs=4M status=progress
+   ```
+   (replace `/dev/sdX` with your actual USB device — careful, this
+   wipes it).
+
+There's a helper script at
+[`scripts/prepare-installer-usb.sh`](../scripts/prepare-installer-usb.sh)
+that automates the dd step.
+
+## Step 2 — Host the kickstart file
+
+The installer needs to fetch `ks.cfg` over the network. Two
+options:
+
+- **Web server** — host it at any URL (your laptop running
+  `python3 -m http.server`, a GitHub raw URL, an internal
+  webserver, …).
+- **USB second partition / second stick** — boot with
+  `inst.ks=hd:LABEL=<label>:/path/ks.cfg`.
+
+## Step 3 — Boot and pass the kickstart URL
+
+At the AlmaLinux installer boot screen, press `Tab` (or `e` for
+GRUB) to edit the kernel command line and append:
+
+```
+inst.ks=https://your.host/ks.cfg
+```
+
+Hit Enter. The installer runs unattended: partitions the disk,
+installs packages, configures the user, reboots into the new
+system.
+
+## Step 4 — Verify SSH access
+
+After reboot, from your laptop:
+
+```bash
+ssh youruser@<server-ip>
+sudo -n true && echo "OK"
+```
+
+If `OK` prints, you're done. Continue with
+[Quickstart](Quickstart.md) → Step 2.
+
+## When to pick a different method
+
+- Need a **cloud** box, not a physical one: see
+  [Install-VPS.md](Install-VPS.md).
+- Want the **fully-automated, paste-once** path on a cloud VPS: see
+  [Install-CloudInit.md](Install-CloudInit.md).
+- Doing a one-off hand-installed box where reproducibility doesn't
+  matter: [Install-Manual.md](Install-Manual.md) is faster.

--- a/docs/Install-Manual.md
+++ b/docs/Install-Manual.md
@@ -1,0 +1,101 @@
+# Install method: Manual install on hardware
+
+Use this when:
+
+- You have physical hardware and want to install **without** a
+  kickstart file (one-off, exploratory, or you just prefer
+  click-through).
+- You're doing a single-shot install and don't expect to
+  re-provision this box.
+
+End state: AlmaLinux 9 booted on the hardware, you can SSH in as a
+non-root sudo user. Ready for the [Quickstart](Quickstart.md).
+
+If you'll be doing this more than once, the
+**[Kickstart route](Install-Kickstart.md)** is faster and gives
+you reproducible installs.
+
+## Step 1 — Prepare the install media
+
+1. Download the **AlmaLinux 9 DVD** ISO (full installer, ~10 GB)
+   or the **boot ISO** (~900 MB, fetches packages over the
+   network) from
+   [almalinux.org/get-almalinux](https://almalinux.org/get-almalinux/).
+2. Flash to a USB stick:
+   ```bash
+   sudo dd if=AlmaLinux-9.x-x86_64-dvd.iso of=/dev/sdX bs=4M status=progress
+   ```
+   (replace `/dev/sdX` carefully — this wipes the device).
+
+There's a helper at
+[`scripts/prepare-installer-usb.sh`](../scripts/prepare-installer-usb.sh).
+
+## Step 2 — Boot the installer and click through
+
+Insert the USB, boot the box, pick "Install AlmaLinux 9" at the
+GRUB menu. The Anaconda installer comes up.
+
+Walk through the installation steps:
+
+1. **Language / keyboard / timezone** — set to your locale.
+2. **Software selection** — pick **"Server"** (text-mode admin
+   tools, no GUI). The Quickstart doesn't need GNOME or KDE.
+3. **Installation destination** — pick the target disk. Use
+   automatic partitioning unless you have a specific layout in
+   mind.
+4. **Network & host name** — connect the network interface, set
+   the hostname to something memorable (e.g. `homeserver`).
+5. **Root account** — set a strong root password. You'll disable
+   root SSH later via `bootstrap-host.sh`, so this only matters
+   for emergency console access.
+6. **User creation** — **important**:
+   - Create a normal user (e.g. `ds`, `admin`, your name).
+   - **Tick "Make this user administrator"** — this adds the user
+     to the `wheel` group and grants sudo access.
+   - Set a password (you can disable password auth later via
+     `bootstrap-host.sh`).
+7. **Begin installation**, wait for it to finish, reboot.
+
+## Step 3 — Configure passwordless sudo
+
+By default, `wheel` group members can sudo *with* their password.
+The setup script needs **passwordless** sudo. SSH in:
+
+```bash
+ssh youruser@<server-ip>
+```
+
+Then create a sudoers drop-in:
+
+```bash
+echo "youruser ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/90-youruser
+sudo chmod 0440 /etc/sudoers.d/90-youruser
+```
+
+Verify:
+
+```bash
+sudo -n true && echo "OK"
+```
+
+## Step 4 — Install your SSH key
+
+If you didn't add it during the installer:
+
+From your **laptop**:
+
+```bash
+ssh-copy-id youruser@<server-ip>
+```
+
+Test that key auth works without prompting for a password:
+
+```bash
+ssh youruser@<server-ip> 'whoami'
+```
+
+## Step 5 — Continue with Quickstart
+
+You now have an AlmaLinux 9 box with SSH-key access and
+passwordless sudo. Continue with **[Quickstart](Quickstart.md)**
+→ Step 2.

--- a/docs/Install-VPS.md
+++ b/docs/Install-VPS.md
@@ -1,0 +1,113 @@
+# Install method: VPS in the cloud
+
+Use this when:
+
+- You want a homeserver-style stack running in the **cloud**, not
+  at home (e.g. a public-facing DNS resolver, a cheap test box, a
+  service that needs to be reachable while you're travelling).
+- You don't have or don't want to run physical hardware.
+
+End state: AlmaLinux 9 booted at a hosting provider, you can SSH
+in as a non-root sudo user. Ready for the
+[Quickstart](Quickstart.md).
+
+> [!NOTE]
+> The future [cloud-init self-provisioning](Install-CloudInit.md)
+> path will combine the steps below with the full Ansible deploy
+> in a single paste. Until that lands, this is the manual route.
+
+## Picking a provider
+
+Any provider that offers AlmaLinux 9 cloud images works. As of
+today (2026):
+
+| Provider | AL 9 images | Notes |
+|---|:---:|---|
+| Hetzner Cloud | ✓ | Cheapest mainstream EU host. €4–8/mo gets you a comfortable mini-homeserver. |
+| DigitalOcean | ✓ | Marketplace + base images both available. |
+| OVH / OVHcloud | ✓ | Usually the cheapest if you can tolerate the UI. |
+| Linode (Akamai) | ✓ | Solid US/EU coverage. |
+| Vultr | ✓ | Wide region selection. |
+| Scaleway | ✓ | Strong EU privacy story. |
+| AWS Lightsail | ✓ | Most expensive of the bunch for the same specs. |
+| Google Cloud / Compute Engine | ✓ | Pay for what you use, more setup overhead. |
+
+Pick on price + region + your existing accounts.
+
+## Sizing
+
+For the full default stack (Pi-hole + Caddy + Syncthing + Music
+Assistant + Ente + Paperless + Jellyfin):
+
+- **Minimum**: 4 GB RAM, 2 vCPU, 80 GB disk. Tight; works for one
+  user.
+- **Comfortable**: 8 GB RAM, 4 vCPU, 160 GB disk. Recommended.
+
+For a **focused subset** (e.g. just DNS + Caddy + Syncthing):
+1 GB RAM, 1 vCPU, 20 GB disk is enough. (See `dnsvserver` in
+the example inventory for a small-footprint deploy.)
+
+## Step 1 — Provision the VM
+
+At the provider's "Create VM" page:
+
+1. **OS image**: AlmaLinux 9.x.
+2. **SSH key**: paste your laptop's `~/.ssh/id_ed25519.pub`. Most
+   providers add it to the default cloud user's `authorized_keys`
+   automatically via cloud-init.
+3. **Cloud-init / user-data** field (optional but cleaner): paste
+   a minimal block that creates a non-root user with passwordless
+   sudo. See the snippet below.
+
+Most providers' AlmaLinux 9 images create a default cloud user
+called `almalinux` with passwordless sudo via cloud-init. If
+that's the case, you can skip the user-data block — just SSH in
+as `almalinux@<ip>`.
+
+### Optional cloud-init snippet for a custom user
+
+If you want a user with a name other than `almalinux`:
+
+```yaml
+#cloud-config
+users:
+  - name: ds
+    groups: wheel
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA... your-laptop-key
+```
+
+## Step 2 — SSH in and verify sudo
+
+```bash
+ssh almalinux@<vm-ip>      # or ds@<vm-ip> if you used the snippet
+sudo -n true && echo "OK"
+```
+
+## Step 3 — Open the right inbound ports
+
+For a public-facing homeserver you'll need at least:
+
+- **22/tcp** during initial setup (move to a non-default port via
+  `bootstrap-host.sh` after first deploy).
+- **80/tcp + 443/tcp** for Caddy (web UIs).
+- Whatever **Tailscale** needs (UDP 41641 for direct connections;
+  most providers don't filter outbound, so usually nothing
+  inbound to open).
+
+Most cloud providers have a separate firewall layer (security
+groups). Configure those alongside the host's `firewalld`.
+
+## Step 4 — Continue with Quickstart
+
+You now have an AlmaLinux 9 VPS with SSH access via a sudo user.
+Continue with **[Quickstart](Quickstart.md)** → Step 2.
+
+## Caveats for cloud deploys
+
+The default `deploy_services` list assumes a home-LAN context (NAS
+mounts, AirPlay, USB DAC, etc.). On a cloud VPS, you'll want to
+pare it down. The example `dnsvserver` host in the inventory is a
+good template for a small cloud-only deploy.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,357 +1,132 @@
-# Quickstart Guide
+# Quickstart
 
-Step-by-step instructions to deploy your own home server using this project.
+The fast path: get a working homeserver in under an hour, running
+the setup directly on the server itself. No separate Ansible
+control machine needed.
 
 ## Prerequisites
 
-- **Fedora Server** installed on a dedicated machine (mini PC, old laptop,
-  NUC) or a VM
-- Basic familiarity with the Linux command line and SSH
+You need an **AlmaLinux 9** machine you can SSH into, with these
+two properties:
 
-### Networking requirements
+1. SSH login as a **non-root user** (e.g. `ds`, `admin`, your
+   first name — anything but `root`).
+2. That user has **passwordless sudo** (`ALL=(ALL) NOPASSWD:ALL` in
+   `/etc/sudoers.d/`).
 
-Your server must be a **direct host on your home network** — not behind
-an additional NAT layer. If you're using a VM (e.g., UTM, VirtualBox,
-Proxmox), configure it with **bridged networking** so it gets its own IP
-address from your home router, just like a physical machine.
+If you don't have that yet, pick one of the install methods below
+and come back when you do:
+
+- **[Kickstart on bare metal](Install-Kickstart.md)** — unattended
+  AlmaLinux 9 install from USB or PXE on a mini-PC / NUC / repurposed
+  laptop. Best when you have hardware in front of you and want
+  reproducibility.
+- **[Cloud-init self-provision](Install-CloudInit.md)** — paste a
+  `user-data` blob into your VPS provider's "Create VM" form.
+  *(Coming soon — see the [implementation plan](CloudInit-Self-Provision-Plan.md).)*
+- **[VPS in the cloud](Install-VPS.md)** — pick AlmaLinux 9 at
+  Hetzner / DigitalOcean / OVH / Linode, configure SSH access at
+  VM-create time. Manual today; cloud-init route above will
+  automate it.
+- **[Manual install on hardware](Install-Manual.md)** — the
+  AlmaLinux 9 Anaconda installer, click-through. Slowest but
+  works on any hardware.
+
+## Networking
+
+Whichever install path you pick, the box must be a **direct host on
+your home network** — not behind an additional NAT layer. If you're
+using a VM (UTM, VirtualBox, Proxmox, …), configure it with
+**bridged networking** so it gets its own IP address from your home
+router, just like a physical machine.
 
 Services like AirPlay (Shairport-sync) and DNS (Pi-hole) rely on
-mDNS/Bonjour discovery and direct LAN connectivity.
-These will not work correctly behind a NAT or on a virtual host-only
-network.
+mDNS / Bonjour discovery and direct LAN connectivity, and won't work
+correctly behind a NAT or on a virtual host-only network.
 
----
+Also: pin the server's IP via a **DHCP reservation on your router**.
+Several roles assume the server's LAN IP is stable (Caddy reverse
+proxy hostnames, Pi-hole local DNS records). Lease drift will
+eventually break them.
 
-## Quick start (single command)
+## Step 1 — SSH in as your sudo user
 
-On a freshly installed Fedora Server, run:
+```bash
+ssh youruser@<server-ip>
+```
+
+Confirm passwordless sudo works:
+
+```bash
+sudo -n true && echo "OK: sudo without password works"
+```
+
+If that prints `OK`, you're good. If it asks for a password,
+configure the `NOPASSWD:ALL` sudoers drop-in first.
+
+## Step 2 — Run the interactive setup script
+
+On the server (not your laptop):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/setup.sh \
   -o /tmp/setup.sh && bash /tmp/setup.sh
 ```
 
-This interactive script will:
-1. Install Ansible, Podman, and dependencies
-2. Clone this repository
-3. Walk you through network configuration and service selection
-4. Generate all config files with vault-encrypted secrets
-5. Deploy the selected services
+The script is interactive — it walks you through:
 
-The server acts as its own Ansible controller — no separate workstation
-needed. After the script finishes, open `http://<server-ip>` to see
-your dashboard.
+1. Installs Ansible, podman, dependencies.
+2. Clones the public repo into `~/home-server`.
+3. Installs the Galaxy role dependency
+   (`luckynrslevin.podman_quadlet`).
+4. Walks you through inventory + host_vars setup, generates
+   vault-encrypted secrets.
+5. Lets you pick which services to deploy.
+6. Runs `ansible-playbook playbooks/site.yml --connection=local
+   --limit <hostname>` against the local box.
 
-In case you face issues with individual services, see Tips and Tricks section below.
+The server acts as **its own Ansible controller** — no separate
+workstation needed.
 
-If you prefer more control over the setup, follow the manual steps
-below.
+When it finishes, open `https://<server-ip>` in your browser to see
+the dashboard.
 
----
+> [!NOTE]
+> The current `setup.sh` was written for Fedora Server and refuses
+> to run on other distros (`dnf` check + Fedora-specific package
+> assumptions). AlmaLinux 9 support is on the roadmap — until then,
+> use the manual deploy flow described in the project README and
+> the role-by-role playbooks in `playbooks/`.
 
-## Manual setup
+## Step 3 — Hand off to Ansible from your laptop (optional)
 
-### 1. Install the operating system
+If you'd rather drive the host from your laptop instead of staying
+on the server, the project also supports the classic
+"Ansible-host pushes to managed host" model. See the project
+[README](../README.md) for that flow:
 
-Flash **Fedora Server** onto a USB stick and boot your server from it.
-This project includes a kickstart file that automates the OS
-installation.
+1. Run `scripts/bootstrap-host.sh` on the server to harden sshd
+   (move off port 22, disable root login, disable password auth).
+2. Set up the `home-server-private` overlay on your laptop with
+   your inventory and vault.
+3. Symlink the overlay into the public repo clone.
+4. `ansible-playbook playbooks/site.yml --limit <host>` from the
+   laptop.
 
-#### Using the kickstart file
+## Troubleshooting
 
-1. Copy `!Linux-kickstart/ks.cfg` and edit it for your hardware:
-   - **Network device**: change `enp1s0` to your NIC name
-   - **Disk device**: change `nvme0n1` to your disk (e.g., `sda`)
-   - **Partition sizes**: adjust to your disk capacity
-   - **Hostname**: change `homeserver` to your preferred name
-   - **User**: change `myuser` to your username
-   - **SSH key**: paste your public key
-   - **Timezone**: change `Europe/Berlin` if needed
+If `setup.sh` aborts mid-deploy, the partial state is safe to
+re-run from — every role is idempotent. Re-running `setup.sh` from
+the same checkout picks up where it left off.
 
-2. Host the kickstart file on a web server (or USB) and boot Fedora
-   with the `inst.ks=` parameter pointing at it.
+For role-specific issues, each role has its own README under
+`roles/<name>/README.md` with debugging notes.
 
-3. The installer runs unattended: partitions the disk, installs
-   packages, configures automatic updates, and reboots.
+## Resetting the host
 
-After reboot, SSH into the server to verify: `ssh myuser@<server-ip>`.
-
-#### Manual install
-
-If you prefer not to use kickstart, install Fedora Server manually and
-ensure:
-- `podman` is installed (`sudo dnf install podman`)
-- Your user has passwordless sudo (`echo "myuser ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/myuser`)
-- SSH key authentication works
-
----
-
-### 2. Clone the repository and install dependencies
-
-SSH into your server and run:
+To wipe all home-server artifacts and start fresh (does **not**
+remove system packages or your primary user):
 
 ```bash
-git clone https://github.com/luckynrslevin/home-server.git
-cd home-server
-
-# Install Ansible (via pipx for the latest version)
-sudo dnf install -y pipx git python3-pyyaml
-pipx install ansible-core
-pipx inject ansible-core ansible
-
-# Install the Galaxy role dependency
-ansible-galaxy install -r roles/requirements.yml
+bash ~/home-server/scripts/clean-host.sh
 ```
-
----
-
-### 3. Set up your inventory
-
-#### hosts.yml
-
-Copy the example and fill in your server's details:
-
-```bash
-cp inventory/hosts.yml.example inventory/hosts.yml
-```
-
-Edit `inventory/hosts.yml`:
-
-```yaml
-all:
-  children:
-    homeservers:
-      hosts:
-        homeserver:
-          ansible_host: 127.0.0.1
-          ansible_connection: local
-          ansible_host_name: myserver
-          ansible_user: myuser
-```
-
-#### Host variables
-
-Create a directory for your host's configuration:
-
-```bash
-mkdir -p inventory/host_vars/homeserver
-cp inventory/host_vars/homeserver.yml.example \
-   inventory/host_vars/homeserver/main.yml
-```
-
-Edit `inventory/host_vars/homeserver/main.yml` and fill in:
-
-- **`deploy_services`** list — which services to deploy on this host
-- **Linux users** (UIDs/GIDs) for each service
-- **Service-specific settings** (hostnames, network ranges, ports)
-- **Vault-encrypted secrets** (see next step)
-
----
-
-### 4. Create vault-encrypted secrets
-
-Create a vault password file:
-
-```bash
-openssl rand -base64 32 > ~/.vaultpw
-chmod 400 ~/.vaultpw
-```
-
-Update `ansible.cfg` to point at it:
-
-```ini
-[defaults]
-vault_password_file = ~/.vaultpw
-```
-
-Generate and encrypt each secret. Example for Pi-hole:
-
-```bash
-openssl rand -base64 24 | \
-  ansible-vault encrypt_string \
-    --encrypt-vault-id default \
-    --stdin-name 'pihole_api_password'
-```
-
-Paste the output into `inventory/host_vars/homeserver/main.yml`.
-Repeat for each service's secrets (see the comments in the example
-file for which secrets each service needs).
-
----
-
-### 5. Create host-specific data files
-
-#### Dashboard config
-
-```bash
-cp roles/dashboard/files/dashboard-config.yaml.example \
-   inventory/host_vars/homeserver/dashboard-config.yaml
-```
-
-Edit it with your server's IP addresses in the service URLs.
-
-#### Syncthing identity (optional)
-
-Only needed if restoring a previous Syncthing installation. Create:
-
-```
-inventory/host_vars/homeserver/syncthing/
-  config.xml.j2    # Syncthing config template
-  cert.pem         # Device certificate
-  key.pem          # Device private key
-```
-
-And set `syncthing_restore_config: true` in your host vars.
-
----
-
-### 6. Deploy services
-
-Deploy all services declared in your `deploy_services` list:
-
-```bash
-ansible-playbook playbooks/site.yml --limit homeserver
-```
-
-Or deploy individual services:
-
-```bash
-ansible-playbook playbooks/pihole.yml --limit homeserver
-ansible-playbook playbooks/syncthing.yml --limit homeserver
-```
-
-You don't need to deploy all services. Pick the ones you want.
-
----
-
-### 7. Verify
-
-Open your browser and go to `http://<server-ip>` to see the dashboard.
-It shows each service's status, container image, update availability,
-volume sizes, and backup timestamps.
-
-Each service also has its own web UI (where applicable):
-
-| Service | URL |
-|---------|-----|
-| Pi-hole | `https://<server-ip>:8443/admin` |
-| Syncthing | `https://<server-ip>:8384` |
-| Jukebox (LMS) | `http://<server-ip>:9100` |
-| Ente Photos | `http://<server-ip>:3000` |
-
----
-
-## Project structure
-
-```
-home-server/
-  setup.sh                             # Interactive single-command installer
-  !Linux-kickstart/ks.cfg              # OS install automation
-  ansible.cfg                          # Ansible configuration
-  playbooks/
-    site.yml                           # Deploy all services for a host
-    <service>.yml                      # Deploy a single service
-  roles/                               # One role per service
-    <role>/
-      defaults/main.yml                # Default variables (generic)
-      tasks/main.yml                   # Deployment logic
-      files/quadlets/                  # Podman Quadlet unit files
-      templates/                       # Jinja2 templates
-  scripts/
-    clean-host.sh                      # Reset a host to clean state
-  inventory/
-    hosts.yml.example                  # Example inventory
-    host_vars/
-      homeserver.yml.example           # Example host variables
-      homeserver/                      # Per-host directory
-        main.yml                       # Variables + vault-encrypted secrets
-        dashboard-config.yaml          # Dashboard service list
-        syncthing/                     # Syncthing identity files (optional)
-```
-
----
-
-## Adding a test server
-
-To test changes before deploying to production, add a second host:
-
-1. Add it to `inventory/hosts.yml` under the `homeservers` group
-2. Create `inventory/host_vars/<testhost>/main.yml` with its own
-   config, secrets, and `deploy_services` list
-3. Deploy with `--limit`:
-   ```bash
-   ansible-playbook playbooks/site.yml --limit homeserver-test
-   ```
-
----
-
-## Updating services
-
-Container images auto-update via `podman-auto-update.timer` (runs
-daily). The dashboard shows when updates are available.
-
-To re-deploy a role after changing its configuration:
-
-```bash
-ansible-playbook playbooks/<service>.yml --limit homeserver
-```
-
----
-
-## Resetting a host
-
-To remove all home-server artifacts and start fresh:
-
-```bash
-ssh <host> 'bash -s' < scripts/clean-host.sh
-```
-
-Or run directly on the host:
-
-```bash
-bash scripts/clean-host.sh
-```
-
-This removes all containers, service users, firewall rules, and
-deployed configs. It does not remove system packages or your primary
-user.
-
----
-
-## Backup and restore
-
-The backup role writes to NFS shares on a NAS. Configure
-`backup_nas_hostname`, `backup_nas_ip`, and `backup_nas_volume` in
-your host vars, then:
-
-```bash
-ansible-playbook playbooks/backup.yml --limit homeserver
-```
-
-The backup runs at the time configured by `backup_time` (default:
-02:00) via a systemd timer. It uses:
-- `podman volume export` (tar) for small config volumes
-- `rsync` for large data volumes
-- `pg_dump` for PostgreSQL databases
-
-To restore: re-run the service's playbook (recreates the container),
-then import the backup volume with `podman volume import`.
-
----
-
-## Per-service documentation
-
-Each role has its own README with variables, secrets, firewall
-ports, deployment notes, and troubleshooting:
-
-- [backup](../roles/backup/README.md) — nightly NFS backup of every service's volumes
-- [caddy](../roles/caddy/README.md) — front-door web server
-- [dashboard](../roles/dashboard/README.md) — generated status page
-- [entephoto](../roles/entephoto/README.md) — Ente Photos (Postgres + MinIO + Museum + Web)
-- [jukebox](../roles/jukebox/README.md) — Lyrion Music Server + Squeezelite
-- [os-audio](../roles/os-audio/README.md) — ALSA prerequisites (used by shairportsync, jukebox)
-- [pihole](../roles/pihole/README.md) — Pi-hole DNS ad-blocker
-- [shairportsync](../roles/shairportsync/README.md) — AirPlay receiver (incl. audio debugging)
-- [syncthing](../roles/syncthing/README.md) — file sync
-- [paperless-ngx](../roles/paperless-ngx/README.md) — document management (OCR + search)
-- [jellyfin](../roles/jellyfin/README.md) — media server (movies, TV, music)


### PR DESCRIPTION
## Summary

Rewrite \`docs/Quickstart.md\` as the AlmaLinux 9 on-target happy path: SSH in as a non-root sudo user, run \`setup.sh\` on the server itself, done. The old version was Fedora-Server-flavoured and described a laptop-driven Ansible flow; the new version matches the project's actual current direction.

Split the "how do I get to an AlmaLinux 9 box with SSH access in the first place" question into four dedicated install-method docs:

- **\`docs/Install-Kickstart.md\`** — unattended bare-metal install via the \`ks.cfg\` shipped under \`!Linux-kickstart/\`.
- **\`docs/Install-CloudInit.md\`** — placeholder for the future one-paste self-provision flow. Links the plan doc + tracking [issue #106](https://github.com/luckynrslevin/home-server/issues/106). Flagged as not implemented yet; users today are pointed at Install-VPS.
- **\`docs/Install-VPS.md\`** — manual cloud-VPS provisioning, with provider comparison table, sizing guidance, optional cloud-init snippet for a custom user, and post-install firewall notes.
- **\`docs/Install-Manual.md\`** — Anaconda click-through for one-off bare-metal installs.

Each install doc converges on the same end state (AL9 booted, non-root sudo user, SSH key in \`authorized_keys\`) and links forward to **Quickstart Step 2**.

## Known gaps flagged in the new Quickstart

- \`setup.sh\` currently has a hard \`dnf\`/Fedora check and Fedora-specific package assumptions. AL9 support is on the roadmap; until then, the manual playbook flow described in the README is the way.

## Test plan

- [ ] Render the four new docs on GitHub and verify the cross-links resolve.
- [ ] Sanity-check the Quickstart prerequisites table formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)