### PR TITLE
pihole: render-safe loop label on OUTPUT-chain redirect task

### DIFF
--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -145,9 +145,15 @@
       - REDIRECT
       - --to-ports
       - "1053"
-  loop: "{{ pihole_output_redirect_check.results }}"
+  loop: "{{ pihole_output_redirect_check.results | default([]) }}"
   loop_control:
-    label: "{{ item.item }}/53 -> 1053 (-d {{ pihole_host_lan_ip }})"
+    # default('?') keeps the label render-safe when the role is being
+    # evaluated on a host that won't actually run pihole (so
+    # pihole_host_lan_ip never got set). Ansible templates the label
+    # for every iteration even if the task is being skipped, so an
+    # undefined var here breaks the task on hosts that omit pihole
+    # from deploy_services.
+    label: "{{ item.item | default('?') }}/53 -> 1053 (-d {{ pihole_host_lan_ip | default('?') }})"
   when: item.rc != 0
   notify: Reload firewalld
 


### PR DESCRIPTION
## Summary

Fix a real role bug that breaks any deployment where pihole is *not* in \`deploy_services\` (e.g. a setup.sh run that doesn't select pihole).

\`loop_control.label\` is evaluated for every loop iteration even when the task is being skipped. The OUTPUT-chain DNS redirect task's label references \`pihole_host_lan_ip\` directly, which is only set by an earlier task that's also gated on \`pihole\` being in \`deploy_services\`. When pihole is absent:

- The earlier task correctly skips → \`pihole_host_lan_ip\` is undefined.
- The OUTPUT-redirect task tries to template its loop label → fails.
- Whole play fails even though the task body would have skipped anyway.

Wrap the two variable references in \`default('?')\` so the label renders cleanly on the skip path. No behaviour change on hosts that do deploy pihole — the defaults are only used when the task is being skipped.

Caught running setup.sh on homeserver2 (PR #111 branch) without selecting pihole.

## Test plan

- [ ] Re-run \`ansible-playbook playbooks/site.yml\` on a host whose \`deploy_services\` excludes pihole — task should report skipped, not failed.
- [ ] Re-run on a host that does include pihole — task still applies firewalld OUTPUT redirects, label still renders the real IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)