### PR TITLE
ansible.cfg: disable -tt for become to avoid pam_systemd OSC pollution

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,12 @@ roles_path = ./roles:./.ansible/roles:~/.ansible/roles:/usr/share/ansible/roles
 stdout_callback = default
 host_key_checking = False
 vault_password_file = vault.pw
+
+[ssh_connection]
+# Don't allocate a pseudo-TTY for become. Fedora's pam_systemd 258+
+# emits OSC 3008 sequences over the TTY for every sudo session, which
+# pollutes ansible's stdout-capture and breaks tasks that parse module
+# JSON output (e.g. luckynrslevin.podman_quadlet's `Get podman version`).
+# Safe because all hosts use passwordless sudo (NOPASSWD).
+use_tty = False
+pipelining = True


### PR DESCRIPTION
## Summary
- Fedora's pam_systemd 258+ emits OSC 3008 escape sequences over the controlling TTY on every sudo session.
- Ansible's default \`use_tty=True\` for become allocates a pseudo-TTY and captures those sequences into module stdout after the JSON payload, breaking JSON parsing.
- Surfaced as: \`luckynrslevin.podman_quadlet\` "Get podman version" → \"Module invocation had junk after the JSON data\" → follow-up \`set_fact\` crash on empty stdout.

## Fix
- Set \`use_tty=False\` and \`pipelining=True\` in ansible.cfg's \`[ssh_connection]\` section.
- Safe because every host uses passwordless sudo (NOPASSWD).

## Test plan
- [x] Reproduced the OSC pollution on prod (homeserver / Fedora) with default config.
- [x] After the change, ad-hoc \`ansible homeserver -m command -a \"podman --version\" --become\` returns clean JSON; site.yml's podman_quadlet preflight no longer fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)