### PR TITLE
setup.sh: preserve system hostname (don't rename to 'homeserver')

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -435,6 +435,14 @@ MUSIC_ASSISTANT_MAC="02:$(openssl rand -hex 5 | sed 's/\(..\)/\1:/g;s/:$//')"
 {
 cat << YAML
 ##################################################################################################
+### Host identity
+# Preserve the system hostname the operator set during OS install,
+# instead of falling back to the inventory key (which is hardcoded
+# to "homeserver"). Without this, os-base would rename the box on
+# every deploy.
+os_base_hostname: $SERVER_HOSTNAME
+
+##################################################################################################
 ### Services to deploy on this host (used by playbooks/site.yml)
 deploy_services:
 YAML


### PR DESCRIPTION
## Summary
- Inventory key is hardcoded \`homeserver\`, so os-base's hostname task renamed any host whose system hostname differed (e.g. \`homeserver2\`) on every deploy.
- Emit \`os_base_hostname: \$SERVER_HOSTNAME\` (the value the operator already chose at the prompt) so os-base preserves it.

## Test plan
- [ ] Re-run setup.sh on a fresh host with a non-default hostname; \`hostnamectl\` afterwards should still report the chosen name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)