### PR TITLE
caddy: restore-certs helper

### DIFF
--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -166,3 +166,29 @@ When reverse proxy is enabled, pairs with
 [pihole](../pihole/README.md) for the LAN-side wildcard DNS record
 (so `*.<caddy_domain>` resolves to the homeserver's LAN IP without
 going to public DNS).
+
+## Operational helpers
+
+Run via `homeserver.sh caddy <action>` (the dispatcher lists all
+helpers if you omit the action):
+
+- `restore-certs [HOST] [-- IMPL_ARGS]` — splice the LE-issued cert
+  tree out of the most recent `caddy-data` tarball on NAS and into
+  the freshly-deployed `caddy-data` volume. Useful after a
+  `clean-host.sh` + reinstall cycle: it lets you skip a fresh ACME
+  issuance (and dodges LE's 5-certs-per-week rate limit) by reusing
+  the certs that were valid before the wipe.
+
+  Only `/data/caddy/certificates/` is restored — the Caddyfile and
+  the rest of the volume's runtime state are left as the new install
+  rendered them, so no risk of reverting config drift.
+
+  Impl flags (after `--`):
+  - `--from PATH` — restore from a specific tarball instead of the
+    newest one. Mostly useful when the newest tar was taken under
+    staging CA and you want the prior prod tar.
+  - `--dry-run` — print which tarball would be used and which certs
+    it contains (CN, issuer, expiry) without touching the volume.
+
+  Reports the restored cert's subject + issuer + expiry on completion
+  so you can confirm you got a real cert and not a staging one.

--- a/roles/caddy/scripts/_restore-certs.sh
+++ b/roles/caddy/scripts/_restore-certs.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Restore Caddy's cert tree from the most recent caddy-data tarball.
+#
+# Why a narrow helper instead of the generic restore: caddy-data also
+# contains runtime state Caddy regenerates from inventory on every
+# deploy, so a full-volume restore would silently revert fresh config.
+# This script touches *only* /data/caddy/certificates/ — the LE certs
+# and ACME account keys — leaving everything else alone.
+set -euo pipefail
+
+DRY_RUN=false
+FROM=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --from) FROM="$2"; shift 2 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+info() { printf '==> %s\n' "$*"; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "must run as root (invoke via 'homeserver.sh caddy restore-certs')"
+
+# Pull NAS coords from the deployed backup script so we don't duplicate
+# inventory plumbing here.
+BACKUP_SCRIPT=/usr/local/bin/home-server-backup.sh
+[[ -f $BACKUP_SCRIPT ]] || die "no $BACKUP_SCRIPT — has the backup role been deployed?"
+
+NAS_HOST=$(grep -m1 '^NAS_HOST=' "$BACKUP_SCRIPT" | cut -d'"' -f2)
+NAS_VOLUME=$(grep -m1 '^NAS_VOLUME=' "$BACKUP_SCRIPT" | cut -d'"' -f2)
+HOSTNAME_DIR=$(grep -m1 '^HOSTNAME_DIR=' "$BACKUP_SCRIPT" | cut -d'"' -f2)
+[[ -n $NAS_HOST && -n $NAS_VOLUME && -n $HOSTNAME_DIR ]] \
+    || die "failed to parse NAS coords from $BACKUP_SCRIPT"
+
+# Mount the backup-tar share read-only.
+MOUNT=/mnt/restore-caddy
+mkdir -p "$MOUNT"
+trap 'umount "$MOUNT" 2>/dev/null || true; rmdir "$MOUNT" 2>/dev/null || true' EXIT
+
+info "Mounting $NAS_HOST:$NAS_VOLUME/backup-tar (ro) at $MOUNT"
+mount -t nfs -o "ro,noatime,hard,_netdev,vers=4" \
+    "$NAS_HOST:$NAS_VOLUME/backup-tar" "$MOUNT"
+
+# Pick the tarball.
+TAR_DIR="$MOUNT/$HOSTNAME_DIR/caddy-data"
+[[ -d $TAR_DIR ]] || die "no caddy-data backups for $HOSTNAME_DIR at $TAR_DIR"
+
+if [[ -z $FROM ]]; then
+    FROM=$(ls -1t "$TAR_DIR"/caddy-data-*.tar.gz 2>/dev/null | head -n1)
+    [[ -n $FROM ]] || die "no caddy-data-*.tar.gz found in $TAR_DIR"
+fi
+info "Source tarball: $FROM"
+
+# Extract just the cert tree to a tmp dir.
+SCRATCH=$(mktemp -d)
+trap 'umount "$MOUNT" 2>/dev/null || true; rmdir "$MOUNT" 2>/dev/null || true; rm -rf "$SCRATCH"' EXIT
+
+info "Extracting caddy/certificates/ to $SCRATCH"
+# podman volume export tars the _data/ contents flat — so /caddy/... at root.
+tar -xzf "$FROM" -C "$SCRATCH" caddy/certificates || \
+    die "tar extract failed — does the tar contain caddy/certificates/?"
+
+[[ -d "$SCRATCH/caddy/certificates" ]] || die "extracted tree missing caddy/certificates/"
+
+# Report what we found — issuer + expiry of any leaf cert.
+info "Restored cert summary:"
+find "$SCRATCH/caddy/certificates" -name '*.crt' -not -path '*/users/*' | while read -r crt; do
+    subj=$(openssl x509 -in "$crt" -noout -subject 2>/dev/null | sed 's/^subject=//')
+    iss=$(openssl x509 -in "$crt" -noout -issuer  2>/dev/null | sed 's/^issuer=//')
+    end=$(openssl x509 -in "$crt" -noout -enddate 2>/dev/null | sed 's/^notAfter=//')
+    printf '    %s\n      issuer: %s\n      expires: %s\n' "$subj" "$iss" "$end"
+done
+
+if $DRY_RUN; then
+    info "DRY RUN — not touching the live volume"
+    exit 0
+fi
+
+# Splice into the live volume. webproxy is the rootless user that owns Caddy.
+LIVE=$(su - webproxy -c "podman volume inspect caddy-data --format '{{.Mountpoint}}'") \
+    || die "caddy-data volume not present — has the caddy role been deployed?"
+info "Target volume: $LIVE"
+
+WEBPROXY_UID=$(id -u webproxy)
+WEBPROXY_GID=$(id -g webproxy)
+
+info "Stopping caddy.service"
+sudo -u webproxy XDG_RUNTIME_DIR="/run/user/$WEBPROXY_UID" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$WEBPROXY_UID/bus" \
+    systemctl --user stop caddy.service || true
+
+mkdir -p "$LIVE/caddy"
+info "Rsyncing certificates/ into live volume"
+# --delete scoped to the certificates subdir — leaves locks/, ocsp/ etc.
+# untouched so Caddy regenerates them naturally on restart.
+rsync -a --delete \
+    "$SCRATCH/caddy/certificates/" "$LIVE/caddy/certificates/"
+
+# Inside the container, files must be owned by root (uid 0) which maps
+# to the rootless webproxy uid on the host. Use podman unshare to chown
+# across the user namespace — same pattern as playbooks/tasks/restore_generic.yml.
+info "Re-owning restored tree inside webproxy's user namespace"
+su - webproxy -c "podman unshare chown -R 0:0 '$LIVE/caddy/certificates'"
+
+info "Starting caddy.service"
+sudo -u webproxy XDG_RUNTIME_DIR="/run/user/$WEBPROXY_UID" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$WEBPROXY_UID/bus" \
+    systemctl --user start caddy.service
+
+# Best-effort liveness check.
+for _ in 1 2 3 4 5; do
+    sleep 1
+    state=$(sudo -u webproxy XDG_RUNTIME_DIR="/run/user/$WEBPROXY_UID" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$WEBPROXY_UID/bus" \
+        systemctl --user is-active caddy.service 2>/dev/null || true)
+    [[ $state == active ]] && break
+done
+info "caddy.service state: ${state:-unknown}"
+info "Done."

--- a/roles/caddy/scripts/restore-certs
+++ b/roles/caddy/scripts/restore-certs
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Restore only the Caddy TLS cert tree from the latest nightly tar backup.
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: homeserver.sh caddy restore-certs [HOST] [-- IMPL_ARGS...]
+
+After a clean-host + reinstall, lifts /data/caddy/certificates/ (LE certs
++ ACME account keys) out of the most recent caddy-data tarball on NAS and
+splices it into the freshly-deployed caddy-data volume. The Caddyfile and
+any other runtime state stay as the new install rendered them.
+
+HOST defaults to "homeserver". Anything after a literal "--" is forwarded
+to the on-target implementation. Useful impl flags:
+    --from PATH     Specific tarball to restore from (default: newest).
+    --dry-run       Show what would be restored; don't touch the volume.
+
+Examples:
+    homeserver.sh caddy restore-certs
+    homeserver.sh caddy restore-certs homeserver2
+    homeserver.sh caddy restore-certs homeserver2 -- --from /mnt/backup/tar/homeserver2/caddy-data/caddy-data-20260520-020000.tar.gz
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+esac
+
+TARGET="${1:-homeserver}"
+shift || true
+
+IMPL_ARGS=""
+if [[ "${1:-}" == "--" ]]; then
+    shift
+    IMPL_ARGS="$*"
+elif [[ $# -gt 0 ]]; then
+    echo "ERROR: unexpected arg(s): $*" >&2
+    echo "Pass impl flags after a literal --" >&2
+    usage
+    exit 2
+fi
+
+cd "${HOMESERVER_REPO_DIR:?HOMESERVER_REPO_DIR must be set — invoke via homeserver.sh}"
+self_dir="$(dirname "$(readlink -f "$0")")"
+
+exec ansible "$TARGET" --become \
+    -m script -a "$self_dir/_restore-certs.sh $IMPL_ARGS"


### PR DESCRIPTION
## Summary

New service helper: \`homeserver.sh caddy restore-certs [HOST]\`

Lifts the LE cert tree (and ACME account keys) out of the most recent \`caddy-data\` nightly tarball on NAS and splices it into a freshly-deployed \`caddy-data\` volume. Leaves the rest of the volume alone, so the Caddyfile and runtime state the new install rendered stay as-is.

Motivation: test-box rebuild cycles on \`homeserver2\` wipe \`caddy-data\` and burn LE's 5-duplicate-certs/week budget on every reinstall. We've been working around this with LE staging CA (fake-CA browser warning). With this helper, a reinstall + \`homeserver.sh caddy restore-certs\` brings the prod cert back from the previous night's tar — zero ACME requests, real green padlock.

Bonus: gives the prod host (\`homeserver\`) a fast-recovery path if its storage ever gets nuked.

## Test plan

On \`homeserver2\`:

- [ ] Take a fresh backup so the tar contains a current cert.
- [ ] Run \`homeserver.sh caddy restore-certs homeserver2 -- --dry-run\` — confirms it finds the right tarball + reports CN/issuer/expiry without touching the volume.
- [ ] Flip \`caddy_acme_ca\` to prod, deploy, take backup, flip back to staging, redeploy → \`caddy-data\` now has staging certs.
- [ ] Run \`homeserver.sh caddy restore-certs homeserver2 -- --from <prior prod tarball>\` → live volume gets prod cert back, caddy restarts, Firefox green padlock.

## Out of scope

- \`--keep-caddy\` flag on \`clean-host.sh\` (separate change).
- Automating restore as part of \`homeserver.sh install\` (operator-driven for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)