### PR TITLE
nextcloud: app:install idempotent across re-deploys

### DIFF
--- a/roles/nextcloud/tasks/postinstall.yml
+++ b/roles/nextcloud/tasks/postinstall.yml
@@ -47,7 +47,7 @@
   changed_when: "'installed' in _oidc_install.stdout and 'already installed' not in _oidc_install.stdout"
   failed_when:
     - _oidc_install.rc != 0
-    - "'already installed' not in _oidc_install.stderr"
+    - "'already installed' not in (_oidc_install.stderr ~ _oidc_install.stdout)"
 
 - name: Enable oidc app # noqa: no-changed-when
   become: true
@@ -75,4 +75,4 @@
   changed_when: "'installed' in _contacts_install.stdout and 'already installed' not in _contacts_install.stdout"
   failed_when:
     - _contacts_install.rc != 0
-    - "'already installed' not in _contacts_install.stderr"
+    - "'already installed' not in (_contacts_install.stderr ~ _contacts_install.stdout)"


### PR DESCRIPTION
## Summary
- \`occ app:install\` writes \"<app> already installed\" to **stdout** with a non-zero rc. The previous \`failed_when\` only checked stderr, so re-deploying broke after first success.
- Concatenate stdout and stderr for the substring check; both oidc + contacts tasks updated.

## Test plan
- [ ] Re-run \`ansible-playbook playbooks/nextcloud.yml --limit homeserver2\` (apps already installed) — should now exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)