### PR TITLE
fix(entephoto-migration): run rclone as root in container

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -145,7 +145,7 @@
     - name: Mirror each bucket (warm pass — museum still serving)
       ansible.builtin.command:
         cmd: >
-          podman run --rm
+          podman run --rm --user 0:0
           --pod entephoto
           -v /home/{{ _ente_user }}/.rclone-migration.conf:/config/rclone/rclone.conf:ro
           docker.io/rclone/rclone:latest
@@ -175,7 +175,7 @@
     - name: Final mirror pass with museum stopped
       ansible.builtin.command:
         cmd: >
-          podman run --rm
+          podman run --rm --user 0:0
           --pod entephoto
           -v /home/{{ _ente_user }}/.rclone-migration.conf:/config/rclone/rclone.conf:ro
           docker.io/rclone/rclone:latest


### PR DESCRIPTION
rclone image demotes to a non-root user that can't read the 0600 config. --user 0:0.