### PR TITLE
paperless-ngx: opt-in OIDC support via django-allauth

### DIFF
--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -40,6 +40,22 @@ paperless_consumer_recursive: false
 paperless_consumer_subdirs_as_tags: false
 paperless_consumer_delete_duplicates: false
 
+# OIDC (opt-in). When enabled, paperless federates auth to an
+# external OpenID Connect provider (e.g. Nextcloud's oidc_provider
+# app). Built-in via django-allauth as of paperless-ngx 2.5+.
+# Required when enabled: paperless_oidc_client_id (string),
+# paperless_oidc_client_secret (vault), paperless_oidc_provider_url
+# (e.g. "https://cloud.example.com").
+paperless_oidc_enabled: false
+paperless_oidc_client_id: ""
+paperless_oidc_client_secret: ""
+paperless_oidc_provider_url: ""
+# When true, hitting /accounts/login/ jumps straight to the IdP
+# login. Local Paperless admin/users can still reach the local form
+# via /accounts/login/?process=login. Set false to keep the local
+# login form as the default (with a "Sign in with Nextcloud" button).
+paperless_oidc_redirect_login_to_sso: true
+
 # SFTP sidecar (opt-in). When enabled, an atmoz/sftp container runs
 # alongside the paperless pod under the same rootless user and mounts
 # `paperless-consume.volume` as its SFTP drop target. A scanner (or any

--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -49,6 +49,19 @@ Environment=PAPERLESS_URL={{ paperless_url | default('') }}
 Environment=USERMAP_UID=1000
 Environment=USERMAP_GID=1000
 
+{% if paperless_oidc_enabled | default(false) %}
+# OIDC — federate auth to an external IdP (e.g. Nextcloud's
+# oidc_provider). Built-in via django-allauth in paperless-ngx 2.5+.
+# provider_id 'nextcloud' is also the path segment in the OIDC
+# callback URL registered on the IdP side:
+# https://<paperless>/accounts/oidc/nextcloud/login/callback/
+Environment=PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
+Environment=PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"APPS":[{"provider_id":"nextcloud","name":"Nextcloud","client_id":"{{ paperless_oidc_client_id }}","secret":"{{ paperless_oidc_client_secret | replace('%', '%%') }}","settings":{"server_url":"{{ paperless_oidc_provider_url }}/index.php/apps/oidc"}}]}}
+{% if paperless_oidc_redirect_login_to_sso | default(true) %}
+Environment=PAPERLESS_REDIRECT_LOGIN_TO_SSO=true
+{% endif %}
+{% endif %}
+
 # Consumer behaviour
 Environment=PAPERLESS_CONSUMER_RECURSIVE={{ paperless_consumer_recursive | bool | string | lower }}
 Environment=PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS={{ paperless_consumer_subdirs_as_tags | bool | string | lower }}


### PR DESCRIPTION
## Summary
- Three new Environment= lines emitted when \`paperless_oidc_enabled: true\`.
- Three required vars: \`paperless_oidc_client_id\`, \`paperless_oidc_client_secret\` (vault), \`paperless_oidc_provider_url\`.
- Default \`paperless_oidc_redirect_login_to_sso: true\` makes \`/accounts/login/\` jump straight to the IdP. Local users can still reach the local form via \`?process=login\`.
- Provider_id hardcoded to \`nextcloud\` (matches the OIDC callback URL Nextcloud expects).
- Client secret %-escaped (systemd Environment= specifier-safe).

## Test plan (Plan C Phase 4)
- [ ] Set the four vars in homeserver2 inventory + the corresponding OIDC client in Nextcloud.
- [ ] Re-deploy paperless-ngx.
- [ ] Open paperless URL → should redirect to Nextcloud login → after auth, redirected back, auto-provisioned local user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)