### PR TITLE
docs: surface unified-CLI verbs in Quickstart + Setup Guide (Phase 7)

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -102,26 +102,53 @@ real Let's Encrypt certificates via DNS-01 against your deSEC
 subdomain, so every device trusts them out of the box (no per-device
 CA install).
 
-## Step 3 — Hand off to Ansible from your laptop (optional)
+## Step 3 — Day-2 lifecycle commands
+
+`setup.sh` is also the entry point for everything after the initial
+install. Operators rarely need to invoke ansible directly.
+
+```bash
+setup.sh add <service>          # add a service that wasn't picked at install
+setup.sh add                    # (no args) list available services + descriptions
+setup.sh remove <service>       # remove a service; data volumes preserved
+setup.sh remove <service> --purge   # remove + delete data volumes
+setup.sh upgrade                # bump within current major release, re-deploy
+setup.sh backup                 # trigger the backup systemd service now
+setup.sh restore                # restore from latest NAS backup
+setup.sh uninstall              # full wipe (= scripts/clean-host.sh)
+setup.sh --help                 # all verbs + flags
+```
+
+Examples:
+
+```bash
+# I picked syncthing during install but actually want Paperless too:
+setup.sh add paperless-ngx
+
+# Upgrade to the latest v2.x release after a few weeks:
+setup.sh upgrade
+
+# Decommission Jellyfin but keep its media volume for now:
+setup.sh remove jellyfin
+```
+
+Each verb is idempotent and prints the underlying ansible command on
+error so power users can drop down to `ansible-playbook` if they want
+to debug deeper. Adding a brand-new service to the project (writing a
+new role) is the only flow that doesn't go through `setup.sh`.
+
+## Hand off to Ansible from your laptop (optional)
 
 If you'd rather drive the host from your laptop instead of staying
 on the server, the project also supports the classic
 "Ansible-host pushes to managed host" model. See the project
-[README](../README.md) for that flow:
-
-1. Run `scripts/bootstrap-host.sh` on the server to harden sshd
-   (move off port 22, disable root login, disable password auth).
-2. Set up the `home-server-private` overlay on your laptop with
-   your inventory and vault.
-3. Symlink the overlay into the public repo clone.
-4. `ansible-playbook playbooks/site.yml --limit <host>` from the
-   laptop.
+[README](../README.md) for that flow.
 
 ## Troubleshooting
 
-If `setup.sh` aborts mid-deploy, the partial state is safe to
-re-run from — every role is idempotent. Re-running `setup.sh` from
-the same checkout picks up where it left off.
+If `setup.sh install` aborts mid-deploy, the partial state is safe to
+re-run from — every role is idempotent. Re-running picks up where it
+left off.
 
 For role-specific issues, each role has its own README under
 `roles/<name>/README.md` with debugging notes.
@@ -132,5 +159,5 @@ To wipe all home-server artifacts and start fresh (does **not**
 remove system packages or your primary user):
 
 ```bash
-bash ~/home-server/scripts/clean-host.sh
+setup.sh uninstall
 ```

--- a/docs/Setup-Guide/05-verify-and-explore.md
+++ b/docs/Setup-Guide/05-verify-and-explore.md
@@ -36,7 +36,7 @@ If you see a padlock — congratulations, you're done. 🎉
 | **DNS doesn't resolve** the subdomain | Your laptop isn't using Pi-hole as DNS, OR you haven't picked Pi-hole in the service list | Set your laptop's DNS to the homeserver's IP, or add the homeserver to your router's DHCP DNS server. |
 | **Cert warning** | Caddy's first cert issuance hadn't completed yet when you opened the URL | Wait 1–2 min; reload. If still wrong, check `journalctl --user -u caddy -n 50` on the server for an ACME error. |
 | **Apex works, subdomains fail with `SSL_ERROR_INTERNAL_ERROR_ALERT`** | Apex cert issued; wildcard cert stuck in an ACME retry loop because the deSEC plugin left stale `_acme-challenge` TXT records. Rare since setup.sh pre-clears them, but possible if Caddy's apex + wildcard orders ever truly race. | `ssh <host> 'sudo -u webproxy XDG_RUNTIME_DIR=/run/user/1011 systemctl --user restart caddy'` then wait ~2 min. Background: [#170](https://github.com/luckynrslevin/home-server/issues/170). |
-| **Connection refused** | Server's firewall not yet open on 443 | Re-run `ansible-playbook playbooks/caddy.yml --connection=local --limit homeserver` on the server. |
+| **Connection refused** | Server's firewall not yet open on 443 | Re-run `setup.sh upgrade` on the server. |
 
 ## Explore
 
@@ -89,6 +89,12 @@ your data.
 
 - **Add more devices** — install the Ente / Syncthing / Jellyfin /
   Music Assistant mobile apps, point them at your subdomain.
+- **Add a service later** — `setup.sh add <service>` on the server.
+  Run `setup.sh add` with no args to see what's available.
+- **Upgrade** — `setup.sh upgrade` bumps to the latest release within
+  the current major and re-runs ansible.
+- **Backup / restore** — `setup.sh backup` triggers a backup now;
+  `setup.sh restore` pulls the latest NAS backup.
 - **Read the role docs** in `roles/<service>/README.md` for
   tuning knobs.
 - **Watch the project repo** for new services landing (Nextcloud,


### PR DESCRIPTION
Closes the unified-CLI plan. Operator-facing docs now point at `setup.sh add` / `remove` / `upgrade` / `backup` / `restore` / `uninstall` instead of raw ansible-playbook invocations.

## Changes
- **Quickstart.md**: new "Day-2 lifecycle commands" section, reset section uses `setup.sh uninstall`, laptop-handoff downgraded.
- **Setup-Guide/05-verify-and-explore.md**: troubleshooting + "where to next" use the new verbs.

Internal architecture descriptions ("setup.sh runs ansible-playbook under the hood") preserved so the model stays transparent — we just stop asking operators to type those commands themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)