### PR TITLE
fix(backup): per-volume subdir for rsync targets

### DIFF
--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -92,7 +92,7 @@
         --format='{% raw %}{{.Mountpoint}}{% endraw %}')
     sudo -u {{ svc.service_user }} podman unshare rsync -a --delete \
         --no-owner --no-group --numeric-ids \
-        "{{ restore_root }}/{{ item.nas_share }}/{{ inventory_hostname }}/" "$MP/"
+        "{{ restore_root }}/{{ item.nas_share }}/{{ inventory_hostname }}/{{ item.name }}/" "$MP/"
   loop: >-
     {{ svc.volumes
        | selectattr('method', 'equalto', 'rsync')

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -106,9 +106,12 @@ backup_rsync_volume() {
     log_error "Cannot inspect volume $volume"
     return 1
   fi
-  local dest="$BACKUP_ROOT/$share/$HOSTNAME_DIR"
+  # Per-volume subdir so two volumes can share the same NFS share
+  # without --delete on the second clobbering the first (entephoto
+  # garage-data + garage-meta both live under `photos/<host>/`).
+  local dest="$BACKUP_ROOT/$share/$HOSTNAME_DIR/$volume"
   mkdir -p "$dest"
-  log "  Rsync backup: $volume → $share/$HOSTNAME_DIR"
+  log "  Rsync backup: $volume → $share/$HOSTNAME_DIR/$volume"
   # --no-owner --no-group --numeric-ids: NFS all_squash maps every UID to the
   #   share's anon user, so chowns from rsync would fail. We deliberately
   #   drop ownership preservation here. On restore, container-native UIDs


### PR DESCRIPTION
Two rsync volumes sharing the same NAS share clobbered each other under `rsync --delete`. Surfaced by the entephoto Garage migration's `garage-data` + `garage-meta` both targeting `backup-photos`.

Adds `/$volume` to the rsync destination + restore source. Existing single-volume-per-share backups re-lay-out on next run; old root-level files become orphans for manual cleanup.

Tested on homeserver2: pre-fix backup wrote only meta (3.6 MB total), post-fix expected to write data (1.1 GB) + meta (3.6 MB) under separate subdirs.