### PR TITLE
setup.sh: hoist is_selected above first use

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -362,6 +362,14 @@ done
 echo
 ok "Selected services: ${SELECTED_SERVICES[*]}"
 
+is_selected() {
+    local needle=$1
+    for s in "${SELECTED_SERVICES[@]}"; do
+        [[ "$s" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
 # ============================================================================
 # Step 6: Generate configuration files
 # ============================================================================
@@ -549,13 +557,6 @@ ok "Generated inventory/host_vars/homeserver/main.yml (with vault-encrypted secr
 # Only include services that were actually selected for deployment, so
 # the dashboard doesn't display stale "Stopped" rows for un-deployed
 # services.
-is_selected() {
-    local needle=$1
-    for s in "${SELECTED_SERVICES[@]}"; do
-        [[ "$s" == "$needle" ]] && return 0
-    done
-    return 1
-}
 
 {
 echo "services:"


### PR DESCRIPTION
## Summary
- PR #129 introduced \`is_selected\` calls in the host_vars/main.yml generation block, which runs before the dashboard-config block where the function was defined — every call printed \"is_selected: command not found\" and emitted an empty \`caddy_reverse_proxy_services:\` list.
- Hoists the function definition to right after \`SELECTED_SERVICES\` is populated.

## Test plan
- [ ] Re-run setup.sh; \`caddy_reverse_proxy_services\` should contain one entry per selected service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)