### PR TITLE
jellyfin: rename default admin user jellyadmin → jellyfinadmin

### DIFF
--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -15,7 +15,7 @@ jellyfin_time_zone: "Europe/Berlin"
 # Set jellyfin_admin_password from a vault-encrypted secret in your
 # private inventory (setup.sh generates this automatically). Leaving
 # it empty disables the postinstall step.
-jellyfin_admin_user: jellyadmin
+jellyfin_admin_user: jellyfinadmin
 jellyfin_admin_password: ""
 
 # Default locale for the metadata wizard. Override in host_vars when


### PR DESCRIPTION
Cosmetic — `jellyfinadmin` reads more naturally than `jellyadmin`. Affects fresh installs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)