### PR TITLE
caddy: add caddy_acme_ca toggle for LE staging on test boxes

### DIFF
--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -55,6 +55,17 @@ caddy_acme_zone: ""
 # provider supports it.
 caddy_acme_token: ""
 
+# ACME directory URL. Default = empty → Caddy uses Let's Encrypt
+# production. Set to the staging URL on test boxes to dodge LE's
+# 5-duplicate-cert-per-week rate limit while iterating:
+#
+#   caddy_acme_ca: "https://acme-staging-v02.api.letsencrypt.org/directory"
+#
+# Staging certs are signed by a fake CA (browsers will warn), so
+# only use this on hosts where you're testing the cert pipeline
+# itself, not for any real traffic. Switch back to "" for prod.
+caddy_acme_ca: ""
+
 # Backup manifest — consumed by the backup role and restore playbook.
 # Only caddy-data is backed up: it holds the LE-issued wildcard cert
 # and the ACME account key. Preserving it across an OS reinstall lets

--- a/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
+++ b/roles/caddy/templates/volumes/caddy-etc/Caddyfile.j2
@@ -11,6 +11,11 @@
 	acme_dns {{ caddy_acme_provider }} {
 		token {{ caddy_acme_token }}
 	}
+{% if caddy_acme_ca | default('') | length > 0 %}
+	# Override ACME directory (default = LE production). Used on test
+	# boxes to point at LE staging and dodge production rate limits.
+	acme_ca {{ caddy_acme_ca }}
+{% endif %}
 }
 
 # Single site block — one wildcard cert, host-matchers route by Host.


### PR DESCRIPTION
## Summary
Adds opt-in \`caddy_acme_ca\` inventory var. Empty default → Caddy uses LE production (unchanged behaviour). Set to the staging URL on a test box → Caddy pulls fake-CA certs with no rate limit.

\`\`\`yaml
caddy_acme_ca: \"https://acme-staging-v02.api.letsencrypt.org/directory\"
\`\`\`

Unblocks rapid test rebuilds on \`simsons-t.dedyn.io\` (we've been hitting the 5-duplicate-cert/week limit on production after repeated clean-host + reinstall cycles).

## Test plan
- [x] Verified via \`caddy adapt\` that empty → production URL (default), set → staging URL.
- [ ] Set on homeserver2 inventory, redeploy, confirm browser shows the fake-CA warning + cert issues successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)