### PR TITLE
fix(entephoto): include_role for museum.yaml render

### DIFF
--- a/playbooks/entephoto-minio-to-garage.yml
+++ b/playbooks/entephoto-minio-to-garage.yml
@@ -192,13 +192,13 @@
     # ------------------------------------------------------------------
     # Phase 4: cut museum over to Garage credentials
     # ------------------------------------------------------------------
+    # include_role pulls in role defaults so museum.yaml.j2 has access
+    # to entephoto_albums_url, entephoto_admin_user_ids, etc. — vars
+    # that don't exist in inventory.
     - name: Re-render museum.yaml against Garage key
-      ansible.builtin.template:
-        src: "{{ playbook_dir }}/../roles/entephoto/templates/volumes/entephoto-museum-config/museum.yaml.j2"
-        dest: "/home/{{ _ente_user }}/.local/share/containers/storage/volumes/entephoto-museum-config/_data/museum.yaml"
-        owner: "{{ _ente_user }}"
-        group: "{{ _ente_user }}"
-        mode: "0600"
+      ansible.builtin.include_role:
+        name: entephoto
+        tasks_from: render-museum-config.yml
 
     - name: Start museum + web pointing at Garage
       ansible.builtin.command:

--- a/roles/entephoto/tasks/main.yml
+++ b/roles/entephoto/tasks/main.yml
@@ -89,27 +89,9 @@
 # volume on FIRST deploy only — subsequent ansible runs with changed
 # inventory (e.g. an updated entephoto_s3_endpoint, or the access key
 # materialized by garage-bootstrap above) don't re-render it, leaving
-# museum.yaml out of sync. Re-render every run directly into the volume's
-# _data dir and bounce the museum container on drift.
-- name: Re-render museum.yaml from inventory (drift correction)
-  become: true
-  become_user: entephoto
-  ansible.builtin.template:
-    src: volumes/entephoto-museum-config/museum.yaml.j2
-    dest: "/home/entephoto/.local/share/containers/storage/volumes/entephoto-museum-config/_data/museum.yaml"
-    mode: "0600"
-  register: _entephoto_museum_yaml
-  failed_when: false
-
-- name: Restart entephoto-museum when config drifted # noqa: no-handler
-  become: true
-  ansible.builtin.command:
-    cmd: >
-      sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
-      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
-      systemctl --user restart entephoto-museum.service
-  changed_when: true
-  when: _entephoto_museum_yaml is changed
+# museum.yaml out of sync.
+- name: Re-render museum.yaml + bounce museum on drift
+  ansible.builtin.include_tasks: render-museum-config.yml
 
 - name: Register backup manifest
   ansible.builtin.set_fact:

--- a/roles/entephoto/tasks/render-museum-config.yml
+++ b/roles/entephoto/tasks/render-museum-config.yml
@@ -1,0 +1,26 @@
+---
+# Re-render museum.yaml directly into the entephoto-museum-config volume
+# and restart the museum container on drift. Split out so the migration
+# playbook can re-use it (include_role pulls in role defaults that
+# museum.yaml.j2 needs: entephoto_albums_url, entephoto_admin_user_ids,
+# etc.).
+
+- name: Re-render museum.yaml from inventory (drift correction)
+  become: true
+  become_user: entephoto
+  ansible.builtin.template:
+    src: volumes/entephoto-museum-config/museum.yaml.j2
+    dest: "/home/entephoto/.local/share/containers/storage/volumes/entephoto-museum-config/_data/museum.yaml"
+    mode: "0600"
+  register: _entephoto_museum_yaml
+  failed_when: false
+
+- name: Restart entephoto-museum when config drifted # noqa: no-handler
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      sudo -u entephoto XDG_RUNTIME_DIR=/run/user/{{ my_linux_users.entephoto.uid }}
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users.entephoto.uid }}/bus
+      systemctl --user restart entephoto-museum.service
+  changed_when: true
+  when: _entephoto_museum_yaml is changed


### PR DESCRIPTION
Standalone template render missed role defaults. Split into a re-usable task file and include via include_role.