### PR TITLE
caddy: use block form for acme_dns directive

### DIFF
--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -7,7 +7,9 @@
 # (desec / cloudflare / hetzner) are bundled in the custom Caddy
 # image — switching providers is just an inventory change.
 {
-	acme_dns {{ caddy_acme_provider }} {{ caddy_acme_token }}
+	acme_dns {{ caddy_acme_provider }} {
+		token {{ caddy_acme_token }}
+	}
 }
 
 # Dashboard (root domain)


### PR DESCRIPTION
## Summary
- Inline form \`acme_dns desec <token>\` fails parsing on a fresh deploy with \"wrong argument count or unexpected line ending after <token>\".
- Block form \`acme_dns desec { token <token> }\` validates cleanly. This is what caddy-dns/desec, caddy-dns/cloudflare, and caddy-dns/hetzner all document.

## Test plan
- [x] \`caddy validate\` passes with the new template on homeserver2.
- [ ] Re-run \`ansible-playbook playbooks/caddy.yml --limit homeserver\` and confirm caddy.service comes up active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)