### PR TITLE
fix: setup.sh remove flag passthrough + restore tag inheritance

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -80,6 +80,8 @@
     - name: Restore caddy
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [caddy]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'caddy') | list | length > 0
@@ -88,6 +90,8 @@
     - name: Restore pihole
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [pihole]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'pihole') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'pihole') | list | length > 0
@@ -96,6 +100,8 @@
     - name: Restore syncthing
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [syncthing]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'syncthing') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'syncthing') | list | length > 0
@@ -104,6 +110,8 @@
     - name: Restore entephoto
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [entephoto]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'entephoto') | list | length > 0
@@ -112,6 +120,8 @@
     - name: Restore paperless-ngx
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [paperless-ngx]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'paperless-ngx') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'paperless-ngx') | list | length > 0
@@ -120,6 +130,8 @@
     - name: Restore jellyfin
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [jellyfin]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'jellyfin') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'jellyfin') | list | length > 0
@@ -128,6 +140,8 @@
     - name: Restore nextcloud
       ansible.builtin.include_tasks:
         file: tasks/restore_generic.yml
+        apply:
+          tags: [nextcloud]
       vars:
         svc: "{{ _restore_manifests | selectattr('_role_name', 'equalto', 'nextcloud') | first }}"
       when: _restore_manifests | selectattr('_role_name', 'equalto', 'nextcloud') | list | length > 0

--- a/setup.sh
+++ b/setup.sh
@@ -517,6 +517,14 @@ PY
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --purge) PURGE=true ;;
+                # Re-accept the top-level CLI flags so they can also
+                # appear after the verb's positional arg, e.g.
+                # `setup.sh remove jellyfin -h homeserver --purge`.
+                # getopts at the top of the script only catches flags
+                # that come before any positional arg.
+                -h) shift; HOSTNAME_FLAG="${1:-}" ;;
+                -v) shift; VAULT_PW_FLAG_FILE="${1:-}" ;;
+                -y|--yes) YES_FLAG=true ;;
                 *) err "Unknown remove flag: $1"; exit 2 ;;
             esac
             shift


### PR DESCRIPTION
Two small fixes from today's homeserver upgrade cycle:

1. **`setup.sh remove <svc> -h <host>`**: was rejected because getopts at the top stops at the first positional, so flags after the service name never reached it. Local parser in remove verb now also accepts `-h`, `-v`, `-y`/`--yes` for ergonomic parity with install/upgrade.

2. **`playbooks/restore.yml --tags <svc>`**: included tasks were skipped because `include_tasks` doesn't inherit tags from the include statement. Added `apply: tags: [<svc>]` to all 7 per-service blocks. Restore now actually runs when invoked with a service tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)