### PR TITLE
pihole: wildcard local-DNS for the caddy ACME domain (Phase 4)

### DIFF
--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -44,6 +44,24 @@ Pi-hole is mirrored on GHCR to sidestep Docker Hub's anonymous-pull rate limit. 
 > DHCP reservation. Lease drift will silently leave Pi-hole
 > answering with stale IPs.
 
+### Wildcard local DNS for the caddy ACME domain
+
+When the caddy role is configured with a public DNS-01 provider —
+i.e. `caddy_acme_subdomain` (deSEC) or `caddy_acme_zone` (BYO
+Cloudflare / Hetzner) is set in inventory — Pi-hole automatically
+gets a **wildcard A record** for that domain pointing at this
+host's LAN IP, so LAN clients reach `*.<domain>` directly instead
+of going through the public DNS path.
+
+Implementation: a dnsmasq config fragment is rendered into the
+`pihole-dnsmasq` volume at deploy time
+(`30-caddy-wildcard.conf`). No extra Pi-hole vars to set — the
+record follows whatever the caddy role is doing.
+
+Wildcard A records aren't supported by Pi-hole's `dns.hosts`
+table (which is exact-match only); the `address=/<domain>/<ip>`
+syntax used here is dnsmasq-native.
+
 ## Secrets
 
 | Variable              | Purpose                              |

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -61,6 +61,21 @@
     podman_quadlet_file_names: >-
       {{ ['pihole.container.j2', 'pihole-etc.volume', 'pihole-dnsmasq.volume']
          + (['unbound.container.j2'] if pihole_enable_unbound | bool else []) }}
+    # When the caddy role is using DNS-01 against a public domain
+    # (deSEC subdomain or BYO zone), stage a wildcard dnsmasq fragment
+    # so LAN clients resolve <anything>.<caddy_acme_subdomain>.dedyn.io
+    # (or .<caddy_acme_zone>) to this host's LAN IP. Wildcard A
+    # records need the dnsmasq `address=` syntax, which Pi-hole's
+    # `dns.hosts` API doesn't support — hence dropping a config
+    # fragment into the pihole-dnsmasq volume.
+    podman_quadlet_volumes_files_to_stage: >-
+      {{
+        ([{'name': 'pihole-dnsmasq',
+           'files': [{'src': '30-caddy-wildcard.conf.j2', 'mode': '0644'}]}]
+         if (caddy_acme_subdomain | length > 0)
+            or (caddy_acme_zone | length > 0)
+         else [])
+      }}
     # Pi-hole admin UI is reverse-proxied by Caddy at https://pihole.<caddy_domain>
     # — direct LAN access on {{ pihole_web_port_https }} intentionally not exposed.
     podman_quadlet_firewall_port_forwards:

--- a/roles/pihole/templates/volumes/pihole-dnsmasq/30-caddy-wildcard.conf.j2
+++ b/roles/pihole/templates/volumes/pihole-dnsmasq/30-caddy-wildcard.conf.j2
@@ -1,0 +1,20 @@
+{# Wildcard A record for the caddy_acme domain.
+   Rendered into the pihole-dnsmasq volume so LAN clients resolve
+   *.<domain> → this host's LAN IP. Loaded by Pi-hole's bundled
+   dnsmasq at startup; reload with `pihole reloaddns`.
+
+   Selection logic:
+     - When `caddy_acme_subdomain` is set, the domain is
+       <subdomain>.dedyn.io (deSEC default platform path).
+     - When `caddy_acme_zone` is set, the domain is the BYO zone
+       (cloudflare / hetzner path).
+     - Otherwise this fragment is not rendered at all (see the
+       conditional on podman_quadlet_volumes_files_to_stage in
+       roles/pihole/tasks/main.yml). #}
+{%- set _domain = (caddy_acme_subdomain ~ '.dedyn.io')
+                  if (caddy_acme_subdomain | length > 0)
+                  else caddy_acme_zone -%}
+# Wildcard A record for *.{{ _domain }}
+# Managed by Ansible — do not edit by hand.
+# Source: roles/pihole/templates/volumes/pihole-dnsmasq/30-caddy-wildcard.conf.j2
+address=/{{ _domain }}/{{ ansible_default_ipv4.address }}


### PR DESCRIPTION
## Summary

Phase 4 of the platform plan: when caddy is configured with a public DNS-01 provider (deSEC \`caddy_acme_subdomain\` or BYO \`caddy_acme_zone\`), give LAN clients a wildcard A record for \`*.<domain>\` → this host's LAN IP. Same URL works on LAN (direct) and over Tailscale (via subnet route) — no per-record manual config.

## Implementation

- New template \`roles/pihole/templates/volumes/pihole-dnsmasq/30-caddy-wildcard.conf.j2\` emits dnsmasq's \`address=/<domain>/<ip>\` syntax (Pi-hole's \`dns.hosts\` table is exact-match only — no wildcard support).
- \`podman_quadlet_volumes_files_to_stage\` extended to include the fragment when either \`caddy_acme_subdomain\` or \`caddy_acme_zone\` is set on the host.
- Cross-role variable read (same pattern as \`caddy_domain\` access today). No new pihole defaults.
- README explains the auto-generated wildcard record.

**Depends on PR #116** (caddy DNS-01 wiring) — without that PR's vars, this fragment is never rendered.

**Backward-compatible**: hosts that don't set either caddy_acme var get the previous behaviour (no fragment rendered, no container restart triggered).

## Test plan

- [ ] On a host with \`caddy_acme_subdomain: myhome\` set: re-deploy pihole. The fragment lands at the volume mountpoint.
- [ ] \`sudo -u pihole podman exec pihole cat /etc/dnsmasq.d/30-caddy-wildcard.conf\` shows the rendered \`address=\` line.
- [ ] From a LAN client: \`dig @<homeserver-ip> arbitrary.myhome.dedyn.io +short\` returns the homeserver's LAN IP.
- [ ] On a host with no \`caddy_acme_*\` vars: re-deploy pihole, fragment is absent, no behaviour change.

## Follow-ups (subsequent PRs)

- **Phase 5** — setup.sh: deSEC prompt + auto-write of the wildcard A record via deSEC API.
- **Phase 6** — drop internal-CA code (after migrating existing deployments).
- **Phase 7** — Tailscale split-DNS doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)