### PR TITLE
nextcloud: hardcode db_user/db_name in backup_manifest

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -41,5 +41,5 @@ backup_manifest:
     - { name: nextcloud-config, method: tar }
     - { name: nextcloud-data, method: rsync, nas_share: nextcloud }
   databases:
-    - { container: nextcloud-postgres, db_user: "{{ nextcloud_db_user }}", db_name: "{{ nextcloud_db_name }}", method: pgdump }
+    - { container: nextcloud-postgres, db_user: ncuser, db_name: nextcloud, method: pgdump }
   post_restore_tasks: restore.yml


### PR DESCRIPTION
Caught during Test 5 (`setup.sh restore`) on homeserver2. restore.yml loads each role's defaults via `include_vars` with a namespace, so the file's `{{ nextcloud_db_user }}` Jinja can't resolve — there's no top-level `nextcloud_db_user`.

Hardcode the literal values (ncuser/nextcloud) in backup_manifest. They match the role's default values; the Jinja indirection was unnecessary and broke restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)