### PR TITLE
pihole: fix pre-pull cwd / become for unbound

### DIFF
--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -190,10 +190,12 @@
 # (which gives up after one failed exec).
 - name: Pre-pull Unbound image # noqa: no-changed-when
   become: true
+  become_user: pihole
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ my_linux_users.pihole.uid }}"
   ansible.builtin.command:
-    cmd: >
-      sudo -u pihole XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.pihole.uid }}
-      podman pull {{ pihole_unbound_image }}
+    cmd: podman pull {{ pihole_unbound_image }}
+    chdir: /tmp
   changed_when: false
   retries: 3
   delay: 5


### PR DESCRIPTION
## Summary
- Pre-pull (PR #134) shell'd \`sudo -u pihole …\` from the play's cwd. ansible's home is 0750, pihole can't chdir there, sudo aborts before podman runs, all retries fail rc=1.
- Use ansible's \`become_user: pihole\` + \`environment:\` for XDG_RUNTIME_DIR and \`chdir: /tmp\` so cwd is world-readable.

## Test plan
- [ ] \`ansible-playbook playbooks/pihole.yml --limit homeserver\` on the failing host; the pre-pull task should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)