### PR TITLE
roles: add per-role install.yml meta files (Phase 4 of unified CLI)

### DIFF
--- a/roles/META-SCHEMA.md
+++ b/roles/META-SCHEMA.md
@@ -1,0 +1,61 @@
+# `roles/<svc>/meta/install.yml` — schema reference
+
+This file is the role's contract with the lifecycle CLI
+(`setup.sh add` / `setup.sh remove`, landing in Phase 5+ of the
+unified-CLI work). Adding or removing a service to a deployment
+uses only this metadata — no per-service code lives in `setup.sh`.
+
+Phase 4 (this commit) ships these files for every optional role;
+they aren't consumed yet. Phase 5 wires them up.
+
+## Top-level fields
+
+| Field | Required | Description |
+|---|---|---|
+| `display_name` | yes | Human-readable name shown in `setup.sh add` menu. |
+| `description` | yes | One-line summary, also shown in the picker. |
+| `rootful` | no | `true` for rootful containers (currently only shairportsync). Default `false`. |
+| `inventory_vars` | yes | List of inventory keys this role needs. Can be empty `[]`. |
+| `side_effects` | yes | Shared inventory keys this role modifies. |
+| `playbooks` | yes | Ansible playbooks `setup.sh add` runs after inventory is updated, in order. |
+| `on_remove` | yes | Reverse-side cleanup spec for `setup.sh remove`. |
+
+## `inventory_vars[]` types
+
+| `type` | Extra fields | Resolution order |
+|---|---|---|
+| `secret` | `generator` (shell command), `vault` (bool) | inventory > generate via `generator` > vault-encrypt if `vault: true` |
+| `config` | `prompt` (text), `default` (literal string or `host_detect:<key>`) | inventory > host_detect > prompt with default |
+| `computed` | `template` (Jinja against already-resolved values) | always rendered fresh; not stored separately |
+| `literal` | `value` (any YAML scalar) | always the given value |
+
+`host_detect` keys recognised today: `lan_subnet`, `lan_gateway`,
+`timezone`, `hostname`, `server_user`. Extend in `setup.sh` as new
+sources are needed.
+
+## `side_effects`
+
+A dict of shared inventory keys → values to merge in on `add`.
+
+- `caddy_reverse_proxy_services`: list of entries appended to the
+  inventory's list.
+- `my_linux_users`: dict of user → `{uid, gid}` merged into the
+  inventory's dict.
+
+On `remove`, `setup.sh` reverses these (filters out the entries
+this role added).
+
+## `on_remove`
+
+| Field | Description |
+|---|---|
+| `inventory_vars_to_clear` | List of inventory keys to delete on remove. Usually mirrors `inventory_vars` plus any `computed` URLs. |
+| `volumes_to_preserve_unless_purge` | List of rootless podman volume names that survive `remove` by default. `setup.sh remove <svc> --purge` deletes them too. |
+
+## Adding a new role
+
+1. Write the role under `roles/<name>/` (defaults, tasks, templates, quadlets).
+2. Create `roles/<name>/meta/install.yml` matching this schema.
+3. Add the role to `playbooks/site.yml` behind `"<name>" in (deploy_services | default([]))`.
+4. Add a single-service playbook at `playbooks/<name>.yml`.
+5. That's it — `setup.sh add <name>` will pick it up via the meta file (once Phase 5 lands).

--- a/roles/entephoto/meta/install.yml
+++ b/roles/entephoto/meta/install.yml
@@ -1,0 +1,76 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Ente Photos"
+description: "Self-hosted end-to-end encrypted photo storage (server side of the Ente apps)"
+
+inventory_vars:
+  - name: entephoto_db_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+  - name: entephoto_minio_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+  - name: entephoto_encryption_key
+    type: secret
+    generator: "openssl rand -base64 32"
+    vault: true
+  - name: entephoto_hash_key
+    type: secret
+    generator: "openssl rand -base64 64 | tr -d '\n'"
+    vault: true
+  - name: entephoto_jwt_secret
+    type: secret
+    generator: "openssl rand -hex 32"
+    vault: true
+  - name: entephoto_api_url
+    type: computed
+    template: "https://photos-api.{{ caddy_domain }}"
+  - name: entephoto_photos_url
+    type: computed
+    template: "https://photos.{{ caddy_domain }}"
+  - name: entephoto_s3_endpoint
+    type: computed
+    template: "photos-s3.{{ caddy_domain }}"
+  - name: entephoto_s3_host
+    type: computed
+    template: "photos-s3.{{ caddy_domain }}"
+  - name: entephoto_s3_local_buckets
+    type: literal
+    value: false  # flips Ente's presigned URLs to https://
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: photos, port: 3000 }
+    - { subdomain: accounts, port: 3001 }
+    - { subdomain: cast, port: 3002 }
+    - { subdomain: auth, port: 3003 }
+    - { subdomain: photos-api, port: 8080 }
+    - { subdomain: photos-s3, port: 3200 }
+  my_linux_users:
+    entephoto:
+      uid: 1008
+      gid: 1008
+
+playbooks:
+  - playbooks/entephoto.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear:
+    - entephoto_db_password
+    - entephoto_minio_password
+    - entephoto_encryption_key
+    - entephoto_hash_key
+    - entephoto_jwt_secret
+    - entephoto_api_url
+    - entephoto_photos_url
+    - entephoto_s3_endpoint
+    - entephoto_s3_host
+    - entephoto_s3_local_buckets
+  volumes_to_preserve_unless_purge:
+    - entephoto-postgres-data
+    - entephoto-minio-data
+    - entephoto-museum-config

--- a/roles/jellyfin/meta/install.yml
+++ b/roles/jellyfin/meta/install.yml
@@ -1,0 +1,30 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Jellyfin"
+description: "Media server for movies, TV and music"
+
+inventory_vars:
+  - name: jellyfin_admin_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: jellyfin, port: 8096 }
+  my_linux_users:
+    jellyfin:
+      uid: 1012
+      gid: 1012
+
+playbooks:
+  - playbooks/jellyfin.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear:
+    - jellyfin_admin_password
+  volumes_to_preserve_unless_purge:
+    - jellyfin-config
+    - jellyfin-media

--- a/roles/music-assistant/meta/install.yml
+++ b/roles/music-assistant/meta/install.yml
@@ -1,0 +1,34 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Music Assistant"
+description: "Music server with built-in Squeezelite/AirPlay/Cast player support"
+
+inventory_vars:
+  - name: music_assistant_squeezelite_mac
+    type: secret
+    # SlimProto identifies players by MAC, so this needs to be stable
+    # across redeploys. First octet 0x02 = locally-administered unicast.
+    generator: "printf '02:%s\n' \"$(openssl rand -hex 5 | sed 's/\\(..\\)/\\1:/g;s/:$//')\""
+    vault: false  # not sensitive; stored plaintext for readability
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: music, port: 8095 }
+  my_linux_users:
+    music-assistant:
+      uid: 1014
+      gid: 1014
+
+playbooks:
+  - playbooks/music-assistant.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear:
+    - music_assistant_squeezelite_mac
+  volumes_to_preserve_unless_purge:
+    - music-assistant-data
+
+# Manual first-run setup at https://music.<caddy_domain>/setup is
+# required after deploy — see issue #66 for the automation tracker.

--- a/roles/nextcloud/meta/install.yml
+++ b/roles/nextcloud/meta/install.yml
@@ -1,0 +1,36 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Nextcloud"
+description: "Files + contacts; also acts as OIDC identity provider for other apps (e.g. Paperless, see docs/SSO-Bootstrap.md)"
+
+inventory_vars:
+  - name: nextcloud_admin_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+  - name: nextcloud_db_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: cloud, port: 8090 }
+  my_linux_users:
+    nextcloud:
+      uid: 1015
+      gid: 1015
+
+playbooks:
+  - playbooks/nextcloud.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear:
+    - nextcloud_admin_password
+    - nextcloud_db_password
+  volumes_to_preserve_unless_purge:
+    - nextcloud-config
+    - nextcloud-data
+    - nextcloud-postgres-data

--- a/roles/paperless-ngx/meta/install.yml
+++ b/roles/paperless-ngx/meta/install.yml
@@ -1,0 +1,49 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Paperless-NGX"
+description: "Document OCR + tagging + search. Optional SSO via Nextcloud (see docs/SSO-Bootstrap.md)."
+
+inventory_vars:
+  - name: paperless_url
+    type: computed
+    template: "https://paperless.{{ caddy_domain }}"
+  - name: paperless_secret_key
+    type: secret
+    generator: "openssl rand -hex 32"
+    vault: true
+  - name: paperless_db_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+  - name: paperless_admin_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: paperless, port: 8000 }
+  my_linux_users:
+    paperless:
+      uid: 1007
+      gid: 1007
+
+playbooks:
+  - playbooks/paperless-ngx.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear:
+    - paperless_url
+    - paperless_secret_key
+    - paperless_db_password
+    - paperless_admin_password
+    # paperless_oidc_* deliberately not listed — if the operator has
+    # wired SSO via the SSO-Bootstrap walkthrough, removing Paperless
+    # leaves the (now-orphaned) OIDC client in Nextcloud and the
+    # inventory keys for it. Operator removes those manually.
+  volumes_to_preserve_unless_purge:
+    - paperless-db-data
+    - paperless-media
+    - paperless-data

--- a/roles/pihole/meta/install.yml
+++ b/roles/pihole/meta/install.yml
@@ -1,0 +1,56 @@
+# Install spec consumed by `setup.sh add` / `remove` (Phase 5+).
+# See docs/Setup-Guide/ — this file is the role's contract with the
+# lifecycle CLI. Adding/removing a role to/from a deployment uses
+# only this file (no per-service code in setup.sh).
+
+display_name: "Pi-hole"
+description: "DNS-level ad-blocker for every device on the LAN"
+
+# Inventory vars this role needs to be deployable.
+# Each is resolved by setup.sh in priority order:
+#   1. existing inventory value (rebuild path)
+#   2. type-specific source:
+#        secret    → run `generator` (openssl rand …) and vault-encrypt
+#        config    → prompt with `default` (literal string or host-detect spec)
+#        computed  → render `template` (Jinja) against already-resolved values
+#        literal   → use `value` verbatim
+inventory_vars:
+  - name: pihole_local_network
+    type: config
+    prompt: "LAN subnet for Pi-hole (CIDR)"
+    default: "host_detect:lan_subnet"  # ip -4 addr show <iface>
+  - name: pihole_local_router
+    type: config
+    prompt: "LAN gateway"
+    default: "host_detect:lan_gateway"  # ip route show default
+  - name: pihole_api_password
+    type: secret
+    generator: "openssl rand -base64 24"
+    vault: true
+
+# Side-effects on shared inventory keys when this role is added.
+# `setup.sh add` merges these in; `setup.sh remove` reverses them.
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: pihole, port: 8443, proto: https }
+  my_linux_users:
+    pihole:
+      uid: 1005
+      gid: 1005
+
+# Playbooks `setup.sh add` runs after inventory is updated, in order.
+playbooks:
+  - playbooks/pihole.yml
+  - playbooks/caddy.yml      # rebuild Caddyfile with new subdomain
+  - playbooks/dashboard.yml  # add tile
+
+# `setup.sh remove` cleanup. Volumes preserved by default; --purge
+# also deletes them.
+on_remove:
+  inventory_vars_to_clear:
+    - pihole_api_password
+    - pihole_local_network
+    - pihole_local_router
+  volumes_to_preserve_unless_purge:
+    - systemd-pihole-etc
+    - systemd-pihole-dnsmasq

--- a/roles/shairportsync/meta/install.yml
+++ b/roles/shairportsync/meta/install.yml
@@ -1,0 +1,26 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Shairport-sync"
+description: "AirPlay 2 audio receiver — rootful, needs host audio device"
+
+# Rootful container — runs as root because shairport needs host
+# audio/network access. No HTTPS UI, so no Caddy entry.
+rootful: true
+
+inventory_vars: []
+
+side_effects:
+  # No caddy entry (audio-only, no web UI).
+  # No service user — runs as root.
+  my_linux_users:
+    shairport:
+      uid: 1001
+      gid: 1001
+
+playbooks:
+  - playbooks/shairportsync.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear: []
+  volumes_to_preserve_unless_purge: []

--- a/roles/syncthing/meta/install.yml
+++ b/roles/syncthing/meta/install.yml
@@ -1,0 +1,26 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Syncthing"
+description: "Encrypted device-to-device file sync (no cloud)"
+
+# Syncthing has no secrets in inventory — per-device identity is
+# managed inside the web UI after first boot.
+inventory_vars: []
+
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: syncthing, port: 8384, proto: https }
+  my_linux_users:
+    syncthg:
+      uid: 1003
+      gid: 1003
+
+playbooks:
+  - playbooks/syncthing.yml
+  - playbooks/caddy.yml
+  - playbooks/dashboard.yml
+
+on_remove:
+  inventory_vars_to_clear: []
+  volumes_to_preserve_unless_purge:
+    - systemd-syncthing


### PR DESCRIPTION
## Summary
Phase 4 of the unified-CLI plan: each optional role gets a `meta/install.yml` declaring what it needs to be deployed and what side-effects it has on shared inventory keys.

This metadata isn't consumed yet (Phase 5's `setup.sh add <service>` wizard reads it). This PR ships the contract so the wizard can be written against a stable shape.

## Files
- `roles/META-SCHEMA.md` — schema reference for contributors.
- `roles/pihole/meta/install.yml`
- `roles/syncthing/meta/install.yml`
- `roles/shairportsync/meta/install.yml`
- `roles/entephoto/meta/install.yml`
- `roles/paperless-ngx/meta/install.yml`
- `roles/jellyfin/meta/install.yml`
- `roles/music-assistant/meta/install.yml`
- `roles/nextcloud/meta/install.yml`

Platform-tier roles (caddy, dashboard, os-base, os-tailscale, backup) deliberately do NOT have an install.yml — they're not add/remove-able.

## Schema highlights
Each role declares:
- `display_name` + `description` — for the picker.
- `inventory_vars` — typed list (secret / config / computed / literal). Each has a defined resolution order.
- `side_effects` — what shared keys this role appends to (`caddy_reverse_proxy_services`, `my_linux_users`).
- `playbooks` — what `setup.sh add` runs after inventory is updated.
- `on_remove` — what to clear + which data volumes survive `setup.sh remove` by default (vs `--purge`).

## Verification
- [x] All 8 meta files YAML-validate.
- [x] Per-role values mirror today's setup.sh emissions byte-for-byte (port map, UID map, secret generators).
- [ ] No verification possible end-to-end yet — Phase 5 wizard not built.

## Out of scope (intentionally)
- Wiring meta files into setup.sh (that's Phase 5).
- Service dependencies (e.g. Paperless OIDC needs Nextcloud). Future phase.
- Schema validation tooling. Add when meta files start being consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)