### PR TITLE
fix(entephoto): keep migration steps pod-internal

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -98,11 +98,19 @@
       become_user: "{{ _ente_user }}"
       changed_when: true
 
-    - name: Wait for Garage S3 API
-      ansible.builtin.wait_for:
-        host: 127.0.0.1
-        port: 3900
-        timeout: 60
+    # Pod-internal check — the pod doesn't yet publish 3900 to the host
+    # (it still publishes 3200 for MinIO). Use `garage status` inside
+    # the container as the readiness probe.
+    - name: Wait for Garage to be ready (pod-internal)
+      become: true
+      become_user: "{{ _ente_user }}"
+      ansible.builtin.command:
+        cmd: podman exec entephoto-garage /garage status
+      register: _garage_ready
+      retries: 30
+      delay: 2
+      until: _garage_ready.rc == 0
+      changed_when: false
 
     - name: Bootstrap Garage layout, buckets, key
       ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/entephoto/tasks/garage-bootstrap.yml"
@@ -138,9 +146,9 @@
       ansible.builtin.command:
         cmd: >
           podman run --rm
-          --network host
+          --pod entephoto
           -v /home/{{ _ente_user }}/.rclone-migration.conf:/config/rclone/rclone.conf:ro
-          rclone/rclone:latest
+          docker.io/rclone/rclone:latest
           --config /config/rclone/rclone.conf
           sync minio:{{ item }} garage:{{ item }}
           --transfers 8 --checkers 16 --checksum
@@ -168,9 +176,9 @@
       ansible.builtin.command:
         cmd: >
           podman run --rm
-          --network host
+          --pod entephoto
           -v /home/{{ _ente_user }}/.rclone-migration.conf:/config/rclone/rclone.conf:ro
-          rclone/rclone:latest
+          docker.io/rclone/rclone:latest
           --config /config/rclone/rclone.conf
           sync minio:{{ item }} garage:{{ item }}
           --transfers 8 --checkers 16 --checksum

--- a/roles/entephoto/tasks/garage-bootstrap.yml
+++ b/roles/entephoto/tasks/garage-bootstrap.yml
@@ -2,18 +2,19 @@
 # Garage bootstrap. Runs against the entephoto-garage container after the
 # pod is up. All steps are idempotent — safe to re-run on every deploy.
 
-- name: Wait for Garage S3 API to accept connections
-  ansible.builtin.wait_for:
-    host: 127.0.0.1
-    port: 3900
-    timeout: 60
-
-- name: Get Garage node ID
+# `podman exec ... /garage status` doubles as the readiness probe — it
+# only returns 0 once the gossip layer is up. Using a host-level
+# wait_for on 3900 would fail until the pod re-publishes that port,
+# which doesn't happen until the cutover.
+- name: Wait for Garage to be ready
   become: true
   become_user: entephoto
   ansible.builtin.command:
     cmd: podman exec entephoto-garage /garage status
   register: _garage_status
+  retries: 30
+  delay: 2
+  until: _garage_status.rc == 0
   changed_when: false
 
 - name: Parse node ID and current layout state


### PR DESCRIPTION
While both backends are live, the pod still publishes 3200 (MinIO) and not 3900 (Garage). Anything that assumed host-level 127.0.0.1:3900 reachability hit timeouts. Move readiness probes and rclone runs into the pod's network namespace.