### PR TITLE
caddy: HTTP-served CA-trust landing page at /trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ If you want to get up and running quickly, head straight to the
 fresh-install path end-to-end (cloud-init bootstrap, private overlay
 setup, vault, and first deploy).
 
+Once deployed, install the homeserver's internal CA on each device
+that wants to reach the web UIs — visit
+`http://<caddy_domain>/trust` (plain HTTP, no warning) for download
+links and per-platform install instructions.
+
 A more detailed setup reference will land here in a follow-up
 revision.
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -91,15 +91,16 @@ The script is interactive — it walks you through:
 The server acts as **its own Ansible controller** — no separate
 workstation needed.
 
-When it finishes, open `https://<server-ip>` in your browser to see
-the dashboard.
+When it finishes, open `https://<caddy_domain>/` in your browser to
+see the dashboard.
 
-> [!NOTE]
-> The current `setup.sh` was written for Fedora Server and refuses
-> to run on other distros (`dnf` check + Fedora-specific package
-> assumptions). AlmaLinux 9 support is on the roadmap — until then,
-> use the manual deploy flow described in the project README and
-> the role-by-role playbooks in `playbooks/`.
+> [!IMPORTANT]
+> Your browser will show a certificate warning the first time
+> because the homeserver runs its own internal CA. Visit
+> **`http://<caddy_domain>/trust`** (plain HTTP, no warning) first —
+> the page has a one-click download for the root certificate plus
+> per-platform install instructions. Once installed, the dashboard
+> URL works cleanly with a green padlock.
 
 ## Step 3 — Hand off to Ansible from your laptop (optional)
 

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -101,17 +101,28 @@ for a LAN home server. Certificate data is persisted in `caddy-data`.
 
 ## Distributing the internal CA to client devices
 
-The role publishes the root CA at two URLs on the dashboard:
+The role publishes a small **HTTP-served landing page** plus the raw
+artifacts so a fresh device can bootstrap trust without first
+trusting the cert it's trying to download:
 
-| URL                              | For                       | UX                                                                                                  |
-|----------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------|
-| `/caddy-trust.mobileconfig`      | iOS / iPadOS / macOS      | Tap in Safari → install Apple configuration profile → two-tap trust on iOS, one-tap on macOS.       |
-| `/caddy-root.crt`                | Linux / Android / other   | Raw PEM cert; install via OS / browser certificate manager.                                         |
+| URL                                            | Scheme | For                       | UX                                                                                                  |
+|------------------------------------------------|:---:|---------------------------|-----------------------------------------------------------------------------------------------------|
+| `http://<caddy_domain>/trust`                  | HTTP | Any device, first install | Self-contained landing page with download links + per-platform install instructions. **Start here on a fresh device.** |
+| `http://<caddy_domain>/caddy-trust.mobileconfig` | HTTP | iOS / iPadOS / macOS      | Apple Configuration Profile bundling the root cert. Linked from the landing page.                    |
+| `http://<caddy_domain>/caddy-root.crt`         | HTTP | Linux / Android / Windows | Raw PEM cert. Linked from the landing page.                                                          |
 
-The mobileconfig profile is generated from
-`templates/caddy-trust.mobileconfig.j2` on every deploy, so a CA
-rotation regenerates the file automatically. The profile is
-unsigned (Apple displays a "Verify" prompt; the user accepts).
+These three paths are the only HTTP exemptions in the Caddyfile;
+everything else on `http://<caddy_domain>` 301-redirects to HTTPS as
+normal. Serving them over HTTP is safe — they're the **public** part
+of the CA and install instructions for it; nothing secret.
+
+Once installed, the user reaches the dashboard at
+`https://<caddy_domain>/` cleanly with no warnings.
+
+The landing page is rendered from
+`templates/trust.html.j2`; the mobileconfig from
+`templates/caddy-trust.mobileconfig.j2`. Both regenerate on every
+deploy, so a CA rotation refreshes them automatically.
 
 ## Internal CA persistence
 

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -183,3 +183,18 @@
   vars:
     caddy_ca_pem_content: "{{ _caddy_ca_pem.content | b64decode }}"
   when: caddy_domain | length > 0
+
+# HTTP-served landing page that walks the user through trusting the
+# CA on their device. Reachable at http://<caddy_domain>/trust without
+# a browser warning (chicken-and-egg fix: you can't fetch the cert
+# from HTTPS until you've trusted it). The Caddyfile exempts /trust,
+# /caddy-root.crt, and /caddy-trust.mobileconfig from the standard
+# HTTP→HTTPS redirect.
+- name: Publish CA-trust landing page via dashboard
+  become: true
+  ansible.builtin.template:
+    src: trust.html.j2
+    dest: /var/www/dashboard/trust.html
+    mode: "0644"
+    setype: container_file_t
+  when: caddy_domain | length > 0

--- a/roles/caddy/templates/trust.html.j2
+++ b/roles/caddy/templates/trust.html.j2
@@ -1,0 +1,133 @@
+{# Rendered to /var/www/dashboard/trust.html, served by Caddy at
+   http://{{ caddy_domain }}/trust (HTTP, no redirect). Plain HTML,
+   inline CSS, no JS, no external resources. #}
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Trust the homeserver CA — {{ caddy_domain }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+           max-width: 760px; margin: 2em auto; padding: 0 1em; color: #1a1a1a; line-height: 1.55; }
+    h1 { margin-bottom: 0.2em; }
+    h2 { margin-top: 1.8em; }
+    .domain { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #0066cc; }
+    .lead { color: #555; font-size: 1.05em; }
+    .downloads { display: flex; flex-wrap: wrap; gap: 0.8em; margin: 1.5em 0; }
+    .downloads a {
+      display: inline-block; padding: 0.85em 1.3em;
+      background: #0066cc; color: white; text-decoration: none;
+      border-radius: 6px; font-weight: 600;
+    }
+    .downloads a:hover { background: #0052a3; }
+    .downloads a small { display: block; font-weight: 400; opacity: 0.85; font-size: 0.85em; margin-top: 0.15em; }
+    details { background: #f4f6fa; border-radius: 6px; padding: 0.8em 1.2em; margin: 0.5em 0; }
+    details[open] { background: #eef1f7; }
+    summary { cursor: pointer; font-weight: 600; padding: 0.2em 0; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
+    pre { background: #1f1f1f; color: #f0f0f0; padding: 1em; border-radius: 6px; overflow-x: auto; }
+    .verify { background: #e8f4ea; border-left: 4px solid #2a8e3f; padding: 1em 1.2em; margin: 2em 0 1em; border-radius: 4px; }
+    .verify a { color: #1c6e2c; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>Trust the homeserver CA</h1>
+  <p class="lead">
+    Every web UI on this server is served at
+    <code class="domain">https://*.{{ caddy_domain }}/</code> with
+    a TLS certificate signed by your homeserver's own internal CA.
+    Install the CA's root certificate on this device once, and every
+    URL works with no warnings.
+  </p>
+
+  <h2>Step 1 — Download the right file for your device</h2>
+  <div class="downloads">
+    <a href="/caddy-trust.mobileconfig" download>
+      Apple Profile (.mobileconfig)
+      <small>iOS · iPadOS · macOS</small>
+    </a>
+    <a href="/caddy-root.crt" download>
+      Root certificate (.crt)
+      <small>Linux · Windows · Android</small>
+    </a>
+  </div>
+
+  <h2>Step 2 — Install on your device</h2>
+
+  <details>
+    <summary>macOS</summary>
+    <p>Option 1 — Apple Configuration Profile (recommended):</p>
+    <ol>
+      <li>Click <b>Apple Profile</b> above. The file downloads to <code>~/Downloads</code>.</li>
+      <li>Double-click the <code>.mobileconfig</code> file in Finder.</li>
+      <li>Open <b>System Settings → Privacy &amp; Security → Profiles</b>, find <i>Caddy Local CA</i>, click <b>Install</b>.</li>
+      <li>Open <b>Keychain Access → System</b>, find the <i>Caddy Local Authority</i> root, double-click it → <b>Trust → "When using this certificate" → Always Trust</b>.</li>
+    </ol>
+    <p>Option 2 — raw PEM via CLI:</p>
+    <pre>sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain \
+  ~/Downloads/caddy-root.crt</pre>
+  </details>
+
+  <details>
+    <summary>iOS / iPadOS</summary>
+    <ol>
+      <li>Open this page in <b>Safari</b> on the device (not in another browser).</li>
+      <li>Tap <b>Apple Profile</b> above. Safari shows "This website is trying to download a configuration profile". Tap <b>Allow</b>.</li>
+      <li>Open <b>Settings → General → VPN &amp; Device Management → Caddy Local CA → Install</b>.</li>
+      <li>Go to <b>Settings → General → About → Certificate Trust Settings</b> and toggle <b>Caddy Local Authority</b> on. (This step is mandatory — without it iOS won't actually trust the cert.)</li>
+    </ol>
+  </details>
+
+  <details>
+    <summary>Linux — Fedora / AlmaLinux / Rocky / RHEL</summary>
+    <pre>sudo cp ~/Downloads/caddy-root.crt /etc/pki/ca-trust/source/anchors/
+sudo update-ca-trust</pre>
+    <p>Chromium-family browsers (Chrome, Edge, Brave) read the system store; restart the browser to pick up the new CA. <b>Firefox</b> uses its own store — <code>Settings → Privacy &amp; Security → Certificates → View Certificates → Authorities → Import</code> and tick "Trust this CA to identify websites".</p>
+  </details>
+
+  <details>
+    <summary>Linux — Debian / Ubuntu</summary>
+    <pre>sudo cp ~/Downloads/caddy-root.crt /usr/local/share/ca-certificates/caddy-root.crt
+sudo update-ca-certificates</pre>
+    <p>Firefox uses its own store — see above.</p>
+  </details>
+
+  <details>
+    <summary>Windows</summary>
+    <p>PowerShell as Administrator:</p>
+    <pre>certutil -addstore -enterprise Root "$env:USERPROFILE\Downloads\caddy-root.crt"</pre>
+    <p>Or via GUI: double-click the <code>.crt</code> → <b>Install Certificate → Local Machine → Place all certificates in: Trusted Root Certification Authorities</b>.</p>
+  </details>
+
+  <details>
+    <summary>Android</summary>
+    <ol>
+      <li>Copy the <code>caddy-root.crt</code> to the device (Files app, AirDrop, etc.).</li>
+      <li><b>Settings → Security &amp; privacy → More security &amp; privacy → Encryption &amp; credentials → Install a certificate → CA certificate</b>.</li>
+      <li>Pick the file, tap <b>Install anyway</b> on the warning.</li>
+    </ol>
+    <p>(Android shows "Network may be monitored" — that's the standard warning for any user-installed CA. It's not specific to this one.)</p>
+  </details>
+
+  <div class="verify">
+    <h2 style="margin: 0 0 0.4em">Step 3 — Verify</h2>
+    <p style="margin: 0">
+      Restart your browser, then open
+      <a href="https://{{ caddy_domain }}/">https://{{ caddy_domain }}/</a>.
+      You should see the dashboard with no warnings and a green
+      padlock. If you still see a warning, check that you installed
+      the <b>root</b> cert (not the intermediate) and that the
+      browser has been restarted.
+    </p>
+  </div>
+
+  <p style="color: #777; font-size: 0.85em; margin-top: 3em">
+    Served over plain HTTP by design — the published cert is the
+    public part of the CA, and these install instructions don't
+    benefit from being on HTTPS (you don't trust the server yet).
+    Everything else on this server is HTTPS-only.
+  </p>
+</body>
+</html>

--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -6,6 +6,25 @@
 # Reverse proxy mode — subdomain-based routing with auto HTTPS
 # ==================================================================
 
+# HTTP — bootstrap path for trusting the internal CA.
+# Caddy by default 301-redirects port 80 → 443, but a fresh device
+# can't reach 443 cleanly until it trusts our CA. Exempt three
+# specific paths from the redirect so the user can fetch the cert,
+# the Apple profile, and the install instructions over plain HTTP.
+# The published artifacts are the public part of the CA + install
+# docs; nothing secret.
+http://{{ caddy_domain }} {
+	@bootstrap path /trust /trust.html /caddy-root.crt /caddy-trust.mobileconfig
+	handle @bootstrap {
+		root * /srv/dashboard
+		try_files {path} {path}.html
+		file_server
+	}
+	handle {
+		redir https://{host}{uri} permanent
+	}
+}
+
 # Dashboard (root domain)
 {{ caddy_domain }} {
 	tls internal


### PR DESCRIPTION
## Summary

Fix the chicken-and-egg in trusting the homeserver's internal CA: a fresh device can't open the HTTPS dashboard without trusting the CA, but the cert and Apple profile are also published from the HTTPS endpoint. Result: hard browser warning on first visit, no clean download path.

Add a small landing page Caddy serves over **plain HTTP** at \`http://<caddy_domain>/trust\` containing:

- Direct download buttons for the root cert (PEM) and Apple Configuration Profile.
- Per-platform install instructions (macOS, iOS/iPadOS, Linux Fedora/Debian families, Windows, Android) as collapsible \`<details>\` sections — copy-paste-runnable, no JS, no external deps.
- Verify link back to \`https://<caddy_domain>/\` once installed.

The Caddyfile gets one new \`http://<caddy_domain>\` site block that exempts only \`/trust\`, \`/trust.html\`, \`/caddy-root.crt\`, and \`/caddy-trust.mobileconfig\` from the standard 301 → HTTPS redirect. Safe because those are the **public** part of the CA plus install instructions for it; nothing secret.

Updates: caddy role README, main README's Getting Started pointer, Quickstart Step 2 (also drops the now-stale "setup.sh is Fedora-only" callout — AL9 support landed in #111).

Caught when homeserver2 came up via setup.sh and the dashboard URL hit a cert warning the user couldn't get past.

## Test plan

- [ ] Re-deploy caddy role on homeserver2.
- [ ] From the laptop browser, navigate to \`http://homeserver2.lan/trust\` — page renders, no warning.
- [ ] Click "Download root cert" — PEM downloads, valid format.
- [ ] Follow the macOS instructions on the page; restart the browser.
- [ ] Navigate to \`https://homeserver2.lan/\` — dashboard renders, no warnings, padlock green.
- [ ] Confirm \`curl -I http://homeserver2.lan/\` returns 301 → HTTPS, but \`curl -I http://homeserver2.lan/trust\` returns 200 with \`text/html\`.
- [ ] Confirm \`curl -I http://homeserver2.lan/caddy-root.crt\` returns 200 with the PEM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)