### PR TITLE
fix(entephoto-migration): pin rclone region

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -131,6 +131,7 @@
           access_key_id = enteadmin
           secret_access_key = {{ entephoto_minio_password }}
           endpoint = http://127.0.0.1:3200
+          region = eu-central-2
           force_path_style = true
 
           [garage]
@@ -139,6 +140,7 @@
           access_key_id = {{ entephoto_s3_access_key_id }}
           secret_access_key = {{ entephoto_s3_secret_access_key }}
           endpoint = http://127.0.0.1:3900
+          region = eu-central-2
           force_path_style = true
       no_log: true
 


### PR DESCRIPTION
Garage validates the v4 scope; rclone's us-east-1 default fails. Pin both backends to eu-central-2 to match garage.toml.