### PR TITLE
caddy: add 2m DNS-01 propagation_delay for deSEC challenges

### DIFF
--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -14,6 +14,9 @@
 
 # Dashboard (root domain)
 {{ caddy_domain }} {
+	tls {
+		propagation_delay 2m
+	}
 	root * /srv/dashboard
 	header Cache-Control "no-store, max-age=0"
 	file_server
@@ -23,6 +26,9 @@
 {% for svc in caddy_reverse_proxy_services %}
 {% if svc.tls | default(true) %}
 {{ svc.subdomain }}.{{ caddy_domain }} {
+	tls {
+		propagation_delay 2m
+	}
 {% else %}
 http://{{ svc.subdomain }}.{{ caddy_domain }} {
 {% endif %}


### PR DESCRIPTION
## Summary
- DNS-01 challenges via deSEC fail on a fresh deploy because Caddy notifies LE the TXT is ready ~3s after writing — LE's secondary validators still see a cached NSEC denial of existence (deSEC's default TTL is 3600s).
- Adding \`propagation_delay 2m\` per-site lets the negative cache expire before LE checks. First-attempt issuance now succeeds.

## Test plan
- [x] Verified on homeserver2: \`certificate obtained successfully\` from acme-v02.api.letsencrypt.org on first attempt with the new template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)