### PR TITLE
paperless-ngx + entephoto: consume project-level SMTP vars (#153)

### DIFF
--- a/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
+++ b/roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2
@@ -45,3 +45,19 @@ internal:
 {% for admin_id in entephoto_admin_user_ids | default([]) %}
         - {{ admin_id }}
 {% endfor %}
+
+{% if smtp_host | default('') | length > 0 %}
+# Project-level SMTP (issue #153 / docs/SMTP-Setup.md). Without this,
+# museum can't deliver the email-verification OTP at signup and the
+# operator has to read the code out of postgres' otts table (see
+# issue #148). With it set, signups Just Work.
+smtp:
+    host: {{ smtp_host }}
+    port: {{ smtp_port }}
+    username: {{ smtp_username }}
+    password: {{ smtp_password | to_json }}
+    email: {{ smtp_from }}
+{% if smtp_encryption in ['starttls', 'ssl'] %}
+    encryption: {{ smtp_encryption }}
+{% endif %}
+{% endif %}

--- a/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
+++ b/roles/paperless-ngx/templates/quadlets/paperless-ngx.container.j2
@@ -49,6 +49,20 @@ Environment=PAPERLESS_URL={{ paperless_url | default('') }}
 Environment=USERMAP_UID=1000
 Environment=USERMAP_GID=1000
 
+{% if smtp_host | default('') | length > 0 %}
+# Project-level SMTP (issue #153 / docs/SMTP-Setup.md). Lets paperless
+# send password-reset, share-notification, and admin emails. The
+# `%` escape (replace('%', '%%')) is needed because systemd treats
+# `%` in Environment= values as a specifier.
+Environment=PAPERLESS_EMAIL_HOST={{ smtp_host }}
+Environment=PAPERLESS_EMAIL_PORT={{ smtp_port }}
+Environment=PAPERLESS_EMAIL_HOST_USER={{ smtp_username | replace('%', '%%') }}
+Environment=PAPERLESS_EMAIL_HOST_PASSWORD={{ smtp_password | replace('%', '%%') }}
+Environment=PAPERLESS_EMAIL_USE_TLS={{ 'true' if smtp_encryption == 'starttls' else 'false' }}
+Environment=PAPERLESS_EMAIL_USE_SSL={{ 'true' if smtp_encryption == 'ssl' else 'false' }}
+Environment=PAPERLESS_EMAIL_FROM={{ smtp_from | replace('%', '%%') }}
+{% endif %}
+
 {% if paperless_oidc_enabled | default(false) %}
 # OIDC — federate auth to an external IdP (e.g. Nextcloud's
 # oidc_provider). Built-in via django-allauth in paperless-ngx 2.5+.


### PR DESCRIPTION
Per-role wiring of the smtp_* host vars from #153. Paperless emits PAPERLESS_EMAIL_*; Ente museum gets a smtp: block. Both gated; nothing changes for hosts without smtp_host set.