### PR TITLE
nextcloud: fix OIDC Provider app id (oidc, not oidc_provider)

### DIFF
--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -97,7 +97,7 @@ The role:
    on first boot can take ~60 s).
 5. Configures Caddy (127.0.0.1) as a trusted reverse proxy.
 6. Installs and enables the **OpenID Connect Identity Provider** app
-   (`oidc_provider`) so other apps can OIDC against Nextcloud.
+   (`oidc`) so other apps can OIDC against Nextcloud.
 7. Installs the **Contacts** app.
 
 ## Bootstrapping OIDC for other apps

--- a/roles/nextcloud/tasks/postinstall.yml
+++ b/roles/nextcloud/tasks/postinstall.yml
@@ -35,13 +35,13 @@
 # Idempotent: occ app:install is a no-op if already installed.
 # --------------------------------------------------------------------------
 
-- name: Install oidc_provider app # noqa: no-changed-when
+- name: Install oidc app # noqa: no-changed-when
   become: true
   ansible.builtin.command:
     cmd: >
       sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
       podman exec -u www-data nextcloud-server
-      php occ app:install oidc_provider
+      php occ app:install oidc
     chdir: /tmp
   register: _oidc_install
   changed_when: "'installed' in _oidc_install.stdout and 'already installed' not in _oidc_install.stdout"
@@ -49,13 +49,13 @@
     - _oidc_install.rc != 0
     - "'already installed' not in _oidc_install.stderr"
 
-- name: Enable oidc_provider app # noqa: no-changed-when
+- name: Enable oidc app # noqa: no-changed-when
   become: true
   ansible.builtin.command:
     cmd: >
       sudo -u nextcloud XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.nextcloud.uid }}
       podman exec -u www-data nextcloud-server
-      php occ app:enable oidc_provider
+      php occ app:enable oidc
     chdir: /tmp
   changed_when: false
 


### PR DESCRIPTION
## Summary
- The original role tried to install \`oidc_provider\` from the appstore, which doesn't exist.
- Correct app ID is \`oidc\` (the community OpenID Connect Identity Provider).
- Confirmed via \`occ app:install oidc\` on homeserver2 (succeeded, version 1.16.6).

## Test plan
- [x] \`occ app:install oidc\` succeeds on homeserver2.
- [ ] Re-run \`ansible-playbook playbooks/nextcloud.yml --limit homeserver2\` — postinstall block should pass cleanly now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)