### PR TITLE
jellyfin: accept 401 from /Startup/User as wizard-complete

### DIFF
--- a/roles/jellyfin/tasks/postinstall.yml
+++ b/roles/jellyfin/tasks/postinstall.yml
@@ -38,14 +38,15 @@
 # --------------------------------------------------------------------------
 # The Startup endpoints are only reachable while the first-run wizard
 # is incomplete. Once /Startup/Complete has been called, GET /Startup/User
-# returns 403 and the entire /Startup/* surface stops accepting writes.
-# That's our idempotency switch.
+# returns 403 (older Jellyfin) or 401 (newer Jellyfin, which now
+# enforces auth on the post-wizard surface). Either is our "wizard
+# already done, skip the walkthrough" signal.
 
 - name: Probe wizard state
   ansible.builtin.uri:
     url: "http://127.0.0.1:8096/Startup/User"
     method: GET
-    status_code: [200, 403]
+    status_code: [200, 401, 403]
     return_content: false
   register: _jellyfin_wizard_probe
 


### PR DESCRIPTION
## Summary
- Jellyfin postinstall failed with HTTP 401 from \`/Startup/User\` on a re-run against an install whose wizard had already completed.
- Newer Jellyfin requires auth on the post-wizard \`/Startup/*\` surface and returns 401 instead of the older 403. Either means \"wizard already done\".
- Adds 401 to the accepted status codes; the existing \`status == 200\` check still gates the wizard walkthrough.

## Test plan
- [ ] Re-run \`ansible-playbook playbooks/jellyfin.yml --limit homeserver\` against the failing host; the probe should now succeed and the role should fall through to library setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)