### PR TITLE
docs: add troubleshooting row for SSL_ERROR_INTERNAL_ERROR_ALERT

### DIFF
--- a/docs/Setup-Guide/05-verify-and-explore.md
+++ b/docs/Setup-Guide/05-verify-and-explore.md
@@ -35,6 +35,7 @@ If you see a padlock — congratulations, you're done. 🎉
 |---|---|---|
 | **DNS doesn't resolve** the subdomain | Your laptop isn't using Pi-hole as DNS, OR you haven't picked Pi-hole in the service list | Set your laptop's DNS to the homeserver's IP, or add the homeserver to your router's DHCP DNS server. |
 | **Cert warning** | Caddy's first cert issuance hadn't completed yet when you opened the URL | Wait 1–2 min; reload. If still wrong, check `journalctl --user -u caddy -n 50` on the server for an ACME error. |
+| **Apex works, subdomains fail with `SSL_ERROR_INTERNAL_ERROR_ALERT`** | Apex cert issued; wildcard cert stuck in an ACME retry loop because the deSEC plugin left stale `_acme-challenge` TXT records. Rare since setup.sh pre-clears them, but possible if Caddy's apex + wildcard orders ever truly race. | `ssh <host> 'sudo -u webproxy XDG_RUNTIME_DIR=/run/user/1011 systemctl --user restart caddy'` then wait ~2 min. Background: [#170](https://github.com/luckynrslevin/home-server/issues/170). |
 | **Connection refused** | Server's firewall not yet open on 443 | Re-run `ansible-playbook playbooks/caddy.yml --connection=local --limit homeserver` on the server. |
 
 ## Explore


### PR DESCRIPTION
## Summary
Adds one row to Step 5 of the Setup Guide's troubleshooting table covering the rare apex-works-but-subdomains-fail symptom (the Caddy ACME race documented in #170 and mitigated by PR #171). One-line recovery via `systemctl --user restart caddy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)