### PR TITLE
Add nextcloud role: Apache + Postgres + Redis pod

### DIFF
--- a/playbooks/nextcloud.yml
+++ b/playbooks/nextcloud.yml
@@ -1,0 +1,7 @@
+- name: Deploy Nextcloud on home server
+  hosts: homeservers
+  become: true
+  gather_facts: true
+
+  roles:
+    - nextcloud

--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -39,6 +39,7 @@
       - entephoto
       - paperless-ngx
       - jellyfin
+      - nextcloud
 
   pre_tasks:
     # Load each role's defaults so backup_manifest vars are available.
@@ -123,4 +124,12 @@
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'jellyfin') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'jellyfin') | list | length > 0
       tags: [jellyfin]
+
+    - name: Restore nextcloud
+      ansible.builtin.include_tasks:
+        file: tasks/restore_generic.yml
+      vars:
+        svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'nextcloud') | first }}"
+      when: _restore_manifests | selectattr('_role_name', 'equalto', 'nextcloud') | list | length > 0
+      tags: [nextcloud]
 

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -53,4 +53,5 @@
     - { role: paperless-ngx, when: "'paperless-ngx' in (deploy_services | default([]))" }
     - { role: jellyfin,        when: "'jellyfin' in (deploy_services | default([]))" }
     - { role: music-assistant, when: "'music-assistant' in (deploy_services | default([]))" }
+    - { role: nextcloud,       when: "'nextcloud' in (deploy_services | default([]))" }
     - { role: backup,          when: "'backup' in (deploy_services | default([]))" }

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -141,6 +141,9 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 | entephoto | `entephoto-minio-data`            | rsync   |
 | jellyfin  | `systemd-jellyfin-config`         | tar     |
 | jellyfin  | `systemd-jellyfin-media`          | rsync   |
+| nextcloud | `nextcloud` (Postgres)            | pgdump  |
+| nextcloud | `nextcloud-config`                | tar     |
+| nextcloud | `nextcloud-data`                  | rsync   |
 | caddy     | `caddy-data`                      | tar     |
 
 > Only `caddy-data` is backed up (the LE-issued wildcard cert

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -1,0 +1,136 @@
+# nextcloud
+
+[Nextcloud](https://nextcloud.com/) — files, contacts, and (via the
+built-in OpenID Connect Identity Provider app) household-wide SSO for
+other services in this stack. Deployed as a rootless Podman pod with
+Apache+PHP, Postgres, and Redis.
+
+## Container images
+
+| Container | Image |
+|-----------|-------|
+| nextcloud-server | `docker.io/library/nextcloud:apache` |
+| nextcloud-postgres | `public.ecr.aws/docker/library/postgres:16` |
+| nextcloud-redis | `public.ecr.aws/docker/library/redis:7-alpine` |
+
+## Service user
+
+`nextcloud` (UID/GID 1015) — rootless.
+
+## Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `nextcloud_image` | `docker.io/library/nextcloud:apache` | Apache+PHP single-container variant. |
+| `nextcloud_listen_port` | `8090` | Internal port on the host that Caddy reverse-proxies. |
+| `nextcloud_admin_user` | `ncadmin` | Admin account auto-created on first start. |
+| `nextcloud_admin_password` | (required, vault) | Admin password — must be set in inventory. |
+| `nextcloud_db_user` | `ncuser` | Postgres user. |
+| `nextcloud_db_name` | `nextcloud` | Postgres database. |
+| `nextcloud_db_password` | (required, vault) | Postgres password — must be set in inventory. |
+| `nextcloud_subdomain` | `cloud` | Subdomain Caddy serves Nextcloud at (`<sub>.<caddy_domain>`). |
+
+The role asserts both passwords are non-empty at the top of
+`tasks/main.yml`; no silent install with default credentials.
+
+## Reverse-proxy entry
+
+Add this to `caddy_reverse_proxy_services` in your host_vars:
+
+```yaml
+- { subdomain: cloud, port: 8090 }
+```
+
+## SMTP
+
+Project-level SMTP relay vars (see [`docs/SMTP-Setup.md`](../../docs/SMTP-Setup.md))
+are picked up automatically. When `smtp_host` is set, Nextcloud's
+`SMTP_*` env vars get rendered into the container quadlet so password
+resets, share notifications, and admin-test mails work out of the box.
+
+## Secrets
+
+| Variable | Purpose |
+|---|---|
+| `nextcloud_admin_password` | Admin login. Vault-encrypt. |
+| `nextcloud_db_password` | Postgres password. Vault-encrypt. |
+
+Generate and vault:
+
+```bash
+openssl rand -base64 24 | ansible-vault encrypt_string \
+  --encrypt-vault-id default --stdin-name 'nextcloud_admin_password'
+
+openssl rand -base64 24 | ansible-vault encrypt_string \
+  --encrypt-vault-id default --stdin-name 'nextcloud_db_password'
+```
+
+## Endpoints
+
+- Web UI: `https://<nextcloud_subdomain>.<caddy_domain>/`
+- WebDAV: `https://<nextcloud_subdomain>.<caddy_domain>/remote.php/dav/`
+
+## Volumes
+
+- `nextcloud-postgres-data` — Postgres data files. (`pgdump` backup.)
+- `nextcloud-data` — user files (the big one, `/var/www/html/data`).
+  Backed up via `rsync` to NAS share `backup-nextcloud`.
+- `nextcloud-config` — `config.php` + installed apps' settings.
+  (`tar` backup.)
+- `nextcloud-redis-data` — Redis AOF persistence (memcache + file
+  locking state). Not backed up — recoverable from cold start.
+- `nextcloud-html` — Nextcloud PHP source. Image-managed, not backed up.
+
+## Deployment
+
+```bash
+ansible-playbook playbooks/nextcloud.yml --limit <host>
+```
+
+The role:
+
+1. Asserts admin + DB passwords are set.
+2. Creates the `nextcloud` rootless user with linger.
+3. Deploys the pod (apache + postgres + redis) via the Galaxy
+   `luckynrslevin.podman_quadlet` role.
+4. Waits for `/status.php` to report `installed:true` (DB migrations
+   on first boot can take ~60 s).
+5. Configures Caddy (127.0.0.1) as a trusted reverse proxy.
+6. Installs and enables the **OpenID Connect Identity Provider** app
+   (`oidc_provider`) so other apps can OIDC against Nextcloud.
+7. Installs the **Contacts** app.
+
+## Bootstrapping OIDC for other apps
+
+After the role finishes, log into Nextcloud as the admin and:
+
+1. **Settings → Administration → Security → OpenID Connect** (or
+   "OAuth 2.0" depending on the app version).
+2. Click **Add client**.
+3. Name: e.g. `Paperless`.
+4. Redirect URI: e.g. `https://paperless.<caddy_domain>/accounts/oidc/<provider_id>/login/callback/` —
+   verify the exact form against the consuming app's documentation.
+5. Save. Copy the generated **client ID** and **client secret**.
+6. Paste them into the consuming role's inventory vars (e.g.
+   `paperless_oidc_client_id` / `paperless_oidc_client_secret`).
+7. Re-deploy the consuming app.
+
+## Restore
+
+The generic restore re-imports the tar/rsync/pgdump artifacts and
+restarts the pod. After that, `tasks/restore.yml` runs
+`occ maintenance:repair --include-expensive` to re-validate the file
+index against the on-disk files.
+
+```bash
+ansible-playbook playbooks/restore.yml --limit <host> --tags nextcloud
+```
+
+## Cross-role dependencies
+
+Pairs with [caddy](../caddy/README.md) — the reverse proxy fronts the
+Nextcloud Apache container at `https://<sub>.<caddy_domain>`.
+
+Source of OIDC identity for any consuming role (today: paperless-ngx
+when `paperless_oidc_enabled: true`; future: jellyfin via plugin,
+vaultwarden, etc.).

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -1,0 +1,45 @@
+---
+# Container images
+nextcloud_image: "docker.io/library/nextcloud:apache"
+nextcloud_postgres_image: "public.ecr.aws/docker/library/postgres:16"
+nextcloud_redis_image: "public.ecr.aws/docker/library/redis:7-alpine"
+
+# Internal port the Nextcloud apache container listens on. Caddy
+# fronts this at https://cloud.<caddy_domain>/. Not exposed in the
+# firewall.
+nextcloud_listen_port: 8090
+
+# Admin account created on first startup. The container's entrypoint
+# uses NEXTCLOUD_ADMIN_USER + NEXTCLOUD_ADMIN_PASSWORD on the very
+# first boot to bootstrap the instance; subsequent restarts ignore
+# them. After first login, change the password via the web UI if you
+# want.
+nextcloud_admin_user: "ncadmin"
+# Set nextcloud_admin_password from a vault-encrypted secret in
+# host_vars. Without it, the role's assert at the top of tasks/main.yml
+# fails fast — no silent install with a default credential.
+nextcloud_admin_password: ""
+
+# Postgres user used by Nextcloud. Vault-encrypt nextcloud_db_password
+# in host_vars.
+nextcloud_db_user: "ncuser"
+nextcloud_db_name: "nextcloud"
+nextcloud_db_password: ""
+
+# Trusted domain Nextcloud will accept Host: headers for. Defaults to
+# cloud.<caddy_domain>; override only if you want a different
+# subdomain.
+nextcloud_subdomain: "cloud"
+
+# Backup manifest — consumed by the backup role and restore playbook.
+# nextcloud-html is the bind-mount target for the image's PHP source
+# tree; it's regenerated on every container start, no backup needed.
+backup_manifest:
+  service_user: nextcloud
+  service_unit: nextcloud-pod
+  volumes:
+    - { name: nextcloud-config, method: tar }
+    - { name: nextcloud-data, method: rsync, nas_share: nextcloud }
+  databases:
+    - { container: nextcloud-postgres, db_user: "{{ nextcloud_db_user }}", db_name: "{{ nextcloud_db_name }}", method: pgdump }
+  post_restore_tasks: restore.yml

--- a/roles/nextcloud/files/quadlets/nextcloud-config.volume
+++ b/roles/nextcloud/files/quadlets/nextcloud-config.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=nextcloud-config

--- a/roles/nextcloud/files/quadlets/nextcloud-data.volume
+++ b/roles/nextcloud/files/quadlets/nextcloud-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=nextcloud-data

--- a/roles/nextcloud/files/quadlets/nextcloud-html.volume
+++ b/roles/nextcloud/files/quadlets/nextcloud-html.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=nextcloud-html

--- a/roles/nextcloud/files/quadlets/nextcloud-postgres-data.volume
+++ b/roles/nextcloud/files/quadlets/nextcloud-postgres-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=nextcloud-postgres-data

--- a/roles/nextcloud/files/quadlets/nextcloud-redis-data.volume
+++ b/roles/nextcloud/files/quadlets/nextcloud-redis-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=nextcloud-redis-data

--- a/roles/nextcloud/files/quadlets/nextcloud.network
+++ b/roles/nextcloud/files/quadlets/nextcloud.network
@@ -1,0 +1,5 @@
+[Unit]
+Description=nextcloud pod network
+
+[Network]
+NetworkName=nextcloud

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+
+- name: Assert required Nextcloud secrets are set
+  ansible.builtin.assert:
+    that:
+      - nextcloud_admin_password | length > 0
+      - nextcloud_db_password | length > 0
+    fail_msg: >-
+      nextcloud_admin_password and nextcloud_db_password must be set
+      (vault-encrypted) in host_vars before deploying. Generate with:
+        openssl rand -base64 24 | ansible-vault encrypt_string \
+          --encrypt-vault-id default --stdin-name '<varname>'
+
+- name: Ensure rootless user group exists
+  ansible.builtin.group:
+    name: nextcloud
+    gid: "{{ my_linux_users.nextcloud.gid }}"
+    state: present
+
+- name: Ensure rootless user exists
+  ansible.builtin.user:
+    name: nextcloud
+    state: present
+    uid: "{{ my_linux_users.nextcloud.uid }}"
+    group: nextcloud
+    create_home: true
+
+- name: Enable linger for rootless user
+  become: true
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger nextcloud"
+  changed_when: false
+
+- name: Enable podman auto-update timer for rootless user # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.nextcloud.uid }}/bus
+      systemctl --user enable --now podman-auto-update.timer
+  changed_when: false
+
+- name: Save current role path
+  ansible.builtin.set_fact:
+    nextcloud_role_path: "{{ role_path }}"
+
+# Deploy Nextcloud as a rootless Podman pod (apache + postgres + redis).
+# All three containers share the pod's network namespace, so the apache
+# container talks to postgres and redis on localhost.
+- name: Deploy nextcloud pod using podman_quadlet
+  ansible.builtin.include_role:
+    name: luckynrslevin.podman_quadlet
+  vars:
+    podman_quadlet_app_name: "nextcloud-pod"
+    podman_quadlet_rootless_user_name: nextcloud
+    podman_quadlet_files_templates_src_path: "{{ nextcloud_role_path }}"
+    podman_quadlet_file_names:
+      - nextcloud.pod.j2
+      - nextcloud.network
+      - nextcloud-postgres.container.j2
+      - nextcloud-redis.container.j2
+      - nextcloud-server.container.j2
+      - nextcloud-postgres-data.volume
+      - nextcloud-redis-data.volume
+      - nextcloud-data.volume
+      - nextcloud-config.volume
+      - nextcloud-html.volume
+
+- name: Run postinstall (OIDC Provider app, Caddy trusted-proxy, etc.)
+  ansible.builtin.include_tasks: postinstall.yml
+
+- name: Register backup manifest
+  ansible.builtin.set_fact:
+    _backup_manifests: >-
+      {{ _backup_manifests | default([]) +
+         [backup_manifest | combine({'_role_name': role_name})] }}
+  when: backup_manifest is defined

--- a/roles/nextcloud/tasks/postinstall.yml
+++ b/roles/nextcloud/tasks/postinstall.yml
@@ -1,0 +1,78 @@
+---
+# Wait for Nextcloud's installer to finish (DB migrations on first boot
+# can take ~60s) before running occ commands.
+
+- name: Wait for Nextcloud /status.php to report installed
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ nextcloud_listen_port }}/status.php"
+    status_code: 200
+    return_content: true
+  register: _nextcloud_status
+  retries: 30
+  delay: 5
+  until: _nextcloud_status.status == 200 and _nextcloud_status.json.installed | default(false)
+
+# --------------------------------------------------------------------------
+# Configure Nextcloud's trusted proxies + overwrite settings.
+# The image's entrypoint sets OVERWRITEPROTOCOL/HOST/CLIURL on first boot,
+# but the trusted_proxies array isn't covered by env vars and is required
+# for the X-Forwarded-* headers from Caddy to be honored.
+# --------------------------------------------------------------------------
+
+- name: Set Caddy as a trusted reverse proxy # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      podman exec -u www-data nextcloud-server
+      php occ config:system:set trusted_proxies 0 --value=127.0.0.1
+    chdir: /tmp
+  changed_when: false
+
+# --------------------------------------------------------------------------
+# Install + enable the OpenID Connect Identity Provider app so other apps
+# (e.g. Paperless, future Vaultwarden) can OIDC-against Nextcloud.
+# Idempotent: occ app:install is a no-op if already installed.
+# --------------------------------------------------------------------------
+
+- name: Install oidc_provider app # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      podman exec -u www-data nextcloud-server
+      php occ app:install oidc_provider
+    chdir: /tmp
+  register: _oidc_install
+  changed_when: "'installed' in _oidc_install.stdout and 'already installed' not in _oidc_install.stdout"
+  failed_when:
+    - _oidc_install.rc != 0
+    - "'already installed' not in _oidc_install.stderr"
+
+- name: Enable oidc_provider app # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      podman exec -u www-data nextcloud-server
+      php occ app:enable oidc_provider
+    chdir: /tmp
+  changed_when: false
+
+# --------------------------------------------------------------------------
+# Contacts app (initial-scope feature per Plan C).
+# --------------------------------------------------------------------------
+
+- name: Install contacts app # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      podman exec -u www-data nextcloud-server
+      php occ app:install contacts
+    chdir: /tmp
+  register: _contacts_install
+  changed_when: "'installed' in _contacts_install.stdout and 'already installed' not in _contacts_install.stdout"
+  failed_when:
+    - _contacts_install.rc != 0
+    - "'already installed' not in _contacts_install.stderr"

--- a/roles/nextcloud/tasks/restore.yml
+++ b/roles/nextcloud/tasks/restore.yml
@@ -1,0 +1,25 @@
+---
+# Nextcloud post-restore hook.
+# After re-importing nextcloud-data + nextcloud-config + the Postgres dump,
+# the file index in the DB needs to re-validate against the on-disk files
+# (mtimes / sizes / checksums). occ maintenance:repair --include-expensive
+# does this.
+
+- name: Wait for Nextcloud to come back up
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ nextcloud_listen_port }}/status.php"
+    status_code: 200
+  register: _nc_post_restore_status
+  retries: 30
+  delay: 5
+  until: _nc_post_restore_status.status == 200
+
+- name: Run maintenance:repair (expensive, scans files) # noqa: no-changed-when
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
+      podman exec -u www-data nextcloud-server
+      php occ maintenance:repair --include-expensive
+    chdir: /tmp
+  changed_when: false

--- a/roles/nextcloud/templates/quadlets/nextcloud-postgres.container.j2
+++ b/roles/nextcloud/templates/quadlets/nextcloud-postgres.container.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=nextcloud postgres database
+PartOf=nextcloud-pod.service
+
+[Container]
+ContainerName=%N
+Image={{ nextcloud_postgres_image }}
+AutoUpdate=registry
+
+Pod=nextcloud.pod
+
+Volume=nextcloud-postgres-data.volume:/var/lib/postgresql/data
+
+Environment=POSTGRES_USER={{ nextcloud_db_user }}
+Environment=POSTGRES_DB={{ nextcloud_db_name }}
+Environment=POSTGRES_PASSWORD={{ nextcloud_db_password }}
+
+HealthCmd=pg_isready -U {{ nextcloud_db_user }} -d {{ nextcloud_db_name }}
+HealthInterval=10s
+HealthStartPeriod=40s

--- a/roles/nextcloud/templates/quadlets/nextcloud-redis.container.j2
+++ b/roles/nextcloud/templates/quadlets/nextcloud-redis.container.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=nextcloud redis (memcache + transactional file locking)
+PartOf=nextcloud-pod.service
+
+[Container]
+ContainerName=%N
+Image={{ nextcloud_redis_image }}
+AutoUpdate=registry
+
+Pod=nextcloud.pod
+
+Volume=nextcloud-redis-data.volume:/data
+
+# AOF persistence — Nextcloud's transactional file locking depends on Redis;
+# losing the lock state on a crash is annoying but not catastrophic. AOF gives
+# us reasonable durability without the throughput cost of fsync=always.
+Exec=redis-server --appendonly yes
+
+HealthCmd=redis-cli ping
+HealthInterval=10s
+HealthStartPeriod=10s

--- a/roles/nextcloud/templates/quadlets/nextcloud-server.container.j2
+++ b/roles/nextcloud/templates/quadlets/nextcloud-server.container.j2
@@ -1,0 +1,46 @@
+[Unit]
+Description=nextcloud server (apache + php)
+PartOf=nextcloud-pod.service
+After=nextcloud-postgres.service nextcloud-redis.service
+
+[Container]
+ContainerName=%N
+Image={{ nextcloud_image }}
+AutoUpdate=registry
+
+Pod=nextcloud.pod
+
+# /var/www/html holds the Nextcloud PHP source — image-managed, regenerated
+# on every container start. /var/www/html/data is user files (the big one);
+# /var/www/html/config holds config.php + installed apps' settings; both are
+# split into their own volumes so backups and restores work cleanly.
+Volume=nextcloud-html.volume:/var/www/html
+Volume=nextcloud-data.volume:/var/www/html/data
+Volume=nextcloud-config.volume:/var/www/html/config
+
+# Bootstrap on first run — entrypoint reads these only when the install
+# hasn't been performed yet. Subsequent restarts ignore them.
+Environment=NEXTCLOUD_ADMIN_USER={{ nextcloud_admin_user }}
+Environment=NEXTCLOUD_ADMIN_PASSWORD={{ nextcloud_admin_password }}
+Environment=NEXTCLOUD_TRUSTED_DOMAINS={{ nextcloud_subdomain }}.{{ caddy_domain }}
+Environment=POSTGRES_HOST=localhost
+Environment=POSTGRES_USER={{ nextcloud_db_user }}
+Environment=POSTGRES_DB={{ nextcloud_db_name }}
+Environment=POSTGRES_PASSWORD={{ nextcloud_db_password }}
+Environment=REDIS_HOST=localhost
+Environment=REDIS_HOST_PORT=6379
+# Tell Nextcloud it's behind a reverse proxy so generated URLs are https://.
+Environment=OVERWRITEPROTOCOL=https
+Environment=OVERWRITEHOST={{ nextcloud_subdomain }}.{{ caddy_domain }}
+Environment=OVERWRITECLIURL=https://{{ nextcloud_subdomain }}.{{ caddy_domain }}
+{% if smtp_host | default('') | length > 0 %}
+# Project-level SMTP — see docs/SMTP-Setup.md.
+Environment=SMTP_HOST={{ smtp_host }}
+Environment=SMTP_PORT={{ smtp_port }}
+Environment=SMTP_AUTHTYPE=LOGIN
+Environment=SMTP_NAME={{ smtp_username }}
+Environment=SMTP_PASSWORD={{ smtp_password }}
+Environment=SMTP_SECURE={{ 'tls' if smtp_encryption == 'starttls' else ('ssl' if smtp_encryption == 'ssl' else '') }}
+Environment=MAIL_FROM_ADDRESS={{ smtp_from.split('@')[0] }}
+Environment=MAIL_DOMAIN={{ smtp_from.split('@')[1] }}
+{% endif %}

--- a/roles/nextcloud/templates/quadlets/nextcloud.pod.j2
+++ b/roles/nextcloud/templates/quadlets/nextcloud.pod.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=nextcloud
+After=network-online.target
+Wants=network-online.target
+
+[Pod]
+PodName=nextcloud
+Network=nextcloud.network
+
+# Apache listens on container :80; Caddy fronts at host :{{ nextcloud_listen_port }}.
+PublishPort={{ nextcloud_listen_port }}:80/tcp
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- New \`roles/nextcloud/\` builds the Plan C foundation: a 3-container rootless Podman pod (\`nextcloud:apache\` + Postgres 16 + Redis 7).
- 5 volumes; backup wired in (\`pgdump\` + \`tar\` + \`rsync\` per the role's \`backup_manifest\`).
- Postinstall installs the **OpenID Connect Identity Provider** (\`oidc_provider\`) app — Nextcloud becomes the OIDC IdP for Paperless (next PR) and any future app that can OIDC.
- Reads project-level SMTP vars (#153) when set — admin test mail / share notifications / password resets all work out of the box.
- Asserts \`nextcloud_admin_password\` + \`nextcloud_db_password\` are set; refuses to install silently with default creds.

## Files
- new role: \`roles/nextcloud/{defaults,tasks,templates,files,README.md}\`
- new playbook: \`playbooks/nextcloud.yml\`
- modified: \`playbooks/site.yml\` (gated on \`'nextcloud' in deploy_services\`), \`playbooks/restore.yml\` (in \`_restorable_services\`), \`roles/backup/README.md\` (new rows).

## Test plan (Plan C Phase 3)
- [ ] Set inventory vars (admin/db passwords vault-encrypted, deploy_services += nextcloud, caddy_reverse_proxy_services += { subdomain: cloud, port: 8090 }, nextcloud Linux user UID=1015) on homeserver2 first.
- [ ] \`ansible-playbook playbooks/nextcloud.yml --limit homeserver2\`.
- [ ] Open \`https://cloud.simsons-t.dedyn.io/\` — login as ncadmin, send test email, install Contacts, verify OIDC Provider app present in Settings → Administration → Security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)