### PR TITLE
caddy: bind :80/:443 directly via ip_unprivileged_port_start

### DIFF
--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -3,11 +3,14 @@
 # Dockerfile + GitHub Actions workflow that publishes this tag.
 caddy_image: "ghcr.io/luckynrslevin/caddy-acme:latest"
 
-# Caddy listen port (unprivileged, mapped via firewall from 80)
-caddy_listen_port: 9080
-
-# Caddy HTTPS listen port (unprivileged, mapped via firewall from 443)
-caddy_listen_port_https: 9443
+# Caddy listen ports. With os-base lowering
+# net.ipv4.ip_unprivileged_port_start to 80, Caddy (rootless via
+# webproxy) binds these directly — no firewall NAT, and pod-to-host
+# traffic from other rootless containers reaches Caddy on the
+# canonical ports, so OIDC issuers / S3 endpoints / etc. don't need
+# `:9443` warts in their inventory URLs.
+caddy_listen_port: 80
+caddy_listen_port_https: 443
 
 # Domain name for the server (e.g. "myhome.dedyn.io"). Required —
 # every reverse-proxy subdomain hangs off this. site.yml asserts it

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -68,15 +68,14 @@
       - name: caddy-etc
         files:
           - { src: 'Caddyfile.j2', mode: '0644' }
-    podman_quadlet_firewall_port_forwards:
-      - { port: 80, proto: 'tcp', toport: "{{ caddy_listen_port }}" }
-      - { port: 443, proto: 'tcp', toport: "{{ caddy_listen_port_https }}" }
-    # Also open the HTTPS listen port directly (not only via 443→9443
-    # forward) so containers on this host can reach Caddy on
-    # <subdomain>.<caddy_domain>:{{ caddy_listen_port_https }} via the
-    # host-gateway. Firewall port-forwards only apply to external traffic,
-    # so pod-to-host traffic needs the port itself open.
+    # Open the published ports in the firewall. Caddy now binds
+    # 80/443 directly (see os-base: ip_unprivileged_port_start=80),
+    # so no firewall NAT is needed — just ACCEPT rules for the
+    # listening ports themselves. This also means pod-to-host
+    # traffic (e.g. paperless to Nextcloud's OIDC endpoint) reaches
+    # Caddy on the canonical port without any `:9443` workaround.
     podman_quadlet_firewall_ports:
+      - "{{ caddy_listen_port }}/tcp"
       - "{{ caddy_listen_port_https }}/tcp"
 
 - name: Reload Caddy configuration # noqa: no-changed-when

--- a/roles/os-base/tasks/main.yml
+++ b/roles/os-base/tasks/main.yml
@@ -77,6 +77,24 @@
     reload: true
   when: os_base_swap_size_mb | int > 0
 
+# Allow rootless containers (notably Caddy) to bind privileged ports
+# 80 + 443 directly. Without this, the alternative is the firewall
+# port-forward 80->9080 / 443->9443, which only fires for traffic
+# entering on the public LAN interface — pod-to-host traffic from
+# other rootless containers (e.g. paperless reaching Nextcloud's
+# OIDC discovery, ente-museum reaching MinIO via the proxied S3
+# endpoint) bypasses the NAT and lands on a closed port. Lowering
+# the unprivileged port boundary to 80 lets pasta publish Caddy on
+# :80/:443 directly and the whole pod-to-host story Just Works.
+- name: Lower unprivileged port boundary so rootless can bind 80/443
+  become: true
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_unprivileged_port_start
+    value: "80"
+    state: present
+    sysctl_set: true
+    reload: true
+
 # ---------------------------------------------------------------- 1
 # podman 5 source on AlmaLinux 9 (and other RHEL-9 derivatives).
 # Fedora's default repo already ships podman 5.x; AL9/Rocky/CentOS 9

--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -61,7 +61,7 @@ Environment=USERMAP_GID=1000
 # container with all keys/values unquoted and django-allauth's
 # JSON parser rejects it.
 Environment=PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
-Environment=PAPERLESS_SOCIALACCOUNT_PROVIDERS={\"openid_connect\":{\"APPS\":[{\"provider_id\":\"nextcloud\",\"name\":\"Nextcloud\",\"client_id\":\"{{ paperless_oidc_client_id }}\",\"secret\":\"{{ paperless_oidc_client_secret | replace('%', '%%') }}\",\"settings\":{\"server_url\":\"{{ paperless_oidc_provider_url }}/index.php/apps/oidc\"}}]}}
+Environment=PAPERLESS_SOCIALACCOUNT_PROVIDERS={\"openid_connect\":{\"APPS\":[{\"provider_id\":\"nextcloud\",\"name\":\"Nextcloud\",\"client_id\":\"{{ paperless_oidc_client_id }}\",\"secret\":\"{{ paperless_oidc_client_secret | replace('%', '%%') }}\",\"settings\":{\"server_url\":\"{{ paperless_oidc_provider_url }}\"}}]}}
 {% if paperless_oidc_redirect_login_to_sso | default(true) %}
 Environment=PAPERLESS_REDIRECT_LOGIN_TO_SSO=true
 {% endif %}


### PR DESCRIPTION
Drop the :9443 wart from inventory by letting rootless Caddy bind canonical ports. os-base sets net.ipv4.ip_unprivileged_port_start=80; caddy defaults flip; firewall NAT replaced with plain ACCEPT. Also fixes paperless OIDC server_url construction.