### PR TITLE
paperless-ngx: escape JSON quotes for systemd Environment= line

### DIFF
--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -55,8 +55,13 @@ Environment=USERMAP_GID=1000
 # provider_id 'nextcloud' is also the path segment in the OIDC
 # callback URL registered on the IdP side:
 # https://<paperless>/accounts/oidc/nextcloud/login/callback/
+#
+# systemd's Environment= line strips double quotes from values, so
+# escape them with backslashes — otherwise the JSON arrives at the
+# container with all keys/values unquoted and django-allauth's
+# JSON parser rejects it.
 Environment=PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
-Environment=PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"APPS":[{"provider_id":"nextcloud","name":"Nextcloud","client_id":"{{ paperless_oidc_client_id }}","secret":"{{ paperless_oidc_client_secret | replace('%', '%%') }}","settings":{"server_url":"{{ paperless_oidc_provider_url }}/index.php/apps/oidc"}}]}}
+Environment=PAPERLESS_SOCIALACCOUNT_PROVIDERS={\"openid_connect\":{\"APPS\":[{\"provider_id\":\"nextcloud\",\"name\":\"Nextcloud\",\"client_id\":\"{{ paperless_oidc_client_id }}\",\"secret\":\"{{ paperless_oidc_client_secret | replace('%', '%%') }}\",\"settings\":{\"server_url\":\"{{ paperless_oidc_provider_url }}/index.php/apps/oidc\"}}]}}
 {% if paperless_oidc_redirect_login_to_sso | default(true) %}
 Environment=PAPERLESS_REDIRECT_LOGIN_TO_SSO=true
 {% endif %}


### PR DESCRIPTION
Reproduced on homeserver2: PAPERLESS_SOCIALACCOUNT_PROVIDERS arrived at the container with all quotes stripped, causing JSON parse failure at startup and rc=1. Backslash-escape the quotes.