### PR TITLE
roles/meta: correct volume names in volumes_to_preserve_unless_purge

### DIFF
--- a/roles/jellyfin/meta/install.yml
+++ b/roles/jellyfin/meta/install.yml
@@ -26,5 +26,6 @@ on_remove:
   inventory_vars_to_clear:
     - jellyfin_admin_password
   volumes_to_preserve_unless_purge:
-    - jellyfin-config
-    - jellyfin-media
+    - systemd-jellyfin-config
+    - systemd-jellyfin-cache
+    - systemd-jellyfin-media

--- a/roles/nextcloud/meta/install.yml
+++ b/roles/nextcloud/meta/install.yml
@@ -33,4 +33,6 @@ on_remove:
   volumes_to_preserve_unless_purge:
     - nextcloud-config
     - nextcloud-data
+    - nextcloud-html
     - nextcloud-postgres-data
+    - nextcloud-redis-data

--- a/roles/paperless-ngx/meta/install.yml
+++ b/roles/paperless-ngx/meta/install.yml
@@ -44,6 +44,9 @@ on_remove:
     # leaves the (now-orphaned) OIDC client in Nextcloud and the
     # inventory keys for it. Operator removes those manually.
   volumes_to_preserve_unless_purge:
-    - paperless-db-data
-    - paperless-media
     - paperless-data
+    - paperless-db-data
+    - paperless-redis-data
+    - paperless-media
+    - paperless-consume
+    - paperless-export

--- a/roles/syncthing/meta/install.yml
+++ b/roles/syncthing/meta/install.yml
@@ -23,4 +23,5 @@ playbooks:
 on_remove:
   inventory_vars_to_clear: []
   volumes_to_preserve_unless_purge:
-    - systemd-syncthing
+    - systemd-syncthing-config
+    - systemd-syncthing-data


### PR DESCRIPTION
Caught during Test 1 of post-Phase-7 verification on homeserver2. Phase 4's meta files (PR #174) had wrong/incomplete volume names for 4 roles — would cause `setup.sh remove --purge` to silently leave stale data because the podman volume delete `|| true`'s away the wrong-name error.

Volume names now match `podman volume ls` output on a real homeserver2 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)