### PR TITLE
setup.sh: integrate backup into install + add verbs (closes #150)

### DIFF
--- a/roles/backup/meta/install.yml
+++ b/roles/backup/meta/install.yml
@@ -1,0 +1,42 @@
+# See roles/pihole/meta/install.yml for schema reference.
+
+display_name: "Backup"
+description: "Nightly rsync/tar/pgdump of every deployed service's data to a LAN NAS via NFS"
+
+# NAS connection info — no sensible defaults. Operator must supply.
+# `backup_nas_ip` has no default (requires LAN-specific value);
+# the others have role defaults that work for a typical Synology
+# layout but can be overridden.
+inventory_vars:
+  - name: backup_nas_hostname
+    type: config
+    prompt: "NAS hostname"
+    default: "nas"
+  - name: backup_nas_ip
+    type: config
+    prompt: "NAS IP address"
+    default: ""
+  - name: backup_nas_volume
+    type: config
+    prompt: "NAS share root path"
+    default: "/volume1"
+  - name: backup_time
+    type: config
+    prompt: "Daily backup time (HH:MM:SS)"
+    default: "02:00:00"
+
+# No side-effects: no web subdomain (CLI-only), no service user
+# (runs as root via systemd service).
+side_effects: {}
+
+playbooks:
+  - playbooks/backup.yml
+  - playbooks/dashboard.yml  # refresh tile (if backup adds one)
+
+on_remove:
+  inventory_vars_to_clear:
+    # NAS coordinates are host-config (multiple services might want
+    # them in the future) so we KEEP them on remove. Drop manually
+    # if needed.
+    []
+  volumes_to_preserve_unless_purge: []

--- a/setup.sh
+++ b/setup.sh
@@ -1127,6 +1127,7 @@ echo
 
 declare -A SERVICES=(
     [dashboard]="Status dashboard showing all services"
+    [backup]="Nightly backup to a NAS via NFS (needs LAN-reachable NAS)"
     [pihole]="Pi-hole DNS ad-blocker"
     [entephoto]="Ente Photos (self-hosted photo storage)"
     [paperless-ngx]="Paperless-NGX document management (OCR + search)"
@@ -1138,9 +1139,10 @@ declare -A SERVICES=(
 
 SELECTED_SERVICES=(caddy nextcloud)
 
-SERVICE_ORDER=(dashboard pihole entephoto paperless-ngx syncthing shairportsync jellyfin music-assistant)
+SERVICE_ORDER=(dashboard backup pihole entephoto paperless-ngx syncthing shairportsync jellyfin music-assistant)
 declare -A SERVICE_DEFAULT_YES=(
     [dashboard]=1
+    [backup]=1
     [pihole]=1
     [entephoto]=1
     [paperless-ngx]=1
@@ -1195,6 +1197,29 @@ is_selected() {
     done
     return 1
 }
+
+# --- NAS prompts (only if backup is selected) ---
+if is_selected backup; then
+    echo
+    echo -e "${BOLD}--- Backup NAS ---${NC}"
+    echo
+    echo "Backup is a nightly rsync/tar/pgdump to a LAN-reachable NAS"
+    echo "via NFS. You need:"
+    echo "  - The NAS reachable on your LAN (DHCP-reserved IP)."
+    echo "  - An NFS share exported to this host's IP, with subdirs"
+    echo "    matching each service that backs up via rsync (\`backup-pihole\`,"
+    echo "    \`backup-syncthing\`, etc. — see roles/backup/README.md)."
+    echo
+    prompt_default backup_nas_hostname "NAS hostname" "nas"
+    prompt_default backup_nas_ip       "NAS IP address" ""
+    if [[ -z "$backup_nas_ip" ]]; then
+        err "NAS IP is required when backup is selected."
+        err "(Set up a DHCP reservation on your router, then re-run.)"
+        exit 1
+    fi
+    prompt_default backup_nas_volume   "NAS share root path" "/volume1"
+    prompt_default backup_time         "Daily backup time (HH:MM:SS)" "02:00:00"
+fi
 
 # ============================================================================
 # Step 6: Generate configuration files
@@ -1505,6 +1530,16 @@ if [[ -n "${SMTP_HOST:-}" ]]; then
     echo "smtp_encryption: \"$SMTP_ENCRYPTION\""
     echo "smtp_from: \"$SMTP_FROM\""
     vault_encrypt "$SMTP_PASSWORD" "smtp_password"
+fi
+
+if is_selected backup; then
+    echo ""
+    echo "### Backup — nightly rsync/tar/pgdump to a LAN NAS via NFS"
+    echo "# See roles/backup/README.md for NAS-side prep (exports + dirs)."
+    echo "backup_nas_hostname: \"$backup_nas_hostname\""
+    echo "backup_nas_ip: \"$backup_nas_ip\""
+    echo "backup_nas_volume: \"$backup_nas_volume\""
+    echo "backup_time: \"$backup_time\""
 fi
 echo "##################################################################################################"
 } > inventory/host_vars/$SERVER_HOSTNAME/main.yml


### PR DESCRIPTION
Closes #150 (the immediate gap — `setup.sh install` now offers backup with NAS prompts; `setup.sh add backup` works post-install via the new `roles/backup/meta/install.yml`).

## Changes
- setup.sh service picker: `backup` added, default Y.
- New NAS prompts when backup is selected: hostname, IP (required), share path, daily time.
- Emits `backup_nas_*` + `backup_time` to inventory main.yml.
- `roles/backup/meta/install.yml` lets the add verb work too (operator supplies NAS IP via inventory edit or --overrides).

## Deferred to v2 (still in #150)
- NFS write probe (mount + test write + cleanup at install time). Polish that catches misconfigured shares earlier; not blocking on a first-time operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)