### PR TITLE
docs: emphasize 'script provisions the machine it runs on'

### DIFF
--- a/docs/Setup-Guide/04-run-setup.md
+++ b/docs/Setup-Guide/04-run-setup.md
@@ -31,8 +31,8 @@ curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/setu
 
 > [!IMPORTANT]
 > Run this **on the server** (i.e. inside the SSH session from
-> Step 3) — not on your laptop. The script provisions the
-> machine it runs on.
+> Step 3) — not on your laptop. **The script provisions the
+> machine it runs on.**
 
 ### What you'll see
 


### PR DESCRIPTION
## Summary
- Bolds the second sentence of the Step 4 IMPORTANT callout so the consequence (\"setup.sh provisions whatever host it's executed on\") stands out for skim-readers.

## Test plan
- [x] Rendered on GitHub: callout looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)