### PR TITLE
fix(ci): planned-app workflow f-string syntax error

### DIFF
--- a/.github/workflows/update-planned-list.yml
+++ b/.github/workflows/update-planned-list.yml
@@ -30,16 +30,16 @@ jobs:
           set -euo pipefail
           # `gh issue list` JSON → markdown bullets, sorted by number asc.
           gh issue list --label planned-app --state open \
-              --limit 100 --json number,title,url \
-            | python3 -c '
-          import json, sys
-          items = sorted(json.load(sys.stdin), key=lambda i: i["number"])
+              --limit 100 --json number,title,url > /tmp/planned.json
+          python3 - <<'PY' > /tmp/planned.md
+          import json
+          items = sorted(json.load(open("/tmp/planned.json")), key=lambda i: i["number"])
           if not items:
               print("_(No open planned-app issues. Open one with the_ `planned-app` _label to propose a feature.)_")
           else:
               for i in items:
-                  print(f"- [{i[\"title\"]}]({i[\"url\"]}) (#{i[\"number\"]})")
-          ' > /tmp/planned.md
+                  print(f"- [{i['title']}]({i['url']}) (#{i['number']})")
+          PY
           cat /tmp/planned.md
 
       - name: Splice into README


### PR DESCRIPTION
## Summary
- Render step in `update-planned-list.yml` failed with `SyntaxError: unexpected character after line continuation character` because `i[\"title\"]` is a backslash inside an f-string expression (illegal pre-3.12, awkward after).
- Rewrote as a heredoc with single-quoted keys, mirroring the splice step.

See failed run: https://github.com/luckynrslevin/home-server/actions/runs/26223473351

## Test plan
- [x] Merge, then trigger via `gh workflow run update-planned-list.yml` and confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)