### PR TITLE
entephoto: pull mc from quay.io to dodge Docker Hub rate limit

### DIFF
--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -2,6 +2,7 @@
 # Container images
 entephoto_postgres_image: "public.ecr.aws/docker/library/postgres:15"
 entephoto_minio_image: "quay.io/minio/minio:latest"
+entephoto_mc_image: "quay.io/minio/mc:latest"
 entephoto_server_image: "ghcr.io/ente-io/server:latest"
 entephoto_web_image: "ghcr.io/ente-io/web:latest"
 

--- a/roles/entephoto/tasks/main.yml
+++ b/roles/entephoto/tasks/main.yml
@@ -78,7 +78,7 @@
   ansible.builtin.shell:
     cmd: |
       su - entephoto -c 'podman run --rm --pod entephoto \
-        --entrypoint sh docker.io/minio/mc:latest -c "
+        --entrypoint sh {{ entephoto_mc_image }} -c "
           for i in \$(seq 1 30); do
             mc alias set h0 http://localhost:3200 {{ entephoto_minio_root_user }} {{ entephoto_minio_password | quote }} && break
             sleep 2


### PR DESCRIPTION
## Summary
- Fresh homeserver deploy hit Docker Hub anonymous pull rate limit on `docker.io/minio/mc:latest` during the bucket-init task.
- MinIO publishes the same image to quay.io; the minio server image in this role is already pulled from there.
- Lifted the image to `entephoto_mc_image` in defaults for consistency with the other image vars.

## Test plan
- [ ] Re-run `ansible-playbook playbooks/entephoto.yml --limit homeserver` on the host that just failed; the "Wait for MinIO and create buckets" task should complete without rate-limit errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)