### PR TITLE
setup.sh: add acl to dnf prereq list

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -676,8 +676,8 @@ if [[ "${ID:-}" =~ ^(almalinux|rocky|centos|rhel)$ ]]; then
     PIPX_PYTHON_ARG=(--python python3.11)
 fi
 
-sudo dnf install -y podman git openssl python3-pyyaml python3-ruamel-yaml pipx &>/dev/null \
-    || sudo dnf install -y podman git openssl python3-pyyaml python3-ruamel-yaml pipx
+sudo dnf install -y podman git openssl acl python3-pyyaml python3-ruamel-yaml pipx &>/dev/null \
+    || sudo dnf install -y podman git openssl acl python3-pyyaml python3-ruamel-yaml pipx
 
 # Hard-fail if pipx still isn't on PATH — usually means EPEL is
 # misconfigured on AL/Rocky.


### PR DESCRIPTION
Fixes ansible 2.20+ become-as-unprivileged-user failures on Fedora when `acl` package isn't installed (ansible tries chmod with NFS4 ACL syntax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)