### PR TITLE
setup.sh: import existing private overlay on rebuild

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -197,13 +197,94 @@ ansible-galaxy install -r roles/requirements.yml --force 2>/dev/null
 ok "Galaxy roles installed."
 
 # ============================================================================
+# Step 3.5: Hostname + optional private overlay
+# ============================================================================
+# Capture hostname early so the overlay prompt can look for an
+# existing host_vars/<hostname>/main.yml. The hostname prompt in
+# Step 5 used to live here; consolidated into this block.
+
+DEFAULT_HOSTNAME=$(hostname -s 2>/dev/null)
+echo
+ask "Server hostname [$DEFAULT_HOSTNAME]:"
+read -r SERVER_HOSTNAME
+SERVER_HOSTNAME=${SERVER_HOSTNAME:-$DEFAULT_HOSTNAME}
+
+OVERLAY_DIR="$HOME/home-server-private"
+OVERLAY_URL=""
+USE_EXISTING_INVENTORY=false
+
+echo
+echo -e "${BOLD}--- Private overlay repo (optional) ---${NC}"
+echo
+echo "If you have a private git repo for inventory storage — either an"
+echo "existing one (rebuild path) or a fresh empty one prepared for"
+echo "this host (first-time path) — point to it here. We'll clone it"
+echo "and either reuse its inventory as-is or generate fresh inventory"
+echo "directly into it."
+echo "Leave empty to keep inventory local in ~/home-server/inventory/."
+echo
+ask "Private overlay repo URL [empty to skip]:"
+read -r OVERLAY_URL
+
+if [[ -n "$OVERLAY_URL" ]]; then
+    ask "Vault password for the overlay (input hidden — invent one if the repo is empty):"
+    read -rs OVERLAY_VAULT_PW
+    echo
+    if [[ -z "$OVERLAY_VAULT_PW" ]]; then
+        err "Vault password is required when using an overlay."
+        exit 1
+    fi
+
+    if [[ ! -d "$OVERLAY_DIR/.git" ]]; then
+        info "Cloning overlay into $OVERLAY_DIR ..."
+        git clone "$OVERLAY_URL" "$OVERLAY_DIR"
+    else
+        ok "Overlay already cloned at $OVERLAY_DIR — pulling latest."
+        (cd "$OVERLAY_DIR" && git pull --ff-only) || warn "git pull failed; continuing with existing tree"
+    fi
+
+    mkdir -p "$OVERLAY_DIR/inventory/host_vars"
+
+    # Vault pw lives in the overlay so future Case 3 rebuilds can
+    # re-read it. ~/.vaultpw is a symlink so ansible.cfg stays valid.
+    echo -n "$OVERLAY_VAULT_PW" > "$OVERLAY_DIR/vault.pw"
+    chmod 400 "$OVERLAY_DIR/vault.pw"
+
+    if [[ -f "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml" ]]; then
+        USE_EXISTING_INVENTORY=true
+        ok "Overlay has existing inventory for '$SERVER_HOSTNAME' — using it as-is."
+    else
+        ok "Overlay has no inventory for '$SERVER_HOSTNAME' yet — will generate fresh into it."
+        existing_hosts=$(ls -1 "$OVERLAY_DIR/inventory/host_vars/" 2>/dev/null | tr '\n' ' ')
+        [[ -n "$existing_hosts" ]] && info "  Other hosts already in overlay: $existing_hosts"
+    fi
+fi
+
+# ============================================================================
 # Step 4: Configure vault password
 # ============================================================================
 info "Step 4/7: Setting up Ansible Vault..."
 
 VAULT_PW_FILE="$HOME/.vaultpw"
 
-if [[ -f "$VAULT_PW_FILE" ]]; then
+if [[ -n "$OVERLAY_URL" ]]; then
+    # Overlay path — point ~/.vaultpw at the overlay's vault.pw.
+    rm -f "$VAULT_PW_FILE"
+    ln -s "$OVERLAY_DIR/vault.pw" "$VAULT_PW_FILE"
+    ok "Vault password symlinked: $VAULT_PW_FILE → $OVERLAY_DIR/vault.pw"
+
+    if [[ "$USE_EXISTING_INVENTORY" == "true" ]]; then
+        if ! ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
+                ansible-vault view "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml" \
+                &>/dev/null; then
+            err "Vault password doesn't decrypt the existing inventory at"
+            err "  $OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml"
+            err "Re-run setup.sh with the correct vault password."
+            exit 1
+        fi
+        ok "Vault password verified — existing inventory decrypts cleanly."
+    fi
+elif [[ -f "$VAULT_PW_FILE" ]]; then
     ok "Vault password already exists at $VAULT_PW_FILE"
 else
     echo
@@ -236,11 +317,48 @@ roles_path = ./roles:./.ansible/roles:~/.ansible/roles:/usr/share/ansible/roles
 stdout_callback = default
 host_key_checking = False
 vault_password_file = $VAULT_PW_FILE
+
+[ssh_connection]
+pipelining = True
+use_tty = False
 EOF
+
+# Replace the public repo's inventory/ stub with a symlink into the
+# overlay so generated (Case 2) or existing (Case 3) inventory lives
+# in the overlay repo.
+if [[ -n "$OVERLAY_URL" ]]; then
+    if [[ ! -L inventory ]]; then
+        rm -rf inventory
+        ln -s "$OVERLAY_DIR/inventory" inventory
+        ok "Symlinked inventory/ → $OVERLAY_DIR/inventory"
+    fi
+fi
 
 # ============================================================================
 # Step 5: Gather host configuration
 # ============================================================================
+if [[ "$USE_EXISTING_INVENTORY" == "true" ]]; then
+    info "Step 5/7: Using existing inventory — skipping configuration prompts."
+    SERVER_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+    # Pull deSEC creds from existing inventory for the A-record refresh
+    # in Step 6.5. ansible-inventory decrypts vaulted vars in its output.
+    INV_JSON=$(ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
+        ansible-inventory --host "$SERVER_HOSTNAME" 2>/dev/null)
+    if [[ -z "$INV_JSON" ]]; then
+        err "ansible-inventory couldn't read host vars for '$SERVER_HOSTNAME'."
+        err "Check inventory/hosts.yml in the overlay."
+        exit 1
+    fi
+    DESEC_SUBDOMAIN=$(echo "$INV_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('caddy_acme_subdomain',''))")
+    DESEC_TOKEN=$(echo "$INV_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('caddy_acme_token',''))")
+    CADDY_DOMAIN=$(echo "$INV_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('caddy_domain',''))")
+    if [[ -z "$DESEC_SUBDOMAIN" || -z "$DESEC_TOKEN" ]]; then
+        err "Existing inventory is missing caddy_acme_subdomain / caddy_acme_token."
+        exit 1
+    fi
+    ok "Loaded inventory for $SERVER_HOSTNAME ($CADDY_DOMAIN)"
+else
+
 info "Step 5/7: Configuring your server..."
 
 echo
@@ -252,16 +370,11 @@ DEFAULT_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
 DEFAULT_IFACE=$(ip route show default 2>/dev/null | awk '{print $5; exit}')
 DEFAULT_GATEWAY=$(ip route show default 2>/dev/null | awk '{print $3; exit}')
 DEFAULT_NETWORK=$(ip -4 addr show "$DEFAULT_IFACE" 2>/dev/null | grep inet | awk '{print $2}' | head -1)
-DEFAULT_HOSTNAME=$(hostname -s 2>/dev/null)
 DEFAULT_USER=$(whoami)
 
 ask "Server IP address [$DEFAULT_IP]:"
 read -r SERVER_IP
 SERVER_IP=${SERVER_IP:-$DEFAULT_IP}
-
-ask "Server hostname [$DEFAULT_HOSTNAME]:"
-read -r SERVER_HOSTNAME
-SERVER_HOSTNAME=${SERVER_HOSTNAME:-$DEFAULT_HOSTNAME}
 
 # --- TLS / cert strategy ---
 # --- TLS via deSEC + Let's Encrypt ---
@@ -439,7 +552,26 @@ vault_encrypt() {
 # --- Generate inventory/hosts.yml ---
 mkdir -p "inventory/host_vars/$SERVER_HOSTNAME"
 
-cat > inventory/hosts.yml << EOF
+# When the overlay already has a multi-host hosts.yml, merge instead
+# of clobber. Pure write for a brand-new file.
+if [[ -s inventory/hosts.yml ]]; then
+    python3 - "$SERVER_HOSTNAME" "$SERVER_USER" << 'PYEOF'
+import sys, yaml
+hostname, user = sys.argv[1], sys.argv[2]
+with open("inventory/hosts.yml") as f:
+    data = yaml.safe_load(f) or {}
+data.setdefault("all", {}).setdefault("children", {}).setdefault(
+    "homeservers", {}).setdefault("hosts", {})[hostname] = {
+        "ansible_host": "127.0.0.1",
+        "ansible_connection": "local",
+        "ansible_user": user,
+    }
+with open("inventory/hosts.yml", "w") as f:
+    yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+PYEOF
+    ok "Merged $SERVER_HOSTNAME into existing inventory/hosts.yml"
+else
+    cat > inventory/hosts.yml << EOF
 all:
   children:
     homeservers:
@@ -449,8 +581,8 @@ all:
           ansible_connection: local
           ansible_user: $SERVER_USER
 EOF
-
-ok "Generated inventory/hosts.yml"
+    ok "Generated inventory/hosts.yml"
+fi
 
 # --- Generate host_vars ---
 info "Generating secrets (this takes a moment)..."
@@ -789,6 +921,8 @@ fi
 
 ok "Generated inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
 
+fi  # end of USE_EXISTING_INVENTORY == false (Steps 5 + 6)
+
 # ============================================================================
 # Step 6.5: deSEC API — upsert the wildcard A record
 # ============================================================================
@@ -888,6 +1022,13 @@ echo "Configuration files:"
 echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml"
 echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
 echo
+
+if [[ -n "${OVERLAY_URL:-}" && "$USE_EXISTING_INVENTORY" != "true" ]]; then
+    echo -e "${BOLD}Persist your generated inventory to the overlay repo:${NC}"
+    echo "  cd $OVERLAY_DIR"
+    echo "  git add -A && git commit -m \"$SERVER_HOSTNAME: initial install\" && git push"
+    echo
+fi
 echo "Container images auto-update daily via podman-auto-update.timer."
 echo "See the Quickstart.md for more details."
 echo

--- a/setup.sh
+++ b/setup.sh
@@ -442,39 +442,39 @@ TIMEZONE=${TIMEZONE:-$DEFAULT_TZ}
 # password. Skip to deploy without working email — apps still install
 # but can't send mail until you fill in these vars later.
 echo
-echo -e "${BOLD}--- SMTP relay (optional but recommended) ---${NC}"
+echo -e "${BOLD}--- SMTP relay (required) ---${NC}"
 echo
-echo "An external SMTP relay (e.g. Mailbox.org, Posteo) lets the apps"
-echo "send password resets, signup OTPs, and share notifications."
-echo "See docs/SMTP-Setup.md for setup details."
+echo "Nextcloud (password resets, share notifications), Ente Photos"
+echo "(signup OTPs) and Paperless need an external SMTP relay to send"
+echo "mail. See docs/SMTP-Setup.md for picking a provider (Mailbox.org"
+echo "/ Posteo / etc.) and generating an app password."
 echo
-ask "Configure SMTP relay now? [Y/n]:"
-read -r SMTP_CONFIGURE
-if [[ ! "$SMTP_CONFIGURE" =~ ^[Nn]$ ]]; then
-    ask "SMTP host [smtp.mailbox.org]:"
-    read -r SMTP_HOST
-    SMTP_HOST=${SMTP_HOST:-smtp.mailbox.org}
-    ask "SMTP port [587]:"
-    read -r SMTP_PORT
-    SMTP_PORT=${SMTP_PORT:-587}
-    ask "SMTP username (full email):"
-    read -r SMTP_USERNAME
-    if [[ -z "$SMTP_USERNAME" ]]; then
-        warn "Empty username — skipping SMTP."
-        SMTP_HOST=""
-    else
-        ask "SMTP password / app password (input hidden):"
-        read -rs SMTP_PASSWORD
-        echo
-        ask "Encryption (starttls / ssl) [starttls]:"
-        read -r SMTP_ENCRYPTION
-        SMTP_ENCRYPTION=${SMTP_ENCRYPTION:-starttls}
-        ask "From address [$SMTP_USERNAME]:"
-        read -r SMTP_FROM
-        SMTP_FROM=${SMTP_FROM:-$SMTP_USERNAME}
-        ok "SMTP relay configured."
-    fi
+ask "SMTP host [smtp.mailbox.org]:"
+read -r SMTP_HOST
+SMTP_HOST=${SMTP_HOST:-smtp.mailbox.org}
+ask "SMTP port [587]:"
+read -r SMTP_PORT
+SMTP_PORT=${SMTP_PORT:-587}
+ask "SMTP username (full email):"
+read -r SMTP_USERNAME
+if [[ -z "$SMTP_USERNAME" ]]; then
+    err "SMTP username is required."
+    exit 1
 fi
+ask "SMTP password / app password (input hidden):"
+read -rs SMTP_PASSWORD
+echo
+if [[ -z "$SMTP_PASSWORD" ]]; then
+    err "SMTP password is required."
+    exit 1
+fi
+ask "Encryption (starttls / ssl) [starttls]:"
+read -r SMTP_ENCRYPTION
+SMTP_ENCRYPTION=${SMTP_ENCRYPTION:-starttls}
+ask "From address [$SMTP_USERNAME]:"
+read -r SMTP_FROM
+SMTP_FROM=${SMTP_FROM:-$SMTP_USERNAME}
+ok "SMTP relay configured."
 
 echo
 echo -e "${BOLD}--- Service Selection ---${NC}"
@@ -485,34 +485,43 @@ echo
 
 declare -A SERVICES
 SERVICES=(
-    [dashboard]="Status dashboard showing all services — recommended"
+    [dashboard]="Status dashboard showing all services"
     [pihole]="Pi-hole DNS ad-blocker"
-    [syncthing]="Syncthing file synchronization"
-    [shairportsync]="Shairport-sync AirPlay audio receiver (needs audio device)"
     [entephoto]="Ente Photos (self-hosted photo storage)"
     [paperless-ngx]="Paperless-NGX document management (OCR + search)"
+    [syncthing]="Syncthing file synchronization"
+    [shairportsync]="Shairport-sync AirPlay audio receiver (needs audio device)"
     [jellyfin]="Jellyfin media server (movies, TV, music)"
     [music-assistant]="Music Assistant music server (optional local Squeezelite player on hosts with a USB DAC)"
-    [nextcloud]="Nextcloud (files + contacts + OpenID Connect identity provider for other apps)"
 )
 
-# Caddy is always deployed — it's the mandatory front-door reverse proxy.
-SELECTED_SERVICES=(caddy)
+# Caddy + Nextcloud are mandatory:
+#   - Caddy is the front-door reverse proxy for every HTTPS service.
+#   - Nextcloud is the household OIDC identity provider (Paperless and
+#     future apps log in against it) and the central file/contacts
+#     workspace.
+SELECTED_SERVICES=(caddy nextcloud)
 
-# Recommended order for deployment of optional services
-SERVICE_ORDER=(dashboard pihole syncthing shairportsync entephoto paperless-ngx jellyfin music-assistant nextcloud)
+# Optional services. Defaults reflect the recommended baseline:
+#   Y — dashboard, pihole, entephoto, paperless-ngx
+#   N — syncthing, shairportsync, jellyfin, music-assistant
+SERVICE_ORDER=(dashboard pihole entephoto paperless-ngx syncthing shairportsync jellyfin music-assistant)
+declare -A SERVICE_DEFAULT_YES=(
+    [dashboard]=1
+    [pihole]=1
+    [entephoto]=1
+    [paperless-ngx]=1
+)
 
 for svc in "${SERVICE_ORDER[@]}"; do
     desc="${SERVICES[$svc]}"
-    if [[ "$svc" == "dashboard" ]]; then
+    if [[ -n "${SERVICE_DEFAULT_YES[$svc]:-}" ]]; then
         ask "Deploy $svc? ($desc) [Y/n]:"
-    else
-        ask "Deploy $svc? ($desc) [y/N]:"
-    fi
-    read -r answer
-    if [[ "$svc" == "dashboard" ]]; then
+        read -r answer
         [[ ! "$answer" =~ ^[Nn]$ ]] && SELECTED_SERVICES+=("$svc")
     else
+        ask "Deploy $svc? ($desc) [y/N]:"
+        read -r answer
         [[ "$answer" =~ ^[Yy]$ ]] && SELECTED_SERVICES+=("$svc")
     fi
 done


### PR DESCRIPTION
## Summary
- Adds an early prompt in `setup.sh` for an optional private overlay git URL + vault password.
- Three branches off that prompt:
  - **empty** → unchanged (local inventory generation).
  - **URL + repo missing `host_vars/<hostname>/main.yml`** → clone, symlink `inventory/` and `vault.pw` into the overlay, run all normal prompts, write generated inventory **into** the cloned overlay (first-time-into-prepared-repo path).
  - **URL + repo has `host_vars/<hostname>/main.yml`** → clone, verify vault decrypts existing inventory, symlink, **skip every prompt that has an inventory equivalent**, refresh deSEC A records for the (possibly new) host IP, deploy (rebuild path).
- Merges into an existing multi-host `inventory/hosts.yml` instead of clobbering it.

## Test plan
- [ ] On a freshly wiped homeserver2: run new setup.sh, paste overlay URL + vault password. Expect Case 2 path — prompts run, generated inventory lands in `~/home-server-private/inventory/host_vars/homeserver2/`, deploy succeeds.
- [ ] After deploy completes, `cd ~/home-server-private && git add -A && git commit && git push` persists the new inventory.
- [ ] Wipe homeserver2 again, re-run setup.sh with same overlay URL + vault. Expect Case 3 path — all prompts skipped, straight to deploy. Box comes back identical.
- [ ] Negative: wrong vault password against existing inventory → fast fail with clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)