### PR TITLE
fix(entephoto): fully-qualify garage image name

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -18,7 +18,7 @@
   vars:
     # Inlined from the role default so this playbook doesn't pull in the
     # entire entephoto defaults file (which would shadow inventory).
-    entephoto_garage_image: "dxflrs/garage:v1.0.1"
+    entephoto_garage_image: "docker.io/dxflrs/garage:v1.0.1"
     _ente_user: entephoto
     _ente_uid: "{{ my_linux_users.entephoto.uid }}"
     _ente_buckets:

--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Container images
 entephoto_postgres_image: "public.ecr.aws/docker/library/postgres:15"
-entephoto_garage_image: "dxflrs/garage:v1.0.1"
+entephoto_garage_image: "docker.io/dxflrs/garage:v1.0.1"
 entephoto_server_image: "ghcr.io/ente-io/server:latest"
 entephoto_web_image: "ghcr.io/ente-io/web:latest"
 


### PR DESCRIPTION
AL9 podman rejects short image names non-interactively. Add explicit `docker.io/` prefix in role default and migration playbook.