### PR TITLE
syncthing: fix ansible_host_name typo

### DIFF
--- a/roles/syncthing/templates/quadlets/syncthing.container.j2
+++ b/roles/syncthing/templates/quadlets/syncthing.container.j2
@@ -11,7 +11,7 @@ Image={{ syncthing_image }}
 AutoUpdate=registry
 
 Network=host
-HostName={{ ansible_host_name }}
+HostName={{ ansible_hostname }}
 
 Volume=syncthing-config.volume:/var/syncthing
 Volume=syncthing-data.volume:/data


### PR DESCRIPTION
One-line fix discovered during Phase 5 `setup.sh add syncthing` testing. Template used `ansible_host_name` (no such ansible fact) instead of `ansible_hostname`. Has been broken since the initial commit but never triggered until now because syncthing wasn't being re-deployed in the recent test cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)