### PR TITLE
backup: segment NAS paths by inventory_hostname (multi-host safe)

### DIFF
--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -44,7 +44,7 @@
 # --- Find latest tar backups ---
 - name: "{{ svc._role_name | upper }}: find latest tar backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/tar/{{ item.name }}/*.tar.gz | head -1
+    ls -t {{ restore_root }}/tar/{{ inventory_hostname }}/{{ item.name }}/*.tar.gz | head -1
   register: _tar_latest
   loop: "{{ svc.volumes | selectattr('method', 'equalto', 'tar') | list }}"
   loop_control:
@@ -54,7 +54,7 @@
 # --- Find latest pgdump backups ---
 - name: "{{ svc._role_name | upper }}: find latest pgdump backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/tar/pgdump-{{ item.container }}/*.sql.gz | head -1
+    ls -t {{ restore_root }}/tar/{{ inventory_hostname }}/pgdump-{{ item.container }}/*.sql.gz | head -1
   register: _pgdump_latest
   loop: "{{ svc.databases | default([]) }}"
   loop_control:
@@ -92,7 +92,7 @@
         --format='{% raw %}{{.Mountpoint}}{% endraw %}')
     sudo -u {{ svc.service_user }} podman unshare rsync -a --delete \
         --no-owner --no-group --numeric-ids \
-        "{{ restore_root }}/{{ item.nas_share }}/" "$MP/"
+        "{{ restore_root }}/{{ item.nas_share }}/{{ inventory_hostname }}/" "$MP/"
   loop: >-
     {{ svc.volumes
        | selectattr('method', 'equalto', 'rsync')

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -42,6 +42,21 @@ The script implements three methods. Each service's volumes are
 assigned the right one based on size, mutability, and whether the
 data is a database.
 
+### Per-host segmentation
+
+Every backup path is prefixed with the host's `inventory_hostname`,
+so multiple homeservers (e.g. prod + test) can share the same NAS
+without colliding. Layout:
+
+```
+backup-tar/<hostname>/<volume>/<volume>-YYYYMMDD-HHMMSS.tar.gz
+backup-tar/<hostname>/pgdump-<container>/<container>-YYYYMMDD-HHMMSS.sql.gz
+backup-<share>/<hostname>/...
+```
+
+Restore reads the same paths via `inventory_hostname`, so each
+host always restores its own data.
+
 ### 1. `tar` — `podman volume export | gzip`
 
 Used for **small, mostly-config volumes** where keeping a daily
@@ -84,7 +99,7 @@ wasteful and history isn't needed (the data is the data).
 - **Restore:**
   ```bash
   rsync -a --no-owner --no-group --numeric-ids \
-      /mnt/backup/<share>/ <volume mount path>/
+      /mnt/backup/<share>/<hostname>/ <volume mount path>/
   sudo -u <user> podman unshare chown -R 0:0 <volume mount path>
   ```
 

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -18,10 +18,13 @@ set -euo pipefail
 # ===========================================================================
 
 # --- Configuration ---
-# NOTE: NAS_HOST / NAS_VOLUME are rendered by Ansible from host_vars.
+# NOTE: NAS_HOST / NAS_VOLUME / HOSTNAME_DIR are rendered by Ansible from
+# host_vars. HOSTNAME_DIR segments every backup path so multiple homeservers
+# (e.g. prod + test) can share the same NAS without colliding.
 BACKUP_ROOT="/mnt/backup"
 NAS_HOST="{{ backup_nas_hostname }}"
 NAS_VOLUME="{{ backup_nas_volume }}"
+HOSTNAME_DIR="{{ inventory_hostname }}"
 # Local mount name → Synology shared folder name.
 # Derived from backup_manifest declarations in each role's defaults.
 declare -A NFS_SHARES=(
@@ -80,7 +83,7 @@ start_service() {
 # --- Backup functions ---
 backup_tar_volume() {
   local user=$1 uid=$2 volume=$3
-  local dest="$BACKUP_ROOT/tar/$volume"
+  local dest="$BACKUP_ROOT/tar/$HOSTNAME_DIR/$volume"
   mkdir -p "$dest"
   log "  Tar backup: $volume"
   if su - "$user" -c "podman volume export $volume" \
@@ -103,8 +106,9 @@ backup_rsync_volume() {
     log_error "Cannot inspect volume $volume"
     return 1
   fi
-  local dest="$BACKUP_ROOT/$share"
-  log "  Rsync backup: $volume → $share"
+  local dest="$BACKUP_ROOT/$share/$HOSTNAME_DIR"
+  mkdir -p "$dest"
+  log "  Rsync backup: $volume → $share/$HOSTNAME_DIR"
   # --no-owner --no-group --numeric-ids: NFS all_squash maps every UID to the
   #   share's anon user, so chowns from rsync would fail. We deliberately
   #   drop ownership preservation here. On restore, container-native UIDs
@@ -121,7 +125,7 @@ backup_rsync_volume() {
 
 backup_pgdump() {
   local user=$1 container=$2 db_user=$3 db_name=$4
-  local dest="$BACKUP_ROOT/tar/pgdump-$container"
+  local dest="$BACKUP_ROOT/tar/$HOSTNAME_DIR/pgdump-$container"
   mkdir -p "$dest"
   log "  pg_dump: $container ($db_name)"
   if su - "$user" -c "podman exec $container pg_dump -U $db_user $db_name" \


### PR DESCRIPTION
## Summary
- Every backup path is now prefixed with \`inventory_hostname\` so multiple homeservers can share one NAS without colliding.
- Layout: \`backup-tar/<host>/<volume>/...\`, \`backup-tar/<host>/pgdump-<container>/...\`, \`backup-<share>/<host>/...\`.
- Restore reads the same per-host paths, so each host always restores its own data.

## Why
Test box (\`homeserver2\`) about to start backing up would otherwise stomp on prod's (\`homeserver\`) data on the same NAS.

## Migration (one-time, on the NAS)
For any pre-existing prod data, move it under a \`<hostname>/\` subdir before the next backup:

```bash
# on the NAS, for each share:
cd /volume1/backup-tar && mkdir -p homeserver && mv systemd-* pgdump-* homeserver/
cd /volume1/backup-photos && mkdir -p homeserver && mv * homeserver/   # etc.
```

Without this, the first new backup run starts a fresh history under the \`homeserver/\` subdir; old tarballs orphan in place (harmless, just stale).

## Test plan
- [ ] After merge + redeploy backup role on prod and on test, both hosts' next backup writes to their own \`<hostname>/\` subtree.
- [ ] \`ansible-playbook playbooks/restore.yml --limit homeserver2 --tags pihole\` reads from \`backup-tar/homeserver2/systemd-pihole-etc/\`, not prod's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)