### PR TITLE
fix(entephoto-migration): inline garage image var

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -16,6 +16,9 @@
   become: true
 
   vars:
+    # Inlined from the role default so this playbook doesn't pull in the
+    # entire entephoto defaults file (which would shadow inventory).
+    entephoto_garage_image: "dxflrs/garage:v1.0.1"
     _ente_user: entephoto
     _ente_uid: "{{ my_linux_users.entephoto.uid }}"
     _ente_buckets:


### PR DESCRIPTION
Standalone playbook can't see role defaults. `vars_files:` would override inventory host_vars (precedence). Inline the image tag.