### PR TITLE
setup.sh: pre-clear stale _acme-challenge TXT (mitigates #170)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -790,18 +790,26 @@ fi
 ok "Generated inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
 
 # ============================================================================
-# Step 6.5: deSEC API — upsert the wildcard A record
+# Step 6.5: deSEC API — upsert A records + clear stale ACME challenge TXT
 # ============================================================================
 # Writes `*.<sub>.dedyn.io` and `<sub>.dedyn.io` → SERVER_IP so LAN
 # clients (Pi-hole) and roaming Tailscale clients both resolve every
 # Caddy subdomain to this host's LAN IP. Caddy then issues a wildcard
 # LE cert against deSEC's DNS-01 challenge during the deploy below.
 # PATCH on the rrset collection is idempotent — safe to re-run.
-info "Step 6.5/7: Writing wildcard A record at deSEC..."
+#
+# Also clears `_acme-challenge.<sub>` TXT. Mitigates issue #170:
+# Caddy's deSEC plugin occasionally leaves stale TXT records from
+# a failed previous order, and the apex + wildcard cert challenges
+# race on the same TXT name. Starting from a clean state ensures
+# Caddy's first DNS-01 round sees only its own values; sending the
+# rrset with records=[] tells deSEC to delete it. No-op if absent.
+info "Step 6.5/7: Writing A records + clearing stale _acme-challenge TXT at deSEC..."
 api_body=$(cat <<JSON
 [
   {"subname":"","type":"A","ttl":3600,"records":["$SERVER_IP"]},
-  {"subname":"*","type":"A","ttl":3600,"records":["$SERVER_IP"]}
+  {"subname":"*","type":"A","ttl":3600,"records":["$SERVER_IP"]},
+  {"subname":"_acme-challenge","type":"TXT","ttl":3600,"records":[]}
 ]
 JSON
 )


### PR DESCRIPTION
## Summary
Adds a TXT-rrset deletion to setup.sh's existing deSEC bulk-PATCH step (Step 6.5) so Caddy starts with a clean \`_acme-challenge.<sub>\` rrset. Mitigates the apex+wildcard ACME race documented in #170.

The deSEC bulk-PATCH endpoint treats \`records: []\` as a delete request, so this is a no-op when no stale records exist.

## Why this and not the real fix?
The proper fix (force Caddy to issue one cert with both apex + wildcard SANs) needs a Caddyfile spike to verify the correct config syntax. This PR is a low-risk mitigation that eliminates the *recovery scenario* (stale TXT from a previous failed order) without touching the Caddy role. Issue #170 stays open for the real fix.

## Test plan
- [ ] Fresh install on a wiped homeserver2 — wildcard cert issues on first attempt without manual Caddy restart.
- [ ] Repeat from-scratch install (where the TXT record is known to have stale values) — Step 6.5 prints success and Caddy issues cert cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)