### PR TITLE
pihole: pull klutchell/unbound from GHCR

### DIFF
--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -45,11 +45,10 @@ pihole_enable_unbound: true
 # on localhost). Convention: 5335 to avoid conflict with Pi-hole on 53.
 pihole_unbound_port: 5335
 
-# Unbound container image. Only published on Docker Hub, which rate-limits
-# unauthenticated pulls; the Galaxy role's pre-pull fallback (>=v1.2.0)
-# uses the locally cached image when the pull fails, so redeploys keep
-# working without credentials once the image has been pulled at least once.
-pihole_unbound_image: "docker.io/klutchell/unbound:latest"
+# Unbound container image. klutchell/unbound publishes to both Docker
+# Hub and GHCR; we default to GHCR to avoid Docker Hub's anonymous
+# pull rate limit.
+pihole_unbound_image: "ghcr.io/klutchell/unbound:latest"
 
 # Run the tasks in verify.yml at the end of deploy to assert that Pi-hole
 # actually works (container healthy, gravity populated, canary blocked,


### PR DESCRIPTION
## Summary
- Switch \`pihole_unbound_image\` to \`ghcr.io/klutchell/unbound:latest\` (mirror of the same image, no anonymous-pull rate limit).

## Test plan
- [ ] Re-run \`ansible-playbook playbooks/pihole.yml --limit homeserver\` on a fresh host; unbound pulls cleanly from GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)