### PR TITLE
docs: multi-page Setup Guide with breadcrumbs and time estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ If you want to get up and running quickly, head straight to the
 fresh-install path end-to-end (cloud-init bootstrap, private overlay
 setup, vault, and first deploy).
 
+Once deployed, install the homeserver's internal CA on each device
+that wants to reach the web UIs — visit
+`http://<caddy_domain>/trust` (plain HTTP, no warning) for download
+links and per-platform install instructions.
+
 A more detailed setup reference will land here in a follow-up
 revision.
 

--- a/README.md
+++ b/README.md
@@ -235,18 +235,14 @@ The guiding principle is **rebuild over repair**: if the system drifts, it shoul
 
 ## Getting Started
 
-If you want to get up and running quickly, head straight to the
-**[Quickstart guide](docs/Quickstart.md)** — it walks through the
-fresh-install path end-to-end (cloud-init bootstrap, private overlay
-setup, vault, and first deploy).
+➡️ **[Setup Guide](docs/Setup-Guide/README.md)** — five short
+pages, ~50–90 min total, takes you from "I just heard about this
+project" to "I'm logged into my dashboard over HTTPS with a green
+padlock". Each step has time estimates and a progress bar.
 
-Once deployed, install the homeserver's internal CA on each device
-that wants to reach the web UIs — visit
-`http://<caddy_domain>/trust` (plain HTTP, no warning) for download
-links and per-platform install instructions.
-
-A more detailed setup reference will land here in a follow-up
-revision.
+Prefer one long page over a wizard? See
+**[Quickstart](docs/Quickstart.md)** — same path, denser
+single-page format.
 
 ---
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -91,15 +91,16 @@ The script is interactive — it walks you through:
 The server acts as **its own Ansible controller** — no separate
 workstation needed.
 
-When it finishes, open `https://<server-ip>` in your browser to see
-the dashboard.
+When it finishes, open `https://<caddy_domain>/` in your browser to
+see the dashboard.
 
-> [!NOTE]
-> The current `setup.sh` was written for Fedora Server and refuses
-> to run on other distros (`dnf` check + Fedora-specific package
-> assumptions). AlmaLinux 9 support is on the roadmap — until then,
-> use the manual deploy flow described in the project README and
-> the role-by-role playbooks in `playbooks/`.
+> [!IMPORTANT]
+> Your browser will show a certificate warning the first time
+> because the homeserver runs its own internal CA. Visit
+> **`http://<caddy_domain>/trust`** (plain HTTP, no warning) first —
+> the page has a one-click download for the root certificate plus
+> per-platform install instructions. Once installed, the dashboard
+> URL works cleanly with a green padlock.
 
 ## Step 3 — Hand off to Ansible from your laptop (optional)
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -4,6 +4,11 @@ The fast path: get a working homeserver in under an hour, running
 the setup directly on the server itself. No separate Ansible
 control machine needed.
 
+> [!TIP]
+> Looking for a step-by-step wizard with progress bars instead of
+> a single long page? Start with the
+> **[Setup Guide](Setup-Guide/README.md)**.
+
 ## Prerequisites
 
 You need an **AlmaLinux 9** machine you can SSH into, with these

--- a/docs/Setup-Guide/01-deSEC-account.md
+++ b/docs/Setup-Guide/01-deSEC-account.md
@@ -1,0 +1,77 @@
+# Step 1 — Set up your deSEC account
+
+> **Setup Guide** · Step 1 of 5 · ▰▱▱▱▱ 20% · ~0 min spent · ~50 min to go
+> **Step 1: deSEC account** · [Step 2: Install OS →](02-install-os.md)
+
+This is the only manual sign-up in the whole guide. ~5 minutes.
+
+## Why deSEC
+
+We use **deSEC** (a German non-profit DNS host) for two things:
+
+- A free `*.dedyn.io` subdomain — your homeserver's permanent
+  address.
+- An API token that lets the homeserver automatically request
+  real Let's Encrypt certificates (so every URL has a green
+  padlock, no per-device CA install).
+
+Why deSEC specifically over alternatives: non-profit, EU-hosted,
+DNSSEC by default, scoped API tokens, and a clean upgrade path if
+you later want to bring your own domain.
+
+## What you'll do
+
+### 1. Create an account
+
+- Open <https://desec.io/> in your browser.
+- Click **Sign Up**.
+- Enter your email, choose a password, confirm via the
+  verification email.
+
+(~2 min.)
+
+### 2. Claim a subdomain
+
+- After login, you're on the dashboard.
+- Click **Create new DNS zone**.
+- Enter a subdomain like `<your-name>` or `<household>-home`
+  followed by `.dedyn.io` — for example, `alice-home.dedyn.io`.
+- Click **Save**.
+
+You now own `alice-home.dedyn.io` and any subdomain under it
+(`pihole.alice-home.dedyn.io`, `paperless.alice-home.dedyn.io`,
+etc.) — Caddy will mint a wildcard cert covering all of them in
+Step 4.
+
+(~1 min.)
+
+### 3. Copy your API token
+
+- Click your email address (top-right) → **Token Management**.
+- Click **Create new token**.
+- Give it a name like `homeserver` and click **Save**.
+- **Copy the token** to a password manager or a temporary note —
+  deSEC shows it only once.
+
+(~1 min.)
+
+## Keep these two values
+
+You'll paste them into `setup.sh` in Step 4:
+
+| | Example |
+|---|---|
+| **Subdomain** (without `.dedyn.io`) | `alice-home` |
+| **API token** | a long opaque string |
+
+## Time check
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — Install OS | next | ~20–60 min |
+| 3 — SSH & sudo | | ~3 min |
+| 4 — Run setup.sh | | ~20 min |
+| 5 — Verify & explore | | ~2 min |
+
+➡️ **[Step 2: Install the OS](02-install-os.md)**

--- a/docs/Setup-Guide/02-install-os.md
+++ b/docs/Setup-Guide/02-install-os.md
@@ -1,0 +1,72 @@
+# Step 2 — Install the OS
+
+> **Setup Guide** · Step 2 of 5 · ▰▰▱▱▱ 40% · ~5 min spent · ~45 min to go
+> [← Step 1: deSEC account](01-deSEC-account.md) · **Step 2: Install OS** · [Step 3: SSH & sudo →](03-ssh-and-sudo.md)
+
+You'll install **AlmaLinux 9** on your hardware (or VPS). Pick the
+sub-method that fits your situation — each is a separate detailed
+doc; come back here when finished.
+
+## Pick your path
+
+### A — Bare-metal, unattended (recommended for repeat installs)
+
+You have a mini-PC, NUC, or repurposed laptop and want a
+reproducible install. The kickstart file does it without
+clicking through the installer.
+
+⏱️ **~20 min** (5 min USB prep + 15 min unattended install).
+
+➡️ **[Install-Kickstart.md](../Install-Kickstart.md)**
+
+---
+
+### B — Bare-metal, click-through (one-off install)
+
+Same hardware story but you'd rather use the Anaconda installer
+GUI. Slightly slower; useful for a one-off.
+
+⏱️ **~45 min** (5 min USB prep + 40 min click-through + first-boot).
+
+➡️ **[Install-Manual.md](../Install-Manual.md)**
+
+---
+
+### C — Cloud VPS (Hetzner / DigitalOcean / OVH / Linode / …)
+
+You don't want physical hardware — just a virtual server in the
+cloud.
+
+⏱️ **~15 min** (provider-side click-through; no flashing).
+
+➡️ **[Install-VPS.md](../Install-VPS.md)**
+
+---
+
+### D — Cloud-init self-provision _(coming soon)_
+
+Paste a `user-data` blob into a cloud provider's "Create VM"
+form, walk away, come back to a fully-deployed homeserver. Not
+yet implemented — tracked in
+[issue #106](https://github.com/luckynrslevin/home-server/issues/106).
+
+## What you'll have when you come back
+
+Whichever path you pick, you should end Step 2 with:
+
+- AlmaLinux 9 booted on the machine.
+- An **IP address** for the server (note it down).
+- An SSH-reachable **non-root user account** on the server, with
+  your laptop's SSH public key in its `~/.ssh/authorized_keys`.
+
+## Time check
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — Install OS | in progress | ~20–60 min |
+| 3 — SSH & sudo | next | ~3 min |
+| 4 — Run setup.sh | | ~20 min |
+| 5 — Verify & explore | | ~2 min |
+
+➡️ **[Step 3: SSH in & verify sudo](03-ssh-and-sudo.md)**

--- a/docs/Setup-Guide/03-ssh-and-sudo.md
+++ b/docs/Setup-Guide/03-ssh-and-sudo.md
@@ -1,0 +1,71 @@
+# Step 3 — SSH in & verify sudo
+
+> **Setup Guide** · Step 3 of 5 · ▰▰▰▱▱ 60% · ~25 min spent · ~25 min to go
+> [← Step 2: Install OS](02-install-os.md) · **Step 3: SSH & sudo** · [Step 4: Run setup.sh →](04-run-setup.md)
+
+The shortest step. ~3 minutes — confirm you can SSH in and that
+your user can run `sudo` without a password.
+
+## What you'll do
+
+### 1. SSH in from your laptop
+
+```bash
+ssh youruser@<server-ip>
+```
+
+(Replace `youruser` and `<server-ip>` with what you set up in
+Step 2. If you used a cloud VPS image with cloud-init's default
+user, try `ssh almalinux@<server-ip>`.)
+
+You should land at a shell prompt without being asked for a
+password (key-based auth).
+
+### 2. Verify passwordless sudo
+
+In that SSH session, run:
+
+```bash
+sudo -n true && echo "OK"
+```
+
+If it prints **OK**, you're done — skip to the next step.
+
+If it asks for a password, you need to configure passwordless
+sudo:
+
+```bash
+echo "$USER ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/90-$USER
+sudo chmod 0440 /etc/sudoers.d/90-$USER
+```
+
+You'll be prompted for the sudo password *once* during this. After
+that, re-run `sudo -n true && echo "OK"` — it should print **OK**
+this time.
+
+### Why passwordless sudo?
+
+`setup.sh` in Step 4 runs a bunch of `sudo dnf install` /
+`sudo systemctl` / etc. calls non-interactively. If sudo prompts
+for a password mid-install, the script can't answer it from a
+piped heredoc. NOPASSWD is the standard pattern for an admin user
+that drives automation on their own box.
+
+## Sanity check
+
+You should now be:
+
+- SSH'd into the server as your non-root user.
+- Able to run `sudo -n true` without a prompt.
+
+## Time check
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — Install OS | ✅ done | ~20–60 min |
+| 3 — SSH & sudo | ✅ done | ~3 min |
+| 4 — Run setup.sh | next | ~20 min |
+| 5 — Verify & explore | | ~2 min |
+
+➡️ **[Step 4: Run setup.sh](04-run-setup.md)**

--- a/docs/Setup-Guide/04-run-setup.md
+++ b/docs/Setup-Guide/04-run-setup.md
@@ -1,0 +1,86 @@
+# Step 4 — Run setup.sh
+
+> **Setup Guide** · Step 4 of 5 · ▰▰▰▰▱ 80% · ~28 min spent · ~22 min to go
+> [← Step 3: SSH & sudo](03-ssh-and-sudo.md) · **Step 4: Run setup.sh** · [Step 5: Verify →](05-verify-and-explore.md)
+
+The longest step (~20 min), but most of it is unattended. ~3
+minutes of your attention up front, ~17 minutes of "container
+images pull and services start" you can use to make coffee.
+
+> [!WARNING]
+> **Work in progress.** The deSEC + Let's Encrypt path described
+> below is the *target* end-state but not yet implemented in
+> `setup.sh`. Tracker: see the platform tracking issue once it's
+> opened. Today's `setup.sh` falls back to an internal CA (per-
+> device root install) — see [Quickstart Step 2](../Quickstart.md)
+> for the current flow. The rest of this page describes how it
+> will work once the implementation lands.
+
+## Heads-up on the prompts
+
+`setup.sh` is interactive. It will ask you for:
+
+| Prompt | What to paste | From Step |
+|---|---|---|
+| **deSEC subdomain** (without `.dedyn.io`) | `alice-home` | 1 |
+| **deSEC API token** | the long opaque string | 1 |
+| **Which services to deploy?** | y/N per service (defaults are sensible) | — |
+
+Have your deSEC values from Step 1 ready in your clipboard /
+notes.
+
+## Run setup.sh
+
+In your SSH session on the server:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/setup.sh \
+  -o /tmp/setup.sh && bash /tmp/setup.sh
+```
+
+> [!IMPORTANT]
+> Run this **on the server** (i.e. inside the SSH session from
+> Step 3) — not on your laptop. The script provisions the
+> machine it runs on.
+
+### What you'll see
+
+Roughly in order:
+
+1. **Prereqs install** — Ansible, podman, python3.11, EPEL — about
+   ~1 min.
+2. **Repo clone** — pulls this project into `~/home-server`.
+3. **Vault setup** — generates or asks for a vault password
+   (encrypts your deSEC token at rest).
+4. **The prompts** — server IP, hostname, deSEC subdomain + token,
+   service picker.
+5. **Deploy** — Ansible runs. **~15–20 min**. You can step away;
+   the script doesn't need more input after the prompts.
+
+## What setup.sh does behind the scenes
+
+- Writes the wildcard A record (`*.<sub>.dedyn.io → <server LAN
+  IP>`) to deSEC via API. (One less manual step in the deSEC
+  dashboard.)
+- Generates your inventory file under
+  `~/home-server/inventory/host_vars/homeserver/main.yml`,
+  including vault-encrypted secrets for every service.
+- Runs `ansible-playbook playbooks/site.yml --connection=local`
+  against your box, deploying every role you picked.
+- Caddy issues a wildcard Let's Encrypt cert for
+  `*.<sub>.dedyn.io` via DNS-01 against deSEC — no inbound port
+  forwarding needed.
+- Pi-hole gets a wildcard local DNS record so LAN clients resolve
+  the subdomain to your homeserver's IP.
+
+## Time check
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — Install OS | ✅ done | ~20–60 min |
+| 3 — SSH & sudo | ✅ done | ~3 min |
+| 4 — Run setup.sh | in progress | ~20 min |
+| 5 — Verify & explore | next | ~2 min |
+
+➡️ **[Step 5: Verify & explore](05-verify-and-explore.md)**

--- a/docs/Setup-Guide/05-verify-and-explore.md
+++ b/docs/Setup-Guide/05-verify-and-explore.md
@@ -1,0 +1,98 @@
+# Step 5 — Verify & explore
+
+> **Setup Guide** · Step 5 of 5 · ▰▰▰▰▰ 100% · ~48 min spent · ~2 min to go
+> [← Step 4: Run setup.sh](04-run-setup.md) · **Step 5: Verify & explore**
+
+You're ~2 minutes from a working homeserver. ☕
+
+## Verify
+
+### 1. Open the dashboard
+
+From your **laptop's** browser:
+
+```
+https://<your-subdomain>.dedyn.io/
+```
+
+(Replace `<your-subdomain>` with what you chose in Step 1 —
+e.g. `https://alice-home.dedyn.io/`.)
+
+You should see:
+
+- The **dashboard page** listing every service you deployed, with
+  status / container image / volumes / last backup time.
+- A **green padlock** in the address bar — no certificate
+  warning, no "this site is unsafe" prompt.
+- No need to install anything on your laptop. The certs are real
+  Let's Encrypt; every device trusts them out of the box.
+
+If you see a padlock — congratulations, you're done. 🎉
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| **DNS doesn't resolve** the subdomain | Your laptop isn't using Pi-hole as DNS, OR you haven't picked Pi-hole in the service list | Set your laptop's DNS to the homeserver's IP, or add the homeserver to your router's DHCP DNS server. |
+| **Cert warning** | Caddy's first cert issuance hadn't completed yet when you opened the URL | Wait 1–2 min; reload. If still wrong, check `journalctl --user -u caddy -n 50` on the server for an ACME error. |
+| **Connection refused** | Server's firewall not yet open on 443 | Re-run `ansible-playbook playbooks/caddy.yml --connection=local --limit homeserver` on the server. |
+
+## Explore
+
+Click any tile on the dashboard to open that service's UI. A few
+good first stops:
+
+- **Pi-hole admin** (`https://pihole.<sub>.dedyn.io/admin`) — see
+  the queries already being filtered. Log in with the admin
+  password setup.sh generated and stored in your vault.
+- **Syncthing** (`https://syncthing.<sub>.dedyn.io/`) — set up a
+  folder share between this server and your laptop / phone.
+- **Ente Photos** (`https://photos.<sub>.dedyn.io/`) — sign up
+  inside the app (this is *your* instance), install the iOS or
+  Android client, point it at your subdomain, start uploading.
+- **Paperless-NGX** (`https://paperless.<sub>.dedyn.io/`) — log
+  in with the admin credentials from your vault, drop a PDF into
+  the consume folder, watch OCR + tagging happen.
+- **Jellyfin** (`https://jellyfin.<sub>.dedyn.io/`) — point it at
+  your media library (if you set up NFS in Step 2 / inventory),
+  install the iOS / tvOS / Android client.
+- **Music Assistant** (`https://music.<sub>.dedyn.io/`) — point
+  it at your music collection in Jellyfin (built-in provider) and
+  add streaming services.
+
+## Optional — remote access via Tailscale
+
+Want to reach your homeserver while travelling? Enable
+**Tailscale** — it gives every device a stable IP on a private
+mesh VPN, no router config, no port forwarding. Then
+`https://paperless.<sub>.dedyn.io/` works from a café in Tokyo
+the same as it works on your home Wi-Fi.
+
+➡️ **[Tailscale-DNS-Setup.md](../Tailscale-DNS-Setup.md)** (~10 min
+admin-console click-through)
+
+## You're done
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — Install OS | ✅ done | ~20–60 min |
+| 3 — SSH & sudo | ✅ done | ~3 min |
+| 4 — Run setup.sh | ✅ done | ~20 min |
+| 5 — Verify & explore | ✅ done | ~2 min |
+
+Total: **~50–90 min** to your own homeserver. Welcome to owning
+your data.
+
+## Where to next
+
+- **Add more devices** — install the Ente / Syncthing / Jellyfin /
+  Music Assistant mobile apps, point them at your subdomain.
+- **Read the role docs** in `roles/<service>/README.md` for
+  tuning knobs.
+- **Watch the project repo** for new services landing (Nextcloud,
+  Home Assistant, Mealie are on the roadmap).
+- **Report any rough edges** — this is still an early-days
+  project; PRs and issues welcome.
+
+[← Back to the guide index](README.md)

--- a/docs/Setup-Guide/README.md
+++ b/docs/Setup-Guide/README.md
@@ -1,0 +1,43 @@
+# Setup Guide
+
+> **Setup Guide** · Index · ▱▱▱▱▱ 0% · ~50–90 min total
+
+Welcome. By the end of this guide you'll have a fully-deployed
+homeserver reachable from your laptop at
+`https://<your-name>.dedyn.io/` — green padlock, no warnings, no
+per-device cert install. The dashboard shows every service that's
+running and lets you click straight into Pi-hole, Syncthing,
+Paperless, Ente Photos, Jellyfin, Music Assistant.
+
+> [!NOTE]
+> Prefer one long page over a wizard? See
+> **[Quickstart](../Quickstart.md)** — same path, denser format.
+
+## What you'll do
+
+| # | Step | Time | What you'll have at the end |
+|---|---|---|---|
+| 1 | [deSEC account](01-deSEC-account.md) | ~5 min | A free `*.dedyn.io` subdomain + an API token in your clipboard. |
+| 2 | [Install the OS](02-install-os.md) | ~20–60 min | AlmaLinux 9 booted on your hardware or VPS, SSH-reachable. |
+| 3 | [SSH & sudo](03-ssh-and-sudo.md) | ~3 min | A working SSH session as a non-root user with passwordless sudo. |
+| 4 | [Run setup.sh](04-run-setup.md) | ~20 min | The full stack deployed, certs issued, services running. |
+| 5 | [Verify & explore](05-verify-and-explore.md) | ~2 min | You're logged into the dashboard. Done. |
+
+**Total budget:** ~50–90 min depending on which OS install method you
+pick in Step 2.
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- A piece of hardware to run the homeserver on (mini-PC, NUC, old
+  laptop, or a cloud VPS). 4 GB RAM minimum, 8 GB+ recommended.
+- A laptop or desktop on the same network — you'll use it to SSH
+  into the server and to load the dashboard.
+- An internet connection (the server needs it to fetch packages
+  and renew certificates).
+- ~1 hour of unrushed time.
+
+## Start
+
+➡️ **[Step 1: Set up your deSEC account](01-deSEC-account.md)**

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -101,17 +101,28 @@ for a LAN home server. Certificate data is persisted in `caddy-data`.
 
 ## Distributing the internal CA to client devices
 
-The role publishes the root CA at two URLs on the dashboard:
+The role publishes a small **HTTP-served landing page** plus the raw
+artifacts so a fresh device can bootstrap trust without first
+trusting the cert it's trying to download:
 
-| URL                              | For                       | UX                                                                                                  |
-|----------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------|
-| `/caddy-trust.mobileconfig`      | iOS / iPadOS / macOS      | Tap in Safari → install Apple configuration profile → two-tap trust on iOS, one-tap on macOS.       |
-| `/caddy-root.crt`                | Linux / Android / other   | Raw PEM cert; install via OS / browser certificate manager.                                         |
+| URL                                            | Scheme | For                       | UX                                                                                                  |
+|------------------------------------------------|:---:|---------------------------|-----------------------------------------------------------------------------------------------------|
+| `http://<caddy_domain>/trust`                  | HTTP | Any device, first install | Self-contained landing page with download links + per-platform install instructions. **Start here on a fresh device.** |
+| `http://<caddy_domain>/caddy-trust.mobileconfig` | HTTP | iOS / iPadOS / macOS      | Apple Configuration Profile bundling the root cert. Linked from the landing page.                    |
+| `http://<caddy_domain>/caddy-root.crt`         | HTTP | Linux / Android / Windows | Raw PEM cert. Linked from the landing page.                                                          |
 
-The mobileconfig profile is generated from
-`templates/caddy-trust.mobileconfig.j2` on every deploy, so a CA
-rotation regenerates the file automatically. The profile is
-unsigned (Apple displays a "Verify" prompt; the user accepts).
+These three paths are the only HTTP exemptions in the Caddyfile;
+everything else on `http://<caddy_domain>` 301-redirects to HTTPS as
+normal. Serving them over HTTP is safe — they're the **public** part
+of the CA and install instructions for it; nothing secret.
+
+Once installed, the user reaches the dashboard at
+`https://<caddy_domain>/` cleanly with no warnings.
+
+The landing page is rendered from
+`templates/trust.html.j2`; the mobileconfig from
+`templates/caddy-trust.mobileconfig.j2`. Both regenerate on every
+deploy, so a CA rotation refreshes them automatically.
 
 ## Internal CA persistence
 

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -183,3 +183,18 @@
   vars:
     caddy_ca_pem_content: "{{ _caddy_ca_pem.content | b64decode }}"
   when: caddy_domain | length > 0
+
+# HTTP-served landing page that walks the user through trusting the
+# CA on their device. Reachable at http://<caddy_domain>/trust without
+# a browser warning (chicken-and-egg fix: you can't fetch the cert
+# from HTTPS until you've trusted it). The Caddyfile exempts /trust,
+# /caddy-root.crt, and /caddy-trust.mobileconfig from the standard
+# HTTP→HTTPS redirect.
+- name: Publish CA-trust landing page via dashboard
+  become: true
+  ansible.builtin.template:
+    src: trust.html.j2
+    dest: /var/www/dashboard/trust.html
+    mode: "0644"
+    setype: container_file_t
+  when: caddy_domain | length > 0

--- a/roles/caddy/templates/trust.html.j2
+++ b/roles/caddy/templates/trust.html.j2
@@ -1,0 +1,133 @@
+{# Rendered to /var/www/dashboard/trust.html, served by Caddy at
+   http://{{ caddy_domain }}/trust (HTTP, no redirect). Plain HTML,
+   inline CSS, no JS, no external resources. #}
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Trust the homeserver CA — {{ caddy_domain }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+           max-width: 760px; margin: 2em auto; padding: 0 1em; color: #1a1a1a; line-height: 1.55; }
+    h1 { margin-bottom: 0.2em; }
+    h2 { margin-top: 1.8em; }
+    .domain { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #0066cc; }
+    .lead { color: #555; font-size: 1.05em; }
+    .downloads { display: flex; flex-wrap: wrap; gap: 0.8em; margin: 1.5em 0; }
+    .downloads a {
+      display: inline-block; padding: 0.85em 1.3em;
+      background: #0066cc; color: white; text-decoration: none;
+      border-radius: 6px; font-weight: 600;
+    }
+    .downloads a:hover { background: #0052a3; }
+    .downloads a small { display: block; font-weight: 400; opacity: 0.85; font-size: 0.85em; margin-top: 0.15em; }
+    details { background: #f4f6fa; border-radius: 6px; padding: 0.8em 1.2em; margin: 0.5em 0; }
+    details[open] { background: #eef1f7; }
+    summary { cursor: pointer; font-weight: 600; padding: 0.2em 0; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
+    pre { background: #1f1f1f; color: #f0f0f0; padding: 1em; border-radius: 6px; overflow-x: auto; }
+    .verify { background: #e8f4ea; border-left: 4px solid #2a8e3f; padding: 1em 1.2em; margin: 2em 0 1em; border-radius: 4px; }
+    .verify a { color: #1c6e2c; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>Trust the homeserver CA</h1>
+  <p class="lead">
+    Every web UI on this server is served at
+    <code class="domain">https://*.{{ caddy_domain }}/</code> with
+    a TLS certificate signed by your homeserver's own internal CA.
+    Install the CA's root certificate on this device once, and every
+    URL works with no warnings.
+  </p>
+
+  <h2>Step 1 — Download the right file for your device</h2>
+  <div class="downloads">
+    <a href="/caddy-trust.mobileconfig" download>
+      Apple Profile (.mobileconfig)
+      <small>iOS · iPadOS · macOS</small>
+    </a>
+    <a href="/caddy-root.crt" download>
+      Root certificate (.crt)
+      <small>Linux · Windows · Android</small>
+    </a>
+  </div>
+
+  <h2>Step 2 — Install on your device</h2>
+
+  <details>
+    <summary>macOS</summary>
+    <p>Option 1 — Apple Configuration Profile (recommended):</p>
+    <ol>
+      <li>Click <b>Apple Profile</b> above. The file downloads to <code>~/Downloads</code>.</li>
+      <li>Double-click the <code>.mobileconfig</code> file in Finder.</li>
+      <li>Open <b>System Settings → Privacy &amp; Security → Profiles</b>, find <i>Caddy Local CA</i>, click <b>Install</b>.</li>
+      <li>Open <b>Keychain Access → System</b>, find the <i>Caddy Local Authority</i> root, double-click it → <b>Trust → "When using this certificate" → Always Trust</b>.</li>
+    </ol>
+    <p>Option 2 — raw PEM via CLI:</p>
+    <pre>sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain \
+  ~/Downloads/caddy-root.crt</pre>
+  </details>
+
+  <details>
+    <summary>iOS / iPadOS</summary>
+    <ol>
+      <li>Open this page in <b>Safari</b> on the device (not in another browser).</li>
+      <li>Tap <b>Apple Profile</b> above. Safari shows "This website is trying to download a configuration profile". Tap <b>Allow</b>.</li>
+      <li>Open <b>Settings → General → VPN &amp; Device Management → Caddy Local CA → Install</b>.</li>
+      <li>Go to <b>Settings → General → About → Certificate Trust Settings</b> and toggle <b>Caddy Local Authority</b> on. (This step is mandatory — without it iOS won't actually trust the cert.)</li>
+    </ol>
+  </details>
+
+  <details>
+    <summary>Linux — Fedora / AlmaLinux / Rocky / RHEL</summary>
+    <pre>sudo cp ~/Downloads/caddy-root.crt /etc/pki/ca-trust/source/anchors/
+sudo update-ca-trust</pre>
+    <p>Chromium-family browsers (Chrome, Edge, Brave) read the system store; restart the browser to pick up the new CA. <b>Firefox</b> uses its own store — <code>Settings → Privacy &amp; Security → Certificates → View Certificates → Authorities → Import</code> and tick "Trust this CA to identify websites".</p>
+  </details>
+
+  <details>
+    <summary>Linux — Debian / Ubuntu</summary>
+    <pre>sudo cp ~/Downloads/caddy-root.crt /usr/local/share/ca-certificates/caddy-root.crt
+sudo update-ca-certificates</pre>
+    <p>Firefox uses its own store — see above.</p>
+  </details>
+
+  <details>
+    <summary>Windows</summary>
+    <p>PowerShell as Administrator:</p>
+    <pre>certutil -addstore -enterprise Root "$env:USERPROFILE\Downloads\caddy-root.crt"</pre>
+    <p>Or via GUI: double-click the <code>.crt</code> → <b>Install Certificate → Local Machine → Place all certificates in: Trusted Root Certification Authorities</b>.</p>
+  </details>
+
+  <details>
+    <summary>Android</summary>
+    <ol>
+      <li>Copy the <code>caddy-root.crt</code> to the device (Files app, AirDrop, etc.).</li>
+      <li><b>Settings → Security &amp; privacy → More security &amp; privacy → Encryption &amp; credentials → Install a certificate → CA certificate</b>.</li>
+      <li>Pick the file, tap <b>Install anyway</b> on the warning.</li>
+    </ol>
+    <p>(Android shows "Network may be monitored" — that's the standard warning for any user-installed CA. It's not specific to this one.)</p>
+  </details>
+
+  <div class="verify">
+    <h2 style="margin: 0 0 0.4em">Step 3 — Verify</h2>
+    <p style="margin: 0">
+      Restart your browser, then open
+      <a href="https://{{ caddy_domain }}/">https://{{ caddy_domain }}/</a>.
+      You should see the dashboard with no warnings and a green
+      padlock. If you still see a warning, check that you installed
+      the <b>root</b> cert (not the intermediate) and that the
+      browser has been restarted.
+    </p>
+  </div>
+
+  <p style="color: #777; font-size: 0.85em; margin-top: 3em">
+    Served over plain HTTP by design — the published cert is the
+    public part of the CA, and these install instructions don't
+    benefit from being on HTTPS (you don't trust the server yet).
+    Everything else on this server is HTTPS-only.
+  </p>
+</body>
+</html>

--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -6,6 +6,25 @@
 # Reverse proxy mode — subdomain-based routing with auto HTTPS
 # ==================================================================
 
+# HTTP — bootstrap path for trusting the internal CA.
+# Caddy by default 301-redirects port 80 → 443, but a fresh device
+# can't reach 443 cleanly until it trusts our CA. Exempt three
+# specific paths from the redirect so the user can fetch the cert,
+# the Apple profile, and the install instructions over plain HTTP.
+# The published artifacts are the public part of the CA + install
+# docs; nothing secret.
+http://{{ caddy_domain }} {
+	@bootstrap path /trust /trust.html /caddy-root.crt /caddy-trust.mobileconfig
+	handle @bootstrap {
+		root * /srv/dashboard
+		try_files {path} {path}.html
+		file_server
+	}
+	handle {
+		redir https://{host}{uri} permanent
+	}
+}
+
 # Dashboard (root domain)
 {{ caddy_domain }} {
 	tls internal


### PR DESCRIPTION
## Summary

Five-page guided walkthrough that takes a new user from "I just heard about this project" to "I'm logged into my dashboard over HTTPS" — each page self-contained with prereqs, exact commands, expected output, and a "next" link.

| Page | Time | Content |
|---|---|---|
| \`README.md\` | — | Index + total ~50–90 min + prereqs + start CTA |
| \`01-deSEC-account.md\` | ~5 min | Sign up at desec.io, claim subdomain, copy API token |
| \`02-install-os.md\` | ~20–60 min | Pick install method → existing Install-* docs |
| \`03-ssh-and-sudo.md\` | ~3 min | SSH + verify passwordless sudo |
| \`04-run-setup.md\` | ~20 min | \`curl … | bash setup.sh\` + prompts walk-through |
| \`05-verify-and-explore.md\` | ~2 min | Open dashboard, click around, optional Tailscale |

Each page leads with a breadcrumb / progress strip:

> **Setup Guide** · Step N of 5 · ▰▰▱▱▱ 40% · ~X min spent · ~Y min to go
> [← prev] · **current** · [next →]

Pure-markdown implementation (no static-site generator) so it renders directly on GitHub with zero infra. MkDocs Material upgrade tracked as a separate follow-up if the wizard format proves useful.

## Aspirational vs current state

Page 04 carries a \`[!WARNING]\` callout because the deSEC + Let's Encrypt path it describes is the *target* end-state — implementation tracked separately (will open as a follow-up issue). Today's setup.sh still uses internal CA; Quickstart Step 2 documents the current flow.

## Integration with existing docs

- README's Getting Started block now points at the guide as the recommended entry path.
- Quickstart adds a top callout pointing the other way (one long page vs the step-by-step wizard).
- Install-* docs are unchanged — linked from Step 2 as sub-steps.

## Test plan

- [ ] Render every page on GitHub; verify the breadcrumb strip and Unicode block bar look right.
- [ ] Click every cross-link end-to-end (README → guide → step 1 → 2 → install sub-doc → 3 → 4 → 5 → dashboard URL placeholder).
- [ ] Confirm WIP callout in page 04 is clear about what's not-yet-implemented and where the current flow is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)