### PR TITLE
setup.sh: add openssl to dnf prereq list

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -676,8 +676,8 @@ if [[ "${ID:-}" =~ ^(almalinux|rocky|centos|rhel)$ ]]; then
     PIPX_PYTHON_ARG=(--python python3.11)
 fi
 
-sudo dnf install -y podman git python3-pyyaml python3-ruamel-yaml pipx &>/dev/null \
-    || sudo dnf install -y podman git python3-pyyaml python3-ruamel-yaml pipx
+sudo dnf install -y podman git openssl python3-pyyaml python3-ruamel-yaml pipx &>/dev/null \
+    || sudo dnf install -y podman git openssl python3-pyyaml python3-ruamel-yaml pipx
 
 # Hard-fail if pipx still isn't on PATH — usually means EPEL is
 # misconfigured on AL/Rocky.


### PR DESCRIPTION
Fedora 43 base doesn't pre-install /usr/bin/openssl. Without it, the secret generation in `resolve_secret` produces empty values. Caught during homeserver upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)