### PR TITLE
setup.sh: preserve operator-added inventory keys across install re-runs

### DIFF
--- a/scripts/preserve_unmanaged_inventory.py
+++ b/scripts/preserve_unmanaged_inventory.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+scripts/preserve_unmanaged_inventory.py — preserve operator-added keys.
+
+Called by `setup.sh install` immediately after the heredoc emits the
+canonical main.yml. The heredoc only knows about the keys setup.sh
+itself manages; any operator-added keys (e.g. jellyfin_nas_mounts,
+shairportsync_airplay_name) would be silently dropped on rebuild.
+
+This script:
+  1. Loads the PRE-EMIT snapshot of main.yml (--old).
+  2. Loads the freshly-emitted main.yml (--new).
+  3. Collects top-level keys present in old but not in new.
+  4. Appends them (with their comments + vault tags preserved) to --new.
+
+Idempotent: re-runs with no unmanaged keys produce zero diff.
+
+Usage:
+    preserve_unmanaged_inventory.py --old <snapshot.yml> --new <main.yml>
+"""
+
+import argparse
+import sys
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap
+except ImportError:
+    print("ERROR: ruamel.yaml not installed.", file=sys.stderr)
+    sys.exit(1)
+
+
+def make_yaml() -> YAML:
+    yaml = YAML(typ="rt")
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    return yaml
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--old", required=True, help="Pre-emit snapshot of main.yml")
+    ap.add_argument("--new", required=True, help="Freshly-emitted main.yml to append to")
+    args = ap.parse_args()
+
+    yaml = make_yaml()
+
+    with open(args.old) as f:
+        old_doc = yaml.load(f)
+    if not isinstance(old_doc, CommentedMap):
+        # Empty or non-mapping snapshot — nothing to preserve.
+        return 0
+
+    with open(args.new) as f:
+        new_doc = yaml.load(f)
+    if not isinstance(new_doc, CommentedMap):
+        new_doc = CommentedMap()
+
+    new_keys = set(new_doc.keys())
+    unmanaged = [k for k in old_doc.keys() if k not in new_keys]
+    if not unmanaged:
+        return 0
+
+    # Build a fresh document containing only the unmanaged keys, so
+    # ruamel can dump just those (preserving their comments + tags).
+    preserved = CommentedMap()
+    for k in unmanaged:
+        preserved[k] = old_doc[k]
+        # Carry over the comment attached to this key, if any.
+        if k in old_doc.ca.items:
+            preserved.ca.items[k] = old_doc.ca.items[k]
+
+    # Append: render preserved as YAML and append after a header.
+    import io
+    buf = io.StringIO()
+    yaml.dump(preserved, buf)
+    body = buf.getvalue()
+
+    with open(args.new, "a") as f:
+        f.write("\n")
+        f.write("##################################################################################################\n")
+        f.write("### Operator-added keys (preserved across `setup.sh install` re-runs)\n")
+        f.write("##################################################################################################\n")
+        f.write(body)
+
+    # Report what was preserved (visible in setup.sh output).
+    print(f"Preserved {len(unmanaged)} unmanaged key(s): {', '.join(unmanaged)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.sh
+++ b/setup.sh
@@ -1335,6 +1335,16 @@ else
     MUSIC_ASSISTANT_MAC="02:$(openssl rand -hex 5 | sed 's/\(..\)/\1:/g;s/:$//')"
 fi
 
+# Snapshot any existing main.yml so we can preserve operator-added
+# unmanaged keys after the heredoc rewrites the file. Empty snapshot
+# (or missing file) means a fresh install — nothing to preserve.
+_unmanaged_snapshot=$(mktemp)
+if [[ -f "inventory/host_vars/$SERVER_HOSTNAME/main.yml" ]]; then
+    cp "inventory/host_vars/$SERVER_HOSTNAME/main.yml" "$_unmanaged_snapshot"
+else
+    : > "$_unmanaged_snapshot"
+fi
+
 # Build the host_vars file
 {
 cat << YAML
@@ -1551,6 +1561,18 @@ if is_selected backup; then
 fi
 echo "##################################################################################################"
 } > inventory/host_vars/$SERVER_HOSTNAME/main.yml
+
+# Re-attach any operator-added keys (jellyfin_nas_mounts, samba_*,
+# pihole_local_dns_records, etc.) that aren't part of setup.sh's
+# managed key set. Without this, a rebuild silently drops them.
+if [[ -s "$_unmanaged_snapshot" ]]; then
+    python3 scripts/preserve_unmanaged_inventory.py \
+        --old "$_unmanaged_snapshot" \
+        --new "inventory/host_vars/$SERVER_HOSTNAME/main.yml" \
+        2> >(while IFS= read -r line; do info "$line"; done >&2) \
+        || warn "preserve_unmanaged_inventory.py failed — check for lost operator-added keys"
+fi
+rm -f "$_unmanaged_snapshot"
 
 ok "Generated inventory/host_vars/$SERVER_HOSTNAME/main.yml (with vault-encrypted secrets)"
 


### PR DESCRIPTION
## Summary
- Bug #1 from the prod-migration triage: `setup.sh install` rewrites `host_vars/<host>/main.yml` from a heredoc that only knows setup.sh-managed keys, silently dropping operator-added keys (e.g. `jellyfin_nas_mounts`, `jellyfin_extra_media_mounts`, `samba_*`, `pihole_local_dns_records`) on rebuild. This is the v1 limitation from #175 that bit us in production today.
- Fix: snapshot the existing `main.yml` before the heredoc runs, then post-process with a new `scripts/preserve_unmanaged_inventory.py` helper that uses ruamel.yaml round-trip mode to re-append any top-level keys present in the snapshot but absent from the freshly emitted file. Vault tags (`!vault | ...`) and per-key values round-trip cleanly; the appended block is fenced with a clearly labelled banner.
- Idempotent: repeated runs with no unmanaged keys produce zero diff.

## Test plan
- [x] Synthetic test: old.yml with `jellyfin_nas_mounts` + `samba_server_string`; new.yml without them → both preserved after script runs.
- [x] Idempotency: re-running script on already-preserved file is a no-op.
- [x] `bash -n setup.sh` clean.
- [ ] End-to-end: run `setup.sh install -y` against homeserver2 with a pre-seeded operator key in inventory; verify the key survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)