### PR TITLE
docs: tighten deSEC sign-up + token steps in Setup Guide

### DIFF
--- a/docs/Setup-Guide/01-deSEC-account.md
+++ b/docs/Setup-Guide/01-deSEC-account.md
@@ -25,9 +25,11 @@ you later want to bring your own domain.
 
 - Open <https://desec.io/> in your browser.
 - Click **Sign Up**.
-- Enter your email, choose a password, accept the terms, submit.
-- Open the verification email from deSEC, click the confirmation
-  link.
+  - Enter your email
+  - chose "No, I'll add one later"
+  - fill in CAPTCHA
+  - accept the terms & sign up
+- Open the verification email from deSEC, click the confirmation link.
 
 (~2 min.)
 
@@ -65,8 +67,10 @@ deSEC's web UI shows your domain's dashboard after Step 2.
 - Leave the default permissions (full account scope) unless you
   know you want to restrict it.
 - Click **Save**.
-- **Copy the token now** to a password manager or a temporary
-  note — deSEC shows it only once.
+
+> [!IMPORTANT]  
+> **Copy the token now** to a password manager or a temporary 
+> note — **deSEC shows it only once**.
 
 (~1 min.)
 


### PR DESCRIPTION
## Summary
- Spell out the exact form choices on deSEC sign-up (email / \"No, I'll add one later\" / CAPTCHA / accept terms) so a new user doesn't get tripped up.
- Promote the \"copy the token now — shown only once\" line to an !IMPORTANT callout.

## Test plan
- [x] Rendered on GitHub: callout + bullet nesting look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)