### PR TITLE
nextcloud: bump /status.php wait to 7.5 min for slow first-boot

### DIFF
--- a/roles/nextcloud/tasks/postinstall.yml
+++ b/roles/nextcloud/tasks/postinstall.yml
@@ -1,6 +1,8 @@
 ---
-# Wait for Nextcloud's installer to finish (DB migrations on first boot
-# can take ~60s) before running occ commands.
+# Wait for Nextcloud's installer to finish before running occ commands.
+# First boot does DB migrations + asset compilation; on slower hardware
+# (aarch64, fresh image pull) this routinely takes 3-4 min. Failed-then-
+# retry on connection-reset is normal during early Apache startup.
 
 - name: Wait for Nextcloud /status.php to report installed
   ansible.builtin.uri:
@@ -8,7 +10,7 @@
     status_code: 200
     return_content: true
   register: _nextcloud_status
-  retries: 30
+  retries: 90
   delay: 5
   until: _nextcloud_status.status == 200 and _nextcloud_status.json.installed | default(false)
 


### PR DESCRIPTION
## Summary
- First-boot Nextcloud DB migrations + asset compilation regularly exceed the previous 150s wait window on slower hardware (aarch64, fresh image pull).
- Bump postinstall \`Wait for Nextcloud /status.php to report installed\` from 30 to 90 retries (7.5 min).

## Test plan
- [ ] Fresh deploy on homeserver2 (aarch64) completes through postinstall without manual re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)