### PR TITLE
caddy: back up caddy-data so the wildcard cert survives a reinstall

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -33,6 +33,7 @@
     nfs_opts: "ro,noatime,vers=4"
     # Services that have backup manifests. Must match role directory names.
     _restorable_services:
+      - caddy
       - pihole
       - syncthing
       - entephoto
@@ -74,6 +75,14 @@
     # parameterised by the service's manifest. Static tags allow
     # --tags filtering.
     # ==================================================================
+
+    - name: Restore caddy
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | list | length > 0
+      tags: [caddy]
 
     - name: Restore pihole
       ansible.builtin.include_tasks:

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -126,12 +126,12 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 | entephoto | `entephoto-minio-data`            | rsync   |
 | jellyfin  | `systemd-jellyfin-config`         | tar     |
 | jellyfin  | `systemd-jellyfin-media`          | rsync   |
+| caddy     | `caddy-data`                      | tar     |
 
-> Caddy volumes are not backed up. All three (`caddy-data`,
-> `caddy-config`, `caddy-etc`) are regenerated from the role on
-> every deploy. Real Let's Encrypt certs live in `caddy-data` and
-> Caddy re-issues them via DNS-01 against deSEC after a fresh
-> install — no persistence needed.
+> Only `caddy-data` is backed up (the LE-issued wildcard cert
+> and ACME account key). `caddy-config` is runtime state and
+> `caddy-etc` is regenerated from the Jinja template on every
+> deploy — neither needs persistence.
 
 ## Deployment
 

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -130,8 +130,10 @@ ansible-vault encrypt_string --encrypt-vault-id default --stdin-name 'caddy_acme
 ## Volumes
 
 - `caddy-data` — TLS certificates issued by Let's Encrypt and
-  auto-renewed. Re-issued from scratch on a fresh install — no
-  backup needed.
+  auto-renewed, plus the ACME account key. **Backed up** so a
+  rebuilt host can restore the wildcard cert instead of re-issuing
+  (and burning a slot in LE's 5-certs-per-week-per-identifier-set
+  rate limit during testing cycles).
 - `caddy-config` — runtime config. Regenerated.
 - `caddy-etc` — staged `Caddyfile` (rendered from Jinja2 template).
 

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -51,3 +51,16 @@ caddy_acme_zone: ""
 # host_vars. Scope to the single zone / single record type when the
 # provider supports it.
 caddy_acme_token: ""
+
+# Backup manifest — consumed by the backup role and restore playbook.
+# Only caddy-data is backed up: it holds the LE-issued wildcard cert
+# and the ACME account key. Preserving it across an OS reinstall lets
+# `restore.yml` skip a fresh issuance entirely (and dodges LE's
+# 5-certs-per-week rate limit on aggressive rebuilds). caddy-config
+# is runtime state, caddy-etc is regenerated from the template — both
+# rebuild from scratch on every deploy.
+backup_manifest:
+  service_user: webproxy
+  service_unit: caddy
+  volumes:
+    - { name: caddy-data, method: tar }

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -85,3 +85,10 @@
     su - webproxy -c 'podman exec caddy caddy reload --config /etc/caddy/Caddyfile 2>&1'
   changed_when: false
   failed_when: false
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined


### PR DESCRIPTION
## Summary
- caddy-data is now in the role's \`backup_manifest\` (\`method: tar\`).
- \`playbooks/restore.yml\` runs caddy first (before any other service that depends on \`https://*.<domain>/\`).
- Documentation updated in caddy + backup README.

## Why
Without persistence, a rebuilt host forces a fresh LE issuance — wasting one of the 5-per-week slots per identifier set and adding the 2-min propagation_delay to every redeploy.

## Test plan
- [ ] Nightly backup writes a \`caddy-data-*.tar.gz\` to the backup NAS share.
- [ ] After a deliberate \`podman volume rm caddy-data\` and \`ansible-playbook playbooks/restore.yml --limit homeserver --tags caddy\`, the wildcard cert is back without a fresh LE call (check caddy logs for "loaded certificate" instead of "obtaining certificate").

🤖 Generated with [Claude Code](https://claude.com/claude-code)