### PR TITLE
setup.sh: wire up `add <service>` verb (Phase 5b)

### DIFF
--- a/scripts/build_add_update.py
+++ b/scripts/build_add_update.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+scripts/build_add_update.py — translate a role's meta/install.yml into
+the update.json that scripts/inventory_merge.py consumes for add mode.
+
+Resolves each declared inventory_var:
+  - secret  → run `generator` (shell command); emit vaulted scalar
+  - config  → leave for setup.sh's interactive prompt (skipped here;
+              caller supplies via --extra-overrides if non-interactive)
+  - computed → render `template` Jinja against existing inventory
+  - literal → emit value verbatim
+
+Side-effects → list/dict update entries (caddy_reverse_proxy_services,
+my_linux_users). The service name itself is always appended to
+deploy_services.
+
+Inventory_vars already set in inventory are skipped (idempotent;
+won't regenerate secrets or re-render computed values).
+
+Usage:
+    build_add_update.py --meta roles/nextcloud/meta/install.yml
+                        --service nextcloud
+                        --vault-password-file ~/.vaultpw
+                        --target-host homeserver2
+                        [--inventory-dir inventory]
+                        [--overrides key1=val1 key2=val2]
+                        --output /tmp/update.json
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def load_existing_inventory(target, vault_pw, inventory_dir):
+    """Get target host's current inventory as a dict (with vault dicts
+    still wrapped — we only need to check key presence for idempotency
+    and to render computed templates against scalar values)."""
+    env = {**os.environ, "ANSIBLE_VAULT_PASSWORD_FILE": vault_pw}
+    if inventory_dir:
+        env["ANSIBLE_INVENTORY"] = os.path.join(inventory_dir, "hosts.yml")
+    try:
+        result = subprocess.run(
+            ["ansible-inventory", "--host", target],
+            capture_output=True, text=True, check=True, env=env,
+        )
+    except subprocess.CalledProcessError:
+        return {}
+    if not result.stdout.strip():
+        return {}
+    return json.loads(result.stdout)
+
+
+def render_template(template_str, ctx):
+    """Render a small Jinja-like template. Uses jinja2 if available
+    (ansible-core depends on it so it should be on PATH), otherwise
+    falls back to str.format-style {key} substitution."""
+    try:
+        from jinja2 import Template
+        return Template(template_str).render(**ctx)
+    except ImportError:
+        # Crude fallback — operators using `computed` vars need jinja2.
+        return template_str.format(**ctx)
+
+
+def resolve_secret(generator):
+    """Run a shell generator command and return its stripped stdout."""
+    result = subprocess.run(
+        ["sh", "-c", generator],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.rstrip("\n")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--meta", required=True)
+    p.add_argument("--service", required=True)
+    p.add_argument("--vault-password-file", required=True)
+    p.add_argument("--target-host", required=True)
+    p.add_argument("--inventory-dir", default="inventory")
+    p.add_argument("--overrides", nargs="*", default=[],
+                   help="key=value pairs to use for `config`-type vars")
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+
+    # Load meta
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: PyYAML not available.", file=sys.stderr)
+        sys.exit(1)
+    with open(args.meta) as f:
+        meta = yaml.safe_load(f)
+
+    # Parse overrides into a dict
+    overrides = {}
+    for kv in args.overrides:
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            overrides[k] = v
+
+    # Existing inventory (for idempotency + computed-template context)
+    existing = load_existing_inventory(
+        args.target_host, args.vault_password_file, args.inventory_dir,
+    )
+
+    # Resolve inventory_vars
+    scalars = {}
+    config_needed = []  # config-type vars not in inventory or overrides
+    for var in meta.get("inventory_vars", []) or []:
+        name = var["name"]
+        vtype = var["type"]
+        if name in existing:
+            continue  # already set, don't clobber
+        if name in overrides:
+            scalars[name] = {"value": overrides[name], "vault": False}
+            continue
+        if vtype == "secret":
+            value = resolve_secret(var["generator"])
+            scalars[name] = {"value": value, "vault": var.get("vault", True)}
+        elif vtype == "computed":
+            value = render_template(var["template"], existing)
+            scalars[name] = {"value": value, "vault": False}
+        elif vtype == "literal":
+            scalars[name] = {"value": var["value"], "vault": False}
+        elif vtype == "config":
+            # caller must supply via --overrides (or via interactive
+            # prompt before invoking this script). Track for reporting.
+            config_needed.append(var)
+        else:
+            print(f"ERROR: unknown var type {vtype!r} for {name!r}", file=sys.stderr)
+            sys.exit(1)
+
+    if config_needed:
+        print("ERROR: the following `config`-type vars need values but"
+              " weren't found in inventory or --overrides:", file=sys.stderr)
+        for var in config_needed:
+            prompt = var.get("prompt", var["name"])
+            print(f"  --overrides {var['name']}=<...>  ({prompt})", file=sys.stderr)
+        sys.exit(2)
+
+    # Side effects → lists + dicts
+    lists = {}
+    dicts = {}
+    side = meta.get("side_effects") or {}
+
+    # deploy_services always gets the service name appended
+    lists["deploy_services"] = {"items": [args.service]}
+
+    if "caddy_reverse_proxy_services" in side:
+        lists["caddy_reverse_proxy_services"] = {
+            "items": side["caddy_reverse_proxy_services"],
+        }
+    if "my_linux_users" in side:
+        dicts["my_linux_users"] = {"entries": side["my_linux_users"]}
+
+    update = {"scalars": scalars, "lists": lists, "dicts": dicts}
+    with open(args.output, "w") as f:
+        json.dump(update, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.sh
+++ b/setup.sh
@@ -418,10 +418,16 @@ case "$VERB" in
             exit 1
         fi
         # Ensure ruamel.yaml is available for the merge step.
+        # Step 1 of `install` adds python3-ruamel-yaml via dnf; this
+        # lazy install covers hosts that ran install before that line
+        # landed (Phase 5b).
         if ! python3 -c "import ruamel.yaml" 2>/dev/null; then
-            info "Installing ruamel.yaml for inventory merge (one-time)..."
-            pipx inject ansible-core ruamel.yaml --quiet 2>/dev/null || \
-                pip install --user ruamel.yaml >/dev/null
+            info "Installing python3-ruamel-yaml for inventory merge (one-time)..."
+            sudo dnf install -y python3-ruamel-yaml &>/dev/null
+            if ! python3 -c "import ruamel.yaml" 2>/dev/null; then
+                err "Failed to install python3-ruamel-yaml. Required for setup.sh add."
+                exit 1
+            fi
         fi
         info "Resolving inventory updates for $SERVICE from $META..."
         UPDATE_JSON=$(mktemp --suffix=.json)
@@ -510,8 +516,8 @@ if [[ "${ID:-}" =~ ^(almalinux|rocky|centos|rhel)$ ]]; then
     PIPX_PYTHON_ARG=(--python python3.11)
 fi
 
-sudo dnf install -y podman git python3-pyyaml pipx &>/dev/null \
-    || sudo dnf install -y podman git python3-pyyaml pipx
+sudo dnf install -y podman git python3-pyyaml python3-ruamel-yaml pipx &>/dev/null \
+    || sudo dnf install -y podman git python3-pyyaml python3-ruamel-yaml pipx
 
 # Hard-fail if pipx still isn't on PATH — usually means EPEL is
 # misconfigured on AL/Rocky.

--- a/setup.sh
+++ b/setup.sh
@@ -70,15 +70,12 @@ Usage: setup.sh [VERB] [flags]
 
 Verbs:
   install      First install or interactive re-install (default).
-  add          Add a service that wasn't deployed before. [Phase 5]
-  remove       Remove a service. [Phase 6]
-  upgrade      Pull newer images + bump release tag. [Phase 3]
-  backup       Run backup now. [Phase 3]
-  restore      Restore from latest NAS backup. [Phase 3]
-  uninstall    Full wipe (today's clean-host.sh). [Phase 3]
-
-(`add` and `remove` land in Phase 5/6; for now manage services
-by editing inventory + running playbooks directly.)
+  add <svc>    Add a service that wasn't deployed before.
+  remove       Remove a service. [Phase 6 — not yet wired]
+  upgrade      Pull newer images + bump release tag within current major.
+  backup       Trigger the backup systemd service now.
+  restore      Restore from latest NAS backup.
+  uninstall    Full wipe (= scripts/clean-host.sh).
 
 Flags (for install):
   -i <url>     Private overlay repo URL (otherwise prompted).
@@ -385,8 +382,94 @@ case "$VERB" in
         info "Running clean-host (wipes containers, users, configs)..."
         exec bash "$INSTALL_DIR/scripts/clean-host.sh"
         ;;
-    add|remove)
-        err "'$VERB' is not yet wired up. Coming in Phase 5/6 of the unified-CLI work."
+    add)
+        SERVICE="${1:-}"
+        if [[ -z "$SERVICE" ]]; then
+            err "Usage: setup.sh add <service>"
+            err "Available services:"
+            for m in "$INSTALL_DIR"/roles/*/meta/install.yml; do
+                svc=$(basename "$(dirname "$(dirname "$m")")")
+                desc=$(python3 -c "import yaml; print(yaml.safe_load(open('$m')).get('description',''))" 2>/dev/null)
+                printf "  %-18s %s\n" "$svc" "$desc"
+            done
+            exit 2
+        fi
+        ensure_install_dir
+        ensure_ansible_on_path
+        META="$INSTALL_DIR/roles/$SERVICE/meta/install.yml"
+        if [[ ! -f "$META" ]]; then
+            err "Unknown service '$SERVICE' (no roles/$SERVICE/meta/install.yml)."
+            err "Run \`setup.sh add\` with no args to see available services."
+            exit 1
+        fi
+        TARGET=$(resolve_target_host)
+        cd "$INSTALL_DIR"
+        VAULT_PW_FILE="$HOME/.vaultpw"
+        if [[ ! -r "$VAULT_PW_FILE" ]]; then
+            err "$VAULT_PW_FILE not readable. Run \`setup.sh install\` first."
+            exit 1
+        fi
+        # Idempotency check: is the service already deployed?
+        if ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
+                ansible-inventory --host "$TARGET" 2>/dev/null \
+                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in (d.get('deploy_services') or []) else 1)"; then
+            warn "$SERVICE is already in deploy_services for $TARGET."
+            warn "Use \`setup.sh upgrade\` to re-deploy with latest images."
+            exit 1
+        fi
+        # Ensure ruamel.yaml is available for the merge step.
+        if ! python3 -c "import ruamel.yaml" 2>/dev/null; then
+            info "Installing ruamel.yaml for inventory merge (one-time)..."
+            pipx inject ansible-core ruamel.yaml --quiet 2>/dev/null || \
+                pip install --user ruamel.yaml >/dev/null
+        fi
+        info "Resolving inventory updates for $SERVICE from $META..."
+        UPDATE_JSON=$(mktemp --suffix=.json)
+        # shellcheck disable=SC2064
+        trap "rm -f $UPDATE_JSON" EXIT
+        if ! python3 scripts/build_add_update.py \
+                --meta "$META" \
+                --service "$SERVICE" \
+                --vault-password-file "$VAULT_PW_FILE" \
+                --target-host "$TARGET" \
+                --inventory-dir "$INSTALL_DIR/inventory" \
+                --output "$UPDATE_JSON"; then
+            err "Failed to build update spec for $SERVICE."
+            exit 1
+        fi
+        INV_FILE="$INSTALL_DIR/inventory/host_vars/$TARGET/main.yml"
+        info "Merging into $INV_FILE..."
+        if ! python3 scripts/inventory_merge.py \
+                --inventory "$INV_FILE" \
+                --vault-password-file "$VAULT_PW_FILE" \
+                --update "$UPDATE_JSON" \
+                --mode add; then
+            err "Failed to merge inventory."
+            exit 1
+        fi
+        ok "Inventory updated."
+        # Run the role's playbooks
+        info "Deploying $SERVICE (running role playbooks)..."
+        # shellcheck disable=SC2046
+        while IFS= read -r pb; do
+            [[ -z "$pb" ]] && continue
+            info "  → $pb"
+            if ! ansible-playbook "$pb" --limit "$TARGET"; then
+                err "Playbook $pb failed. Inventory has been updated but"
+                err "the role isn't fully deployed. Investigate, then re-run:"
+                err "  cd $INSTALL_DIR && ansible-playbook $pb --limit $TARGET"
+                exit 1
+            fi
+        done < <(python3 -c "import yaml; [print(pb) for pb in yaml.safe_load(open('$META'))['playbooks']]")
+        ok "$SERVICE deployed."
+        echo
+        info "Persist the inventory update to the overlay:"
+        echo "  cd $HOME/home-server-private"
+        echo "  git add -A && git commit -m '$TARGET: add $SERVICE' && git push"
+        exit 0
+        ;;
+    remove)
+        err "'remove' is not yet wired up. Coming in Phase 6."
         exit 2
         ;;
 esac


### PR DESCRIPTION
End of Phase 5. `setup.sh add <service>` is now generic across every optional role — driven by the per-role `meta/install.yml` (Phase 4) and the structural-merge helper (Phase 5a / PR #181).

## Usage

```
setup.sh add                       # list available services
setup.sh add syncthing             # add the syncthing role
setup.sh add nextcloud             # idempotent — refuses if already deployed
```

## Flow
1. Validate `<service>` (must have `roles/<svc>/meta/install.yml`).
2. Idempotency: refuse if already in `deploy_services`.
3. Lazy-install `ruamel.yaml` if missing.
4. Build the update spec via `scripts/build_add_update.py`:
   - secrets generated via meta's `generator` command
   - computed vars rendered via Jinja2 against current inventory
   - literals/configs handled per meta type
5. Apply via `scripts/inventory_merge.py` (preserves operator-added unmanaged keys + comments).
6. Run each playbook listed in the meta, in order.
7. Print a copy-paste reminder to commit + push the overlay.

## Test plan
- [ ] `setup.sh add` (no args) — lists every service from `roles/*/meta/install.yml`.
- [ ] `setup.sh add nextcloud` on a host that has nextcloud — refuses cleanly.
- [ ] `setup.sh add syncthing` on homeserver2 (where syncthing isn't deployed) — adds it cleanly, inventory updated, role deployed.
- [ ] After add: overlay diff shows only the expected new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)