### PR TITLE
setup.sh: link dashboard tiles to Caddy proxy URLs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -560,7 +560,7 @@ cat << EOF
     service: pihole
     urls:
       - label: Admin UI
-        url: https://${SERVER_IP}:8443/admin
+        url: https://pihole.${CADDY_DOMAIN}/admin
     volumes:
       - systemd-pihole-etc
       - systemd-pihole-dnsmasq
@@ -576,7 +576,7 @@ cat << EOF
     service: syncthing
     urls:
       - label: Web UI
-        url: https://${SERVER_IP}:8384
+        url: https://syncthing.${CADDY_DOMAIN}
     volumes:
       - systemd-syncthing
 
@@ -591,9 +591,9 @@ cat << EOF
     service: entephoto-pod
     urls:
       - label: Photos
-        url: http://${SERVER_IP}:3000
+        url: https://photos.${CADDY_DOMAIN}
       - label: API
-        url: http://${SERVER_IP}:8080/ping
+        url: https://photos-api.${CADDY_DOMAIN}/ping
     volumes:
       - entephoto-postgres-data
       - entephoto-minio-data
@@ -610,7 +610,7 @@ cat << EOF
     service: paperless-ngx-pod
     urls:
       - label: Web UI
-        url: http://${SERVER_IP}:8000
+        url: https://paperless.${CADDY_DOMAIN}
     volumes:
       - paperless-db-data
       - paperless-media


### PR DESCRIPTION
## Summary
- Generated dashboard tiles linked to \`https://<ip>:<port>\` for pihole / syncthing / photos / paperless. Those ports aren't exposed in the firewall — only the reverse-proxied subdomains are.
- Switched to \`https://<sub>.<caddy_domain>\` to match the \`caddy_reverse_proxy_services\` entries (and how jellyfin/music are already emitted).

## Test plan
- [ ] Re-run setup.sh on a fresh host, open the dashboard, confirm tiles open the proxied service over HTTPS with green padlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)