### PR TITLE
setup.sh: cover nextcloud + SMTP for fresh-install reproducibility

### DIFF
--- a/docs/SSO-Bootstrap.md
+++ b/docs/SSO-Bootstrap.md
@@ -1,0 +1,160 @@
+# SSO bootstrap — Nextcloud as the OIDC Identity Provider
+
+When you deploy **Nextcloud** with this project, it doubles as your
+household's OpenID Connect Identity Provider for any other app that
+can OIDC. Today: **Paperless-NGX**. Future: Jellyfin (via plugin),
+Vaultwarden, anything else that supports the openid_connect backend.
+
+The Nextcloud role pre-installs the `oidc` app, but **registering
+each OIDC client and wiring its credentials into the consuming role
+is a one-time manual step** per app — there's no public Nextcloud
+API to create OIDC clients programmatically.
+
+This doc walks the bootstrap for Paperless. The same pattern applies
+to any other app you add later.
+
+---
+
+## Prerequisites
+
+- Nextcloud deployed and reachable at `https://cloud.<caddy_domain>/`.
+- You can log in as the `ncadmin` user (from
+  `nextcloud_admin_password` in your inventory).
+- The Paperless role is deployed (without OIDC yet) and reachable at
+  `https://paperless.<caddy_domain>/`.
+
+---
+
+## Step 1 — Register the OIDC client in Nextcloud
+
+1. Sign in to Nextcloud as `ncadmin`.
+2. Top-right avatar → **Administrative settings** → left sidebar
+   **Security** → scroll to **OpenID Connect 1.0**.
+3. Click **Add client**.
+4. Fill the form:
+
+   | Field | Value |
+   |---|---|
+   | Name | `paperless` |
+   | Redirection URI | `https://paperless.<caddy_domain>/accounts/oidc/nextcloud/login/callback/` |
+   | Signing algorithm | **RS256** |
+   | Client type | **Confidential** |
+
+   The trailing slash on the redirect URI matters. The `nextcloud`
+   segment after `/accounts/oidc/` is the `provider_id` the role
+   hardcodes — leave it as `nextcloud`.
+
+5. **Save**. Nextcloud generates a **Client ID** and **Client
+   Secret**. Copy both immediately — the secret is shown once.
+
+---
+
+## Step 2 — Add the credentials to inventory
+
+In your private overlay's `inventory/host_vars/<host>/main.yml`,
+under the Paperless block:
+
+```yaml
+paperless_oidc_enabled: true
+paperless_oidc_client_id: "<paste client ID>"
+paperless_oidc_provider_url: "https://cloud.<caddy_domain>"
+paperless_oidc_client_secret: !vault | ...
+```
+
+Vault-encrypt the secret before pasting:
+
+```bash
+cd ~/home-server   # or wherever vault.pw is wired up
+ansible-vault encrypt_string --encrypt-vault-id default \
+    --stdin-name 'paperless_oidc_client_secret'
+# paste the secret, then Ctrl-D
+```
+
+Copy the YAML block it prints into the inventory.
+
+Commit + push:
+
+```bash
+cd ~/github/home-server-private
+git add -A && git commit -m "<host>: enable Paperless OIDC via Nextcloud"
+git push origin main
+```
+
+---
+
+## Step 3 — Redeploy Paperless
+
+```bash
+cd ~/home-server
+ansible-playbook playbooks/paperless-ngx.yml --limit <host>
+```
+
+The container picks up the new `PAPERLESS_APPS` + `PAPERLESS_SOCIALACCOUNT_PROVIDERS`
++ `PAPERLESS_REDIRECT_LOGIN_TO_SSO` env vars and starts redirecting
+visitors to Nextcloud for login.
+
+---
+
+## Step 4 — End-to-end login test
+
+In a fresh private window:
+
+1. Open `https://paperless.<caddy_domain>/` → should redirect to
+   `https://cloud.<caddy_domain>/login` (Nextcloud).
+2. Log in as `ncadmin` (or any Nextcloud user).
+3. First time only: Nextcloud shows a consent screen for the
+   `paperless` client. Approve.
+4. Redirected back to Paperless, **auto-logged-in as a new
+   Paperless local user** named after the Nextcloud username (e.g.
+   `ncadmin`).
+
+If you see HTTP 403 on `/api/ui_settings/` after login, the
+auto-provisioned user has no permissions yet — see Step 5.
+
+---
+
+## Step 5 — Grant the new user admin (per-user, one-time)
+
+Paperless creates OIDC users without `is_staff` / `is_superuser`
+flags. Most of the UI returns 403 until they're promoted. For each
+user that should be admin:
+
+```bash
+ssh <host> "sudo -u paperless XDG_RUNTIME_DIR=/run/user/1007 \
+    podman exec paperless-ngx python manage.py shell -c \
+    \"from django.contrib.auth.models import User; \
+    u=User.objects.get(username='<nextcloud-username>'); \
+    u.is_superuser=True; u.is_staff=True; u.save(); print('promoted')\""
+```
+
+For users you want to keep as regular (non-admin), skip this step.
+
+---
+
+## Fallback: local login still works
+
+If OIDC / Nextcloud is ever down or the SSO redirect misbehaves,
+the local Paperless `admin` user from the original install still
+works. Bypass the auto-redirect with the `?process=login` query
+parameter:
+
+```
+https://paperless.<caddy_domain>/accounts/login/?process=login
+```
+
+Useful for emergency access and for the very first deploy when
+you need to promote your first OIDC user before they have UI access.
+
+---
+
+## Adding more OIDC apps later
+
+Repeat Steps 1–4 for each app. Each app gets its own
+**Client ID** + **Client Secret** in Nextcloud, its own `*_oidc_*`
+inventory vars, and its own `provider_id` in the role template.
+The Nextcloud side doesn't need redeploy — only the consuming app.
+
+For Jellyfin specifically, the OIDC integration goes through the
+[`jellyfin-plugin-sso`](https://github.com/9p4/jellyfin-plugin-sso)
+plugin. That role hasn't grown the integration yet; track as a
+follow-up when family-profile separation in Jellyfin becomes useful.

--- a/docs/Setup-Guide/04-run-setup.md
+++ b/docs/Setup-Guide/04-run-setup.md
@@ -15,10 +15,18 @@ images pull and services start" you can use to make coffee.
 |---|---|---|
 | **deSEC subdomain** (without `.dedyn.io`) | `mydomain` | 1 |
 | **deSEC API token** | the long opaque string | 1 |
+| **SMTP relay** (optional but recommended) | host / username / app-password | — |
 | **Which services to deploy?** | y/N per service (defaults are sensible) | — |
 
 Have your deSEC values from Step 1 ready in your clipboard /
 notes.
+
+> [!TIP]
+> The SMTP prompt accepts skipping (`n`), but several apps
+> (Nextcloud password resets, Ente signup OTPs, Paperless
+> notifications) need a working relay to be useful day-to-day.
+> See [SMTP-Setup.md](../SMTP-Setup.md) for picking a provider
+> (Mailbox.org / Posteo / etc.) and generating an app password.
 
 ## Run setup.sh
 

--- a/setup.sh
+++ b/setup.sh
@@ -319,6 +319,50 @@ ask "Timezone [$DEFAULT_TZ]:"
 read -r TIMEZONE
 TIMEZONE=${TIMEZONE:-$DEFAULT_TZ}
 
+# --- SMTP relay (project-level) ---
+# Needed by Nextcloud (password resets / share notifications), Ente
+# Photos (signup OTPs — without SMTP, the operator has to read codes
+# out of postgres), and Paperless-NGX (notifications). One relay
+# config used by every role.
+#
+# See docs/SMTP-Setup.md. Recommended: Mailbox.org with an app
+# password. Skip to deploy without working email — apps still install
+# but can't send mail until you fill in these vars later.
+echo
+echo -e "${BOLD}--- SMTP relay (optional but recommended) ---${NC}"
+echo
+echo "An external SMTP relay (e.g. Mailbox.org, Posteo) lets the apps"
+echo "send password resets, signup OTPs, and share notifications."
+echo "See docs/SMTP-Setup.md for setup details."
+echo
+ask "Configure SMTP relay now? [Y/n]:"
+read -r SMTP_CONFIGURE
+if [[ ! "$SMTP_CONFIGURE" =~ ^[Nn]$ ]]; then
+    ask "SMTP host [smtp.mailbox.org]:"
+    read -r SMTP_HOST
+    SMTP_HOST=${SMTP_HOST:-smtp.mailbox.org}
+    ask "SMTP port [587]:"
+    read -r SMTP_PORT
+    SMTP_PORT=${SMTP_PORT:-587}
+    ask "SMTP username (full email):"
+    read -r SMTP_USERNAME
+    if [[ -z "$SMTP_USERNAME" ]]; then
+        warn "Empty username — skipping SMTP."
+        SMTP_HOST=""
+    else
+        ask "SMTP password / app password (input hidden):"
+        read -rs SMTP_PASSWORD
+        echo
+        ask "Encryption (starttls / ssl) [starttls]:"
+        read -r SMTP_ENCRYPTION
+        SMTP_ENCRYPTION=${SMTP_ENCRYPTION:-starttls}
+        ask "From address [$SMTP_USERNAME]:"
+        read -r SMTP_FROM
+        SMTP_FROM=${SMTP_FROM:-$SMTP_USERNAME}
+        ok "SMTP relay configured."
+    fi
+fi
+
 echo
 echo -e "${BOLD}--- Service Selection ---${NC}"
 echo
@@ -336,13 +380,14 @@ SERVICES=(
     [paperless-ngx]="Paperless-NGX document management (OCR + search)"
     [jellyfin]="Jellyfin media server (movies, TV, music)"
     [music-assistant]="Music Assistant music server (optional local Squeezelite player on hosts with a USB DAC)"
+    [nextcloud]="Nextcloud (files + contacts + OpenID Connect identity provider for other apps)"
 )
 
 # Caddy is always deployed — it's the mandatory front-door reverse proxy.
 SELECTED_SERVICES=(caddy)
 
 # Recommended order for deployment of optional services
-SERVICE_ORDER=(dashboard pihole syncthing shairportsync entephoto paperless-ngx jellyfin music-assistant)
+SERVICE_ORDER=(dashboard pihole syncthing shairportsync entephoto paperless-ngx jellyfin music-assistant nextcloud)
 
 for svc in "${SERVICE_ORDER[@]}"; do
     desc="${SERVICES[$svc]}"
@@ -421,6 +466,8 @@ PAPERLESS_SECRET_KEY=$(openssl rand -hex 32)
 PAPERLESS_DB_PW=$(openssl rand -base64 24)
 PAPERLESS_ADMIN_PW=$(openssl rand -base64 24)
 JELLYFIN_ADMIN_PW=$(openssl rand -base64 24)
+NEXTCLOUD_ADMIN_PW=$(openssl rand -base64 24)
+NEXTCLOUD_DB_PW=$(openssl rand -base64 24)
 
 # Generate a stable, locally-administered unicast MAC for Music
 # Assistant's built-in Squeezelite player. First octet 0x02 sets the
@@ -480,6 +527,9 @@ my_linux_users:
   music-assistant:
     uid: 1014
     gid: 1014
+  nextcloud:
+    uid: 1015
+    gid: 1015
 ##################################################################################################
 
 ### Caddy reverse-proxy + Let's Encrypt via deSEC DNS-01
@@ -509,6 +559,7 @@ fi
 is_selected paperless-ngx   && echo '  - { subdomain: paperless, port: 8000 }'
 is_selected jellyfin        && echo '  - { subdomain: jellyfin, port: 8096 }'
 is_selected music-assistant && echo '  - { subdomain: music, port: 8095 }'
+is_selected nextcloud       && echo '  - { subdomain: cloud, port: 8090 }'
 echo ""
 
 cat << YAML
@@ -577,6 +628,26 @@ vault_encrypt "$PAPERLESS_ADMIN_PW" "paperless_admin_password"
 echo ""
 echo "### Jellyfin"
 vault_encrypt "$JELLYFIN_ADMIN_PW" "jellyfin_admin_password"
+
+if is_selected nextcloud; then
+    echo ""
+    echo "### Nextcloud"
+    vault_encrypt "$NEXTCLOUD_ADMIN_PW" "nextcloud_admin_password"
+    echo ""
+    vault_encrypt "$NEXTCLOUD_DB_PW" "nextcloud_db_password"
+fi
+
+if [[ -n "${SMTP_HOST:-}" ]]; then
+    echo ""
+    echo "### SMTP relay (project-level — used by Nextcloud, Ente, Paperless)"
+    echo "# See docs/SMTP-Setup.md for provider/credential setup + rotation."
+    echo "smtp_host: \"$SMTP_HOST\""
+    echo "smtp_port: $SMTP_PORT"
+    echo "smtp_username: \"$SMTP_USERNAME\""
+    echo "smtp_encryption: \"$SMTP_ENCRYPTION\""
+    echo "smtp_from: \"$SMTP_FROM\""
+    vault_encrypt "$SMTP_PASSWORD" "smtp_password"
+fi
 echo "##################################################################################################"
 } > inventory/host_vars/$SERVER_HOSTNAME/main.yml
 
@@ -695,6 +766,22 @@ cat << EOF
         url: https://music.${CADDY_DOMAIN}
     volumes:
       - music-assistant-data
+
+EOF
+fi
+
+if is_selected nextcloud; then
+cat << EOF
+  - name: Nextcloud
+    user: nextcloud
+    uid: 1015
+    service: nextcloud-pod
+    urls:
+      - label: Web UI
+        url: https://cloud.${CADDY_DOMAIN}
+    volumes:
+      - nextcloud-config
+      - nextcloud-data
 
 EOF
 fi


### PR DESCRIPTION
Fresh setup.sh run on a clean OS now produces a working Nextcloud + SMTP-enabled deployment without manual inventory edits. Two genuinely-post-deploy manual steps remain (OIDC client registration, per-user superuser promotion) — both documented in the new `docs/SSO-Bootstrap.md`.