### PR TITLE
clean-host.sh: add music-assistant + nextcloud service users

### DIFF
--- a/scripts/clean-host.sh
+++ b/scripts/clean-host.sh
@@ -11,7 +11,7 @@
 # This removes:
 #   - All rootless and rootful containers, volumes, images
 #   - Service users (shairport, syncthg, pihole, jukebox, entephoto,
-#     paperless, jellyfin, webproxy)
+#     paperless, jellyfin, webproxy, music-assistant, nextcloud)
 #   - Systemd units (dashboard, backup timers)
 #   - Deployed scripts and configs
 #   - Firewall rules added by the roles
@@ -37,7 +37,7 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
-SERVICE_USERS=(shairport syncthg pihole jukebox entephoto paperless jellyfin webproxy)
+SERVICE_USERS=(shairport syncthg pihole jukebox entephoto paperless jellyfin webproxy music-assistant nextcloud)
 
 # ---- Stop and remove containers ----
 info "Stopping containers and cleaning podman state..."


### PR DESCRIPTION
SERVICE_USERS array was missing music-assistant (UID 1014, weeks-old gap) and nextcloud (UID 1015, today). Adding both so a cleanup leaves no residue from either role.