### PR TITLE
backup: per-host NAS share + script-triggered Btrfs snapshots

### DIFF
--- a/docs/NAS-Setup.md
+++ b/docs/NAS-Setup.md
@@ -1,0 +1,158 @@
+# NAS setup (Synology, DSM 7.x)
+
+One-time operator setup so the project's backup script can write to
+the NAS, and trigger a consistency snapshot after each successful
+nightly run. Repeat for every home-server host.
+
+Prereq: NAS volume must be **Btrfs** (Storage Manager → Storage shows
+the underlying filesystem). Without Btrfs there are no snapshots.
+
+## 1. Create a per-host shared folder
+
+DSM → Control Panel → Shared Folder → **Create**:
+
+| Field | Value |
+|---|---|
+| Name | `backup-<host>`  (e.g. `backup-homeserver`, `backup-homeserver2`) |
+| Volume | the Btrfs volume |
+| Description | "Home-server backup target — <host>" |
+| Hide this shared folder in 'My Network Places' | yes (preference) |
+| Enable Recycle Bin | **no** — useless for NFS deletes, just wastes space |
+| Encrypt this shared folder | no (operator preference; backups already include vault secrets) |
+
+After create → **Edit** → **NFS Permissions** → Create:
+| Field | Value |
+|---|---|
+| Hostname or IP | the host's IP (e.g. `192.168.1.231`) |
+| Privilege | Read/Write |
+| Squash | `Map all users to admin` *(no_root_squash equivalent — needed because the backup script runs as root)* |
+| Security | `sys` |
+| Enable async | yes |
+| Allow connections from non-privileged ports | no |
+
+Repeat the NFS rule for each home-server host that should write to
+this share (typically only one — the host the share is named after).
+
+## 2. Install Snapshot Replication
+
+Package Center → install **Snapshot Replication**. No configuration
+yet — we set policy in step 3.
+
+## 3. Per-share snapshot policy
+
+Snapshot Replication → **Snapshots** tab → select `backup-<host>` →
+**Settings**:
+
+- **Schedule** tab — disable the hourly default. Add one custom rule:
+  - Daily at **05:00** (well after the 02:00 backup completes —
+    generous margin for slow nights). This is the fallback in case
+    the script-triggered snapshot fails.
+- **Retention** tab — **Advanced**:
+  - Latest snapshots: **24**
+  - Daily: **7**
+  - Weekly: **4**
+
+Save. Retention applies to all snapshots on the share — both DSM-
+scheduled and script-triggered.
+
+## 4. NAS-side user for the snapshot trigger
+
+Control Panel → User & Group → **Create**:
+
+| Field | Value |
+|---|---|
+| Username | `homeserver-backup` |
+| Password | (random, doesn't matter — we use SSH key auth) |
+| Description | "Home-server backup script — snapshot trigger only" |
+| Disallow the user to change account password | yes |
+| User groups | `users` (default) |
+
+Application permissions → restrict everything (no DSM web, no File
+Station, etc.). Only SSH is needed.
+
+## 5. Enable SSH on the NAS
+
+Control Panel → Terminal & SNMP → **Enable SSH service**. Default port
+22 is fine unless you've moved it.
+
+## 6. Sudoers entry for the snapshot CLI
+
+`synosharesnapshot` requires root. SSH in to the NAS as your admin
+user one time and add a sudoers drop-in for the new user — one line
+per share to keep the wildcard tight:
+
+```
+echo 'homeserver-backup ALL=(root) NOPASSWD: /usr/syno/sbin/synosharesnapshot create backup-homeserver*' \
+    | sudo tee /etc/sudoers.d/snapshot-trigger > /dev/null
+echo 'homeserver-backup ALL=(root) NOPASSWD: /usr/syno/sbin/synosharesnapshot create backup-homeserver2*' \
+    | sudo tee -a /etc/sudoers.d/snapshot-trigger > /dev/null
+sudo chmod 0440 /etc/sudoers.d/snapshot-trigger
+```
+
+(Add one line per home-server host. The trailing `*` lets the
+hardcoded `--retry 3 desc=…` flags through without weakening the
+share-name lock.)
+
+## 7. SSH key pair per host
+
+On each home-server host (as root):
+
+```bash
+ssh-keygen -t ed25519 -N '' -C "$(hostname)-backup-snapshot" -f /root/.ssh/nas-snapshot
+chmod 0400 /root/.ssh/nas-snapshot
+cat /root/.ssh/nas-snapshot.pub
+```
+
+Copy the printed public key. On the NAS, append it to
+`homeserver-backup`'s `authorized_keys` with the locked command
+matching that host's share. SSH in to the NAS, then:
+
+```bash
+mkdir -p /var/services/homes/homeserver-backup/.ssh
+chmod 0700 /var/services/homes/homeserver-backup/.ssh
+chown -R homeserver-backup:users /var/services/homes/homeserver-backup/.ssh
+
+# Edit and append one line per host (replace the AAAA… key blob):
+sudo tee -a /var/services/homes/homeserver-backup/.ssh/authorized_keys <<'EOF'
+command="sudo /usr/syno/sbin/synosharesnapshot create backup-homeserver --retry 3 desc=home-server-backup",no-port-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA… homeserver
+command="sudo /usr/syno/sbin/synosharesnapshot create backup-homeserver2 --retry 3 desc=home-server-backup",no-port-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA… homeserver2
+EOF
+
+sudo chown homeserver-backup:users /var/services/homes/homeserver-backup/.ssh/authorized_keys
+sudo chmod 0600 /var/services/homes/homeserver-backup/.ssh/authorized_keys
+```
+
+(DSM may require enabling "User Home" service first — Control Panel →
+User & Group → Advanced → User Home.)
+
+## 8. Smoke test from the host
+
+```bash
+ssh -i /root/.ssh/nas-snapshot homeserver-backup@nas
+```
+
+Should print a `Snapshot created` line and exit 0. Snapshot Replication
+in DSM should immediately show one new snapshot in the share's history.
+
+If it fails, check:
+- `sudo tail /var/log/auth.log` on the NAS for the SSH attempt
+- `synosharesnapshot list backup-<host>` to confirm whether it created
+  anything
+
+## 9. Inventory wiring
+
+In `inventory/host_vars/<host>/main.yml`:
+
+```yaml
+backup_nas_snapshot_user: homeserver-backup
+# backup_nas_snapshot_key_path: defaults to /root/.ssh/nas-snapshot
+```
+
+Without `backup_nas_snapshot_user`, the snapshot-trigger step is
+skipped (the deploy is otherwise identical).
+
+## Future hosts
+
+For each new home-server host: repeat steps 1 (create share + NFS
+perms), 6 (sudoers — append one line), 7 (key + authorized_keys —
+append one line), 9 (inventory).

--- a/playbooks/backup-layout-migrate.yml
+++ b/playbooks/backup-layout-migrate.yml
@@ -1,0 +1,136 @@
+---
+# One-off helper for hosts already running the old NAS backup layout
+# (per-data-class shares: backup-tar, backup-photos, backup-<share>…).
+#
+# Switches to the new per-host layout (`backup-<host>/<app>/{tar,rsync,pgdump}/…`).
+# No automatic NAS-side file moves — DSM has no SSH/API path that's
+# both reliable and safe for a generic mv. Instead this playbook
+# prints the exact rename commands the operator should run on the NAS,
+# pauses, then redeploys the backup role and triggers one fresh run.
+
+- name: Migrate NAS backup layout to per-host shares
+  hosts: all
+  gather_facts: false
+  become: true
+
+  vars_prompt:
+    - name: confirm
+      prompt: |
+        Migrate the target host(s) from the per-data-class NAS backup layout
+        (backup-tar, backup-photos, …) to the per-host layout
+        (backup-<host>/<app>/…).
+
+        Pre-flight (do BEFORE typing yes):
+        1. NAS-side shared folder `backup-<host>` exists for every target,
+           NFS-exported to that host with no_root_squash.
+        2. SSH key + sudoers entry per docs/NAS-Setup.md installed (if you
+           want the snapshot trigger).
+
+        Continue?
+      private: false
+      default: "no"
+
+  pre_tasks:
+    - name: Abort unless confirmed
+      ansible.builtin.fail:
+        msg: "Aborting — answer 'yes' to proceed."
+      when: confirm | lower not in ['yes', 'y']
+
+    - name: Announce per-host start
+      ansible.builtin.debug:
+        msg: "Migrating {{ inventory_hostname }} → backup-{{ inventory_hostname }}"
+
+  tasks:
+    # ----------------------------------------------------------------
+    # Phase 1 — stop the timer so no nightly run lands mid-migration
+    # ----------------------------------------------------------------
+    - name: Stop + disable the backup timer
+      ansible.builtin.systemd_service:
+        name: home-server-backup.timer
+        enabled: false
+        state: stopped
+      failed_when: false
+
+    # ----------------------------------------------------------------
+    # Phase 2 — point the operator at the NAS-side moves
+    # ----------------------------------------------------------------
+    - name: Print NAS-side migration commands
+      ansible.builtin.debug:
+        msg: |
+          ============================================================
+          MANUAL STEP — run on the NAS as an admin user:
+
+          NAS=/volume1
+          NEW=$NAS/backup-{{ inventory_hostname }}
+          mkdir -p "$NEW"
+
+          # Existing tar tree (covers tar volumes + pgdumps for this host):
+          # /volume1/backup-tar/{{ inventory_hostname }}/<volume_or_pgdump-…>/
+          # The new layout segments by app, but we don't know which app
+          # owned which volume from the NAS side alone — easiest path is to
+          # re-organise by listing volumes per app in your role manifests,
+          # OR (recommended) just leave the old tree as-is for ~7 days as
+          # rollback insurance and let the new backup populate the new tree
+          # from scratch.
+
+          # Rsync trees, per share that exists today:
+          for share in photos jellyfin-media nextcloud paperless-media syncthing; do
+              SRC="$NAS/backup-$share/{{ inventory_hostname }}"
+              [ -d "$SRC" ] || continue
+              for vol in "$SRC"/*; do
+                  vol_name=$(basename "$vol")
+                  # Look up which app this volume belongs to in your repo's
+                  # role manifests, then:
+                  #   mkdir -p $NEW/<app>/rsync
+                  #   mv "$vol" $NEW/<app>/rsync/
+                  echo "TODO: move $vol → \$NEW/<app>/rsync/$vol_name"
+              done
+          done
+
+          ALTERNATIVE: skip the moves entirely. After today's backup the
+          new layout is populated from scratch and the old shares are
+          orphan trees you can delete after one verified backup cycle.
+          ============================================================
+
+    - name: Pause for operator confirmation of NAS moves (or accept fresh-start)
+      ansible.builtin.pause:
+        prompt: "Press ENTER when you've decided (moved files OR chosen fresh-start). Ctrl-C to abort."
+
+    # ----------------------------------------------------------------
+    # Phase 3 — redeploy the backup role with the new template
+    # ----------------------------------------------------------------
+    - name: Re-render the backup script with the new layout
+      ansible.builtin.include_role:
+        name: backup
+
+    # ----------------------------------------------------------------
+    # Phase 4 — run one backup now to populate the new layout
+    # ----------------------------------------------------------------
+    - name: Trigger one backup
+      ansible.builtin.systemd_service:
+        name: home-server-backup.service
+        state: started
+
+    - name: Final guidance
+      ansible.builtin.debug:
+        msg: |
+          ============================================================
+          Verification (run from the workstation):
+
+          ssh {{ inventory_hostname }} sudo tail -50 /var/log/home-server-backup.log
+
+          Expected: "=== Backup finished (0 errors) ===" plus a
+          "NAS snapshot trigger: ok" line if the snapshot user is set.
+
+          Then on the NAS check the new layout exists:
+            ls -la /volume1/backup-{{ inventory_hostname }}/
+
+          After one verified backup cycle (~24h), delete the orphan
+          trees on the NAS:
+            /volume1/backup-tar/{{ inventory_hostname }}/
+            /volume1/backup-photos/{{ inventory_hostname }}/
+            /volume1/backup-jellyfin-media/{{ inventory_hostname }}/
+            /volume1/backup-nextcloud/{{ inventory_hostname }}/
+            /volume1/backup-paperless-media/{{ inventory_hostname }}/
+            /volume1/backup-syncthing/{{ inventory_hostname }}/
+          ============================================================

--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -4,47 +4,31 @@
 # Expected svc keys:
 #   service_user   — Linux username (key into my_linux_users for UID)
 #   service_unit   — systemd --user unit to stop/start
-#   volumes[]      — list of {name, method, nas_share?, restore_opt_in?}
+#   volumes[]      — list of {name, method, restore_opt_in?}
 #   databases[]    — optional list of {container, db_user, db_name, method}
 #   post_restore_tasks — optional role-relative path for post-restore hook
 #   _role_name     — injected by the aggregation set_fact
+#
+# Reads from per-host NAS layout:
+#   nas:/<vol>/backup-<host>/<app>/{tar,rsync,pgdump}/<volume_or_container>/
 
-# --- Mount NAS shares ---
-- name: "{{ svc._role_name | upper }}: mount NAS tar share"
+# --- Mount the host's NAS share ---
+- name: "{{ svc._role_name | upper }}: mount NAS host share"
   block:
     - ansible.builtin.file:
-        path: "{{ restore_root }}/tar"
+        path: "{{ restore_root }}"
         state: directory
     - ansible.posix.mount:
-        path: "{{ restore_root }}/tar"
-        src: "{{ nas_host }}:{{ nas_volume }}/backup-tar"
+        path: "{{ restore_root }}"
+        src: "{{ nas_host }}:{{ nas_volume }}/backup-{{ inventory_hostname }}"
         fstype: nfs
         opts: "{{ nfs_opts }}"
         state: ephemeral
-
-- name: "{{ svc._role_name | upper }}: mount NAS rsync shares"
-  block:
-    - ansible.builtin.file:
-        path: "{{ restore_root }}/{{ item.nas_share }}"
-        state: directory
-      loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
-      loop_control:
-        label: "{{ item.nas_share }}"
-    - ansible.posix.mount:
-        path: "{{ restore_root }}/{{ item.nas_share }}"
-        src: "{{ nas_host }}:{{ nas_volume }}/backup-{{ item.nas_share }}"
-        fstype: nfs
-        opts: "{{ nfs_opts }}"
-        state: ephemeral
-      loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
-      loop_control:
-        label: "{{ item.nas_share }}"
-  when: svc.volumes | selectattr('method', 'equalto', 'rsync') | list | length > 0
 
 # --- Find latest tar backups ---
 - name: "{{ svc._role_name | upper }}: find latest tar backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/tar/{{ inventory_hostname }}/{{ item.name }}/*.tar.gz | head -1
+    ls -t {{ restore_root }}/{{ svc._role_name }}/tar/{{ item.name }}/*.tar.gz | head -1
   register: _tar_latest
   loop: "{{ svc.volumes | selectattr('method', 'equalto', 'tar') | list }}"
   loop_control:
@@ -54,7 +38,7 @@
 # --- Find latest pgdump backups ---
 - name: "{{ svc._role_name | upper }}: find latest pgdump backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/tar/{{ inventory_hostname }}/pgdump-{{ item.container }}/*.sql.gz | head -1
+    ls -t {{ restore_root }}/{{ svc._role_name }}/pgdump/{{ item.container }}/*.sql.gz | head -1
   register: _pgdump_latest
   loop: "{{ svc.databases | default([]) }}"
   loop_control:
@@ -92,7 +76,7 @@
         --format='{% raw %}{{.Mountpoint}}{% endraw %}')
     sudo -u {{ svc.service_user }} podman unshare rsync -a --delete \
         --no-owner --no-group --numeric-ids \
-        "{{ restore_root }}/{{ item.nas_share }}/{{ inventory_hostname }}/{{ item.name }}/" "$MP/"
+        "{{ restore_root }}/{{ svc._role_name }}/rsync/{{ item.name }}/" "$MP/"
   loop: >-
     {{ svc.volumes
        | selectattr('method', 'equalto', 'rsync')
@@ -117,17 +101,8 @@
     file: "{{ playbook_dir }}/../roles/{{ svc._role_name }}/tasks/{{ svc.post_restore_tasks }}"
   when: svc.post_restore_tasks is defined
 
-# --- Unmount NAS shares ---
-- name: "{{ svc._role_name | upper }}: unmount NAS rsync shares"
+# --- Unmount the host's NAS share ---
+- name: "{{ svc._role_name | upper }}: unmount NAS host share"
   ansible.posix.mount:
-    path: "{{ restore_root }}/{{ item.nas_share }}"
-    state: unmounted
-  loop: "{{ svc.volumes | selectattr('method', 'equalto', 'rsync') | list }}"
-  loop_control:
-    label: "{{ item.nas_share }}"
-  when: svc.volumes | selectattr('method', 'equalto', 'rsync') | list | length > 0
-
-- name: "{{ svc._role_name | upper }}: unmount NAS tar share"
-  ansible.posix.mount:
-    path: "{{ restore_root }}/tar"
+    path: "{{ restore_root }}"
     state: unmounted

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -1,8 +1,14 @@
 # backup
 
 Deploys an autonomous nightly backup of every other role's volumes to
-an NFS share on a NAS. Runs as a `systemd` service driven by a timer
-— no Ansible needed once installed.
+a single per-host NFS share on a NAS. Runs as a `systemd` service
+driven by a timer — no Ansible needed once installed.
+
+After a successful run, the script triggers a Synology Btrfs snapshot
+of the host's NAS share (via SSH) so off-site copies are taken at a
+moment of known point-in-time consistency across every volume of every
+service. On failure, an email alert is sent via the project SMTP
+config.
 
 ## Container image
 
@@ -15,12 +21,15 @@ rootless container volumes via `podman unshare`.
 
 ## Variables
 
-| Variable              | Default       | Purpose                                             |
-|-----------------------|---------------|-----------------------------------------------------|
-| `backup_time`         | `02:00:00`    | systemd `OnCalendar` time-of-day (HH:MM:SS).        |
-| `backup_nas_hostname` | `nas`         | Short hostname pinned in `/etc/hosts`.              |
-| `backup_nas_ip`       | `192.168.x.x` | NAS IP — pinned in `/etc/hosts` so backups don't depend on DNS. |
-| `backup_nas_volume`   | `/volume1`    | Path prefix on the NAS (Synology uses `/volume1`).  |
+| Variable                       | Default                | Purpose                                                            |
+|--------------------------------|------------------------|--------------------------------------------------------------------|
+| `backup_time`                  | `02:00:00`             | systemd `OnCalendar` time-of-day (HH:MM:SS).                       |
+| `backup_nas_hostname`          | `nas`                  | Short hostname pinned in `/etc/hosts`.                             |
+| `backup_nas_ip`                | `192.168.x.x`          | NAS IP — pinned in `/etc/hosts` so backups don't depend on DNS.    |
+| `backup_nas_volume`            | `/volume1`             | Path prefix on the NAS (Synology uses `/volume1`).                 |
+| `backup_alert_recipient`       | `{{ smtp_from }}`      | Email address that receives failure alerts.                        |
+| `backup_nas_snapshot_user`     | *empty (off)*          | SSH username on the NAS for the post-backup snapshot trigger. Empty = no snapshot. |
+| `backup_nas_snapshot_key_path` | `/root/.ssh/nas-snapshot` | Path to the private key authenticating as `backup_nas_snapshot_user`. |
 
 Override all NAS variables per-host in inventory.
 
@@ -30,11 +39,41 @@ Override all NAS variables per-host in inventory.
 
 ## Secrets
 
-None.
+`smtp_password` is read from the project-level `smtp_*` vault entries
+(shared with Ente, Paperless, Nextcloud) and rendered into the deployed
+backup script. File mode is `0700` root-owned to keep it out of
+unprivileged hands; same trust boundary as the rendered `museum.yaml`.
 
 ## Firewall ports
 
-None. Backup traffic is outbound NFS on the LAN.
+None. Backup traffic is outbound NFS + SSH on the LAN.
+
+## NAS layout
+
+Every host writes to **one dedicated NFS share** — `backup-<host>`. The
+share is one Btrfs subvolume, so one snapshot captures everything that
+host has backed up. Layout inside the share:
+
+```
+backup-<host>/
+  <app>/
+    tar/
+      <volume>/<volume>-YYYYMMDD-HHMMSS.tar.gz
+    rsync/
+      <volume>/...
+    pgdump/
+      <container>/<container>-YYYYMMDD-HHMMSS.sql.gz
+```
+
+`<app>` is the role name (entephoto, paperless-ngx, …). One share per
+host eliminates the prior cross-share consistency problem (DB dump on
+`backup-tar` could end up out of sync with rsync mirror on
+`backup-photos` since DSM snapshots were per-share and unaware of the
+backup window).
+
+See [docs/NAS-Setup.md](../../docs/NAS-Setup.md) for the one-time NAS
+configuration (per-host share, NFS perms, snapshot policy, SSH key for
+the snapshot trigger).
 
 ## Backup methods
 
@@ -42,114 +81,122 @@ The script implements three methods. Each service's volumes are
 assigned the right one based on size, mutability, and whether the
 data is a database.
 
-### Per-host segmentation
-
-Every backup path is prefixed with the host's `inventory_hostname`,
-so multiple homeservers (e.g. prod + test) can share the same NAS
-without colliding. Layout:
-
-```
-backup-tar/<hostname>/<volume>/<volume>-YYYYMMDD-HHMMSS.tar.gz
-backup-tar/<hostname>/pgdump-<container>/<container>-YYYYMMDD-HHMMSS.sql.gz
-backup-<share>/<hostname>/...
-```
-
-Restore reads the same paths via `inventory_hostname`, so each
-host always restores its own data.
-
 ### 1. `tar` — `podman volume export | gzip`
 
 Used for **small, mostly-config volumes** where keeping a daily
 history is cheap and useful.
 
-- The container is stopped first (so the on-disk state is consistent).
+- The container is stopped first (consistent on-disk state).
 - `podman volume export <vol>` streams the volume contents as tar,
-  piped through `gzip`, and saved as
-  `<vol>-YYYYMMDD-HHMMSS.tar.gz` on the NAS.
-- **Retention:** the last 7 daily snapshots are kept; older ones
-  are deleted.
-- **Restore:** re-create the empty volume (re-run the role's
-  playbook), then
-  ```bash
-  gunzip -c <snapshot>.tar.gz | sudo -u <user> podman volume import <vol> -
-  ```
+  piped through `gzip`, saved as
+  `backup-<host>/<app>/tar/<vol>/<vol>-YYYYMMDD-HHMMSS.tar.gz`.
+- **Retention:** last 7 daily snapshots are kept on the share.
+  Older NAS-side snapshots (Snapshot Replication) extend history
+  further.
+- **Restore:** see [Restore](#restore).
 
-Used for: pihole (`systemd-pihole-etc`, `systemd-pihole-dnsmasq`),
-syncthing config (`systemd-syncthing-config`), jukebox config + playlist
-(`jukebox-server-config`, `jukebox-server-playlist`),
-entephoto museum config (`entephoto-museum-config`).
-
-### 2. `rsync` — mirror to a dedicated NFS share
+### 2. `rsync` — file-level mirror
 
 Used for **large data volumes** where a full daily tarball would be
 wasteful and history isn't needed (the data is the data).
 
 - The container is stopped first.
 - `podman volume inspect` gives the mount path on the host.
-- `rsync -rltD --delete --no-owner --no-group --numeric-ids`
-  mirrors the volume's contents into a dedicated share on the NAS
-  (`backup-photos`, `backup-syncthing`, `backup-xchange`,
-  `backup-music`).
-- Ownership is **not** preserved — NFS `all_squash` would reject
-  chowns anyway, and rootless container UIDs differ between hosts.
-  On restore, ownership is re-applied with `podman unshare chown`.
-- **No retention / no history** — the share always reflects the
-  latest mirror. Pair with NAS-side snapshots (Btrfs, ZFS, Synology
-  Snapshot Replication) if you want point-in-time recovery.
-- **Restore:**
-  ```bash
-  rsync -a --no-owner --no-group --numeric-ids \
-      /mnt/backup/<share>/<hostname>/ <volume mount path>/
-  sudo -u <user> podman unshare chown -R 0:0 <volume mount path>
-  ```
-
-Used for: syncthing data (`systemd-syncthing-data` → `syncthing`),
-jukebox music (`jukebox-server-music` → `music`), entephoto MinIO
-(`entephoto-minio-data` → `photos`).
+- `rsync -rltD --delete --no-owner --no-group --numeric-ids` mirrors
+  the volume's contents into `backup-<host>/<app>/rsync/<vol>/`.
+- Ownership is **not** preserved (NFS `all_squash` rejects chowns;
+  rootless container UIDs differ per host). On restore, ownership is
+  re-applied with `podman unshare chown`.
+- **No retention on the live mirror** — current state only. Pair with
+  NAS-side Btrfs snapshots for point-in-time recovery.
 
 ### 3. `pgdump` — logical PostgreSQL dump
 
-Used for **PostgreSQL databases**, where the right unit of backup
-is a SQL dump, not the on-disk files.
+Used for **PostgreSQL databases**.
 
 - Runs **with the container up** (`pg_dump` is a consistent logical
   snapshot, no need to stop the database).
-- `podman exec <container> pg_dump -U <user> <db>` is piped through
-  `gzip` and saved as `<container>-YYYYMMDD-HHMMSS.sql.gz`.
-- **Retention:** last 7 daily snapshots; older ones deleted.
-- **Restore:**
-  ```bash
-  gunzip -c <snapshot>.sql.gz \
-      | sudo -u <user> podman exec -i <container> psql -U <user> <db>
-  ```
+- `podman exec <container> pg_dump …` is piped through gzip and saved
+  as `backup-<host>/<app>/pgdump/<container>/<container>-YYYYMMDD-HHMMSS.sql.gz`.
+- **Retention:** last 7 daily snapshots on the share.
 
-Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
+## Cross-volume consistency (and why)
+
+Each role's backup_manifest may declare multiple volumes plus a
+database. The script stops the service, dumps the DB, copies all tar
+volumes, rsyncs all rsync volumes, then starts the service. During
+that window the on-disk state across all of the service's volumes is
+mutually consistent.
+
+The post-backup NAS snapshot fires immediately after this — capturing
+everything written in this run as one atomic point-in-time across the
+host's entire `backup-<host>` share. A restore against any snapshot
+picks a known-good cross-volume state, eliminating the "DB rows
+reference object keys not present in the rsync mirror" failure mode.
+
+## NAS snapshot trigger
+
+After the last role is processed (and only when `$ERRORS -eq 0`), the
+script SSHs to the NAS:
+
+```bash
+ssh -i $NAS_SNAPSHOT_KEY $NAS_SNAPSHOT_USER@$NAS_HOST
+```
+
+The NAS user's `~/.ssh/authorized_keys` locks that connection to a
+single command (per host, hardcoded share):
+
+```
+command="sudo /usr/syno/sbin/synosharesnapshot create backup-<host> --retry 3 desc=home-server-backup",no-port-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA…
+```
+
+If the trigger fails (NAS rebooting, SSH key broken, etc.), the script
+logs an error but exits successfully — the data is already on the NAS;
+only the consistency marker is missing. A DSM-scheduled fallback
+snapshot at 05:00 (operator-configured) catches up.
+
+Set `backup_nas_snapshot_user` to enable; leave empty to skip the
+trigger on hosts that haven't been provisioned with the SSH key yet.
+
+## Email alert on failure
+
+When `$ERRORS -gt 0`, the script sends a single email via the
+project-level SMTP config (reuses `smtp_host`, `smtp_port`,
+`smtp_username`, `smtp_password`, `smtp_from`). Subject:
+`[home-server backup] FAILED on <host>`. Body: tail of
+`/var/log/home-server-backup.log`. Recipient defaults to `smtp_from`;
+override with `backup_alert_recipient`.
+
+If `smtp_host` isn't set on a host, the email step is omitted at
+render time (no email, exit non-zero still).
 
 ## What gets backed up per service
 
-| Service   | Volume / DB                       | Method  |
-|-----------|-----------------------------------|---------|
-| pihole    | `systemd-pihole-etc`              | tar     |
-| pihole    | `systemd-pihole-dnsmasq`          | tar     |
-| syncthing | `systemd-syncthing-config`        | tar     |
-| syncthing | `systemd-syncthing-data`          | rsync   |
-| jukebox   | `jukebox-server-config`           | tar     |
-| jukebox   | `jukebox-server-playlist`         | tar     |
-| jukebox   | `jukebox-server-music`            | rsync   |
-| entephoto | `ente_db` (Postgres)              | pgdump  |
-| entephoto | `entephoto-museum-config`         | tar     |
-| entephoto | `entephoto-minio-data`            | rsync   |
-| jellyfin  | `systemd-jellyfin-config`         | tar     |
-| jellyfin  | `systemd-jellyfin-media`          | rsync   |
-| nextcloud | `nextcloud` (Postgres)            | pgdump  |
-| nextcloud | `nextcloud-config`                | tar     |
-| nextcloud | `nextcloud-data`                  | rsync   |
-| caddy     | `caddy-data`                      | tar     |
+Derived automatically from each role's `backup_manifest`. Current set
+across the project:
 
-> Only `caddy-data` is backed up (the LE-issued wildcard cert
-> and ACME account key). `caddy-config` is runtime state and
-> `caddy-etc` is regenerated from the Jinja template on every
-> deploy — neither needs persistence.
+| Service        | Volume / DB                       | Method  |
+|----------------|-----------------------------------|---------|
+| pihole         | `systemd-pihole-etc`              | tar     |
+| pihole         | `systemd-pihole-dnsmasq`          | tar     |
+| syncthing      | `systemd-syncthing-config`        | tar     |
+| syncthing      | `systemd-syncthing-data`          | rsync   |
+| entephoto      | `ente_db` (Postgres)              | pgdump  |
+| entephoto      | `entephoto-museum-config`         | tar     |
+| entephoto      | `entephoto-garage-data`           | rsync   |
+| entephoto      | `entephoto-garage-meta`           | rsync   |
+| paperless-ngx  | `paperless` (Postgres)            | pgdump  |
+| paperless-ngx  | `paperless-redis-data`            | tar     |
+| paperless-ngx  | `paperless-data`                  | tar     |
+| paperless-ngx  | `paperless-export`                | tar     |
+| paperless-ngx  | `paperless-media`                 | rsync   |
+| jellyfin       | `systemd-jellyfin-config`         | tar     |
+| jellyfin       | `systemd-jellyfin-media`          | rsync (restore_opt_in) |
+| nextcloud      | `nextcloud` (Postgres)            | pgdump  |
+| nextcloud      | `nextcloud-config`                | tar     |
+| nextcloud      | `nextcloud-data`                  | rsync   |
+| music-assistant| `music-assistant-data`            | tar     |
+| caddy          | `caddy-data`                      | tar     |
 
 ## Deployment
 
@@ -157,12 +204,21 @@ Used for: entephoto Postgres (`entephoto-postgres` / `ente_db`).
 ansible-playbook playbooks/backup.yml --limit homeserver
 ```
 
+Operator one-time prerequisite per host: NAS-side share + SSH key
+setup per [docs/NAS-Setup.md](../../docs/NAS-Setup.md).
+
 ## Restore
 
-The exact command depends on the backup method — see the per-method
-"Restore" snippets above. The common shape is:
+```bash
+ansible-playbook playbooks/restore.yml --limit <host>
+```
 
-1. Re-run the service's playbook to recreate the container and an
-   empty volume.
-2. Restore the data using the method matching how it was backed up
-   (`podman volume import`, `rsync`, or `psql`).
+Mounts `nas:/<vol>/backup-<host>/` once, then for each service: stops
+the unit, restores tar volumes (`podman volume import`), rsyncs rsync
+volumes via `podman unshare`, restores pgdumps, runs the role's
+optional `post_restore_tasks` hook, starts the unit.
+
+To restore from a specific snapshot rather than the live mirror,
+DSM-side: Snapshot Replication → select share → Browse → pick
+timestamp → Restore to a sibling folder, then point `restore_root` at
+that folder for the play.

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -8,9 +8,30 @@
 #   backup doesn't depend on external DNS being up
 # - backup_nas_volume: absolute path prefix on the NAS where the shared
 #   folders live (e.g. Synology uses "/volume1" for the first storage volume)
+#
+# The NFS share itself is derived: backup-<inventory_hostname>. Operator
+# creates that shared folder on the NAS per host (see docs/NAS-Setup.md).
 # Time of day for the nightly backup (systemd OnCalendar format, HH:MM:SS).
 backup_time: "02:00:00"
 
 backup_nas_hostname: nas
 backup_nas_ip: 192.168.x.x
 backup_nas_volume: /volume1
+
+# --- Failure alert email -----------------------------------------------
+# Reuses the project-level smtp_* vars (smtp_host, smtp_port, smtp_username,
+# smtp_password, smtp_from). Backup script sends a mail with the log tail
+# when ERRORS > 0. If smtp_host isn't defined on this host, the alert step
+# is omitted at render time and backup just exits non-zero on failure.
+# Override to send to a different inbox (default: smtp_from).
+backup_alert_recipient: "{{ smtp_from | default('') }}"
+
+# --- NAS snapshot trigger ----------------------------------------------
+# After a successful backup, the script SSHs to the NAS as this user and
+# the command locked into authorized_keys runs
+#   `sudo synosharesnapshot create backup-<host>`.
+# Leave backup_nas_snapshot_user empty to skip the trigger entirely
+# (e.g. on hosts where the NAS-side SSH key isn't provisioned yet).
+# See docs/NAS-Setup.md for the one-time setup.
+backup_nas_snapshot_user: ""
+backup_nas_snapshot_key_path: /root/.ssh/nas-snapshot

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -11,32 +11,43 @@ set -euo pipefail
 #   - rsync:  rsync volume mount path (current mirror, no history)
 #   - pgdump: pg_dump logical database backup (with daily retention)
 #
-# Backup target: NFS shares on Synology NAS.
-#   One shared folder for all tar/pgdump archives, plus a dedicated shared
-#   folder per rsync dataset (e.g. photos, syncthing, music, paperless-media).
-#   All shares are mounted at startup and unmounted on exit (even on failure).
+# Backup target: ONE NFS share per host on the NAS
+#   (e.g. /volume1/backup-<host>/).
+#   Layout inside:
+#       <app>/tar/<volume>/<volume>-<ts>.tar.gz
+#       <app>/rsync/<volume>/…
+#       <app>/pgdump/<container>/<container>-<ts>.sql.gz
+#   One share = one Btrfs subvolume = one snapshot scope, so a Synology
+#   snapshot of this share captures ALL of this host's backups at once.
+#
+# After a successful run, the script SSH's to the NAS and triggers a
+# Btrfs snapshot of the host share — so the snapshot timestamp aligns
+# with the moment the on-disk state is mutually consistent across all
+# of a service's volumes (pgdump matches rsync matches tar).
+#
+# On any error, an email is sent via the project SMTP config.
+#
+# NOTE: this script is rendered with vault secrets (smtp_password)
+# inline. File mode is 0700 root:root so the secrets are not world-
+# readable; same trust boundary as the rendered museum.yaml.
 # ===========================================================================
 
 # --- Configuration ---
-# NOTE: NAS_HOST / NAS_VOLUME / HOSTNAME_DIR are rendered by Ansible from
-# host_vars. HOSTNAME_DIR segments every backup path so multiple homeservers
-# (e.g. prod + test) can share the same NAS without colliding.
+# NAS_HOST / NAS_VOLUME / HOSTNAME_DIR are rendered by Ansible from
+# host_vars. The single NFS share for this host is backup-<HOSTNAME_DIR>.
 BACKUP_ROOT="/mnt/backup"
 NAS_HOST="{{ backup_nas_hostname }}"
 NAS_VOLUME="{{ backup_nas_volume }}"
 HOSTNAME_DIR="{{ inventory_hostname }}"
-# Local mount name → Synology shared folder name.
-# Derived from backup_manifest declarations in each role's defaults.
-declare -A NFS_SHARES=(
-  [tar]=backup-tar
-{% for share in _backup_manifests | map(attribute='volumes') | flatten | selectattr('method', 'equalto', 'rsync') | map(attribute='nas_share') | unique | sort %}
-  [{{ share }}]=backup-{{ share }}
-{% endfor %}
-)
+HOST_SHARE="backup-${HOSTNAME_DIR}"
 MOUNT_OPTS="noatime,hard,_netdev,vers=4"
 RETENTION_DAYS=7
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 ERRORS=0
+
+# Snapshot trigger config (optional — empty user = skip).
+NAS_SNAPSHOT_USER="{{ backup_nas_snapshot_user | default('') }}"
+NAS_SNAPSHOT_KEY="{{ backup_nas_snapshot_key_path | default('/root/.ssh/nas-snapshot') }}"
 
 # --- Logging (off the NFS mount, so logs survive mount failures) ---
 LOG_FILE="/var/log/home-server-backup.log"
@@ -44,21 +55,16 @@ mkdir -p "$(dirname "$LOG_FILE")"
 log()       { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
 log_error() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" | tee -a "$LOG_FILE" >&2; ERRORS=$((ERRORS+1)); }
 
-# --- Mount all NFS shares ---
-for local_name in "${!NFS_SHARES[@]}"; do
-  remote=${NFS_SHARES[$local_name]}
-  mkdir -p "$BACKUP_ROOT/$local_name"
-  log "Mounting $NAS_HOST:$NAS_VOLUME/$remote → $BACKUP_ROOT/$local_name"
-  mount -t nfs -o "$MOUNT_OPTS" \
-    "$NAS_HOST:$NAS_VOLUME/$remote" "$BACKUP_ROOT/$local_name" \
-    || { log_error "Mount failed for $remote, aborting"; exit 1; }
-done
+# --- Mount the host's NFS share ---
+mkdir -p "$BACKUP_ROOT"
+log "Mounting $NAS_HOST:$NAS_VOLUME/$HOST_SHARE → $BACKUP_ROOT"
+mount -t nfs -o "$MOUNT_OPTS" \
+    "$NAS_HOST:$NAS_VOLUME/$HOST_SHARE" "$BACKUP_ROOT" \
+    || { log_error "Mount failed for $HOST_SHARE, aborting"; exit 1; }
 
 trap '
-  for local_name in "${!NFS_SHARES[@]}"; do
-    log "Unmounting $BACKUP_ROOT/$local_name"
-    umount "$BACKUP_ROOT/$local_name" || true
-  done
+  log "Unmounting $BACKUP_ROOT"
+  umount "$BACKUP_ROOT" || true
 ' EXIT
 
 log "=== Backup started ==="
@@ -81,9 +87,13 @@ start_service() {
 }
 
 # --- Backup functions ---
+# Path layout under $BACKUP_ROOT (== the NAS host share):
+#     <app>/tar/<volume>/<volume>-<ts>.tar.gz
+#     <app>/rsync/<volume>/…
+#     <app>/pgdump/<container>/<container>-<ts>.sql.gz
 backup_tar_volume() {
-  local user=$1 uid=$2 volume=$3
-  local dest="$BACKUP_ROOT/tar/$HOSTNAME_DIR/$volume"
+  local user=$1 uid=$2 volume=$3 app=$4
+  local dest="$BACKUP_ROOT/$app/tar/$volume"
   mkdir -p "$dest"
   log "  Tar backup: $volume"
   if su - "$user" -c "podman volume export $volume" \
@@ -95,28 +105,23 @@ backup_tar_volume() {
     rm -f "$dest/${volume}-${TIMESTAMP}.tar.gz"
     return 1
   fi
-  # Retention: remove old backups
   find "$dest" -name "*.tar.gz" -mtime +"$RETENTION_DAYS" -delete
 }
 
 backup_rsync_volume() {
-  local user=$1 uid=$2 volume=$3 share=$4
+  local user=$1 uid=$2 volume=$3 app=$4
   local mount_path
   if ! mount_path=$(su - "$user" -c "podman volume inspect $volume --format={% raw %}{{.Mountpoint}}{% endraw %}"); then
     log_error "Cannot inspect volume $volume"
     return 1
   fi
-  # Per-volume subdir so two volumes can share the same NFS share
-  # without --delete on the second clobbering the first (entephoto
-  # garage-data + garage-meta both live under `photos/<host>/`).
-  local dest="$BACKUP_ROOT/$share/$HOSTNAME_DIR/$volume"
+  local dest="$BACKUP_ROOT/$app/rsync/$volume"
   mkdir -p "$dest"
-  log "  Rsync backup: $volume → $share/$HOSTNAME_DIR/$volume"
+  log "  Rsync backup: $volume → $app/rsync/$volume"
   # --no-owner --no-group --numeric-ids: NFS all_squash maps every UID to the
-  #   share's anon user, so chowns from rsync would fail. We deliberately
-  #   drop ownership preservation here. On restore, container-native UIDs
-  #   are re-applied with `podman unshare chown` inside the rootless user's
-  #   namespace (UIDs differ per host anyway).
+  #   share's anon user, so chowns from rsync would fail. Drop ownership
+  #   preservation here. On restore, container-native UIDs are re-applied
+  #   with `podman unshare chown` inside the rootless user's namespace.
   if rsync -rltD --delete --no-owner --no-group --numeric-ids \
       "$mount_path/" "$dest/" 2>>"$LOG_FILE"; then
     log "  Rsync backup: $volume done ($(du -sh "$dest" | cut -f1))"
@@ -127,8 +132,8 @@ backup_rsync_volume() {
 }
 
 backup_pgdump() {
-  local user=$1 container=$2 db_user=$3 db_name=$4
-  local dest="$BACKUP_ROOT/tar/$HOSTNAME_DIR/pgdump-$container"
+  local user=$1 container=$2 db_user=$3 db_name=$4 app=$5
+  local dest="$BACKUP_ROOT/$app/pgdump/$container"
   mkdir -p "$dest"
   log "  pg_dump: $container ($db_name)"
   if su - "$user" -c "podman exec $container pg_dump -U $db_user $db_name" \
@@ -140,13 +145,13 @@ backup_pgdump() {
     rm -f "$dest/${container}-${TIMESTAMP}.sql.gz"
     return 1
   fi
-  # Retention: remove old backups
   find "$dest" -name "*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
 }
 
 # =======================================================================
 # Backup definitions per service
 # Generated from backup_manifest declarations in each role's defaults.
+# Each service's $app subdir is the role name (svc._role_name).
 # =======================================================================
 {% for svc in _backup_manifests %}
 
@@ -155,15 +160,15 @@ log "--- {{ svc._role_name | capitalize }} ---"
 {% if svc.databases is defined %}
 {% for db in svc.databases %}
 # pg_dump runs while service is up (consistent logical snapshot)
-backup_pgdump {{ svc.service_user }} {{ db.container }} {{ db.db_user }} {{ db.db_name }}
+backup_pgdump {{ svc.service_user }} {{ db.container }} {{ db.db_user }} {{ db.db_name }} {{ svc._role_name }}
 {% endfor %}
 {% endif %}
 stop_service {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ svc.service_unit }}
 {% for vol in svc.volumes %}
 {% if vol.method == 'tar' %}
-backup_tar_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }}
+backup_tar_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }} {{ svc._role_name }}
 {% elif vol.method == 'rsync' %}
-backup_rsync_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }} {{ vol.nas_share }}
+backup_rsync_volume {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ vol.name }} {{ svc._role_name }}
 {% endif %}
 {% endfor %}
 start_service {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} {{ svc.service_unit }}
@@ -171,4 +176,52 @@ start_service {{ svc.service_user }} {{ my_linux_users[svc.service_user].uid }} 
 
 # =======================================================================
 log "=== Backup finished ($ERRORS errors) ==="
+
+# --- Trigger a NAS-side snapshot (only when error-free) ---
+# Captures a Btrfs snapshot of $HOST_SHARE NOW, so every snapshot's
+# timestamp aligns with a point-in-time-consistent backup state.
+# Snapshot failure is logged but NOT fatal — the data is on NAS, only
+# the snapshot marker is missing. Tomorrow's DSM-scheduled fallback
+# snapshot (or the next nightly run) catches up.
+if [ "$ERRORS" -eq 0 ] && [ -n "$NAS_SNAPSHOT_USER" ]; then
+  log "Triggering NAS snapshot of $HOST_SHARE"
+  if ssh -o StrictHostKeyChecking=accept-new \
+         -o BatchMode=yes \
+         -i "$NAS_SNAPSHOT_KEY" \
+         "$NAS_SNAPSHOT_USER@$NAS_HOST" \
+         >>"$LOG_FILE" 2>&1; then
+    log "NAS snapshot trigger: ok"
+  else
+    log_error "NAS snapshot trigger failed (data is safely on NAS; only the consistency marker is missing)"
+  fi
+fi
+
+# --- Email alert on failure ---
+{% if smtp_host is defined and smtp_host | length > 0 %}
+if [ "$ERRORS" -gt 0 ]; then
+  log "Sending failure alert to {{ backup_alert_recipient | default(smtp_from) }}"
+  python3 <<PYEOF || log_error "Failed to send alert email (logged-only — not retried)"
+import smtplib, ssl, socket
+from email.message import EmailMessage
+host = socket.gethostname()
+try:
+    with open("/var/log/home-server-backup.log") as f:
+        body = f.read()[-8000:]
+except FileNotFoundError:
+    body = "(log file missing)"
+msg = EmailMessage()
+msg["Subject"] = f"[home-server backup] FAILED on {host}"
+msg["From"]    = "{{ smtp_from }}"
+msg["To"]      = "{{ backup_alert_recipient | default(smtp_from) }}"
+msg.set_content(body)
+ctx = ssl.create_default_context()
+with smtplib.SMTP("{{ smtp_host }}", {{ smtp_port | default(587) }}) as s:
+    s.ehlo()
+    s.starttls(context=ctx)
+    s.login("{{ smtp_username }}", "{{ smtp_password }}")
+    s.send_message(msg)
+PYEOF
+fi
+{% endif %}
+
 [ "$ERRORS" -eq 0 ] || exit 1

--- a/roles/entephoto/defaults/main.yml
+++ b/roles/entephoto/defaults/main.yml
@@ -52,8 +52,8 @@ backup_manifest:
   service_unit: entephoto-pod
   volumes:
     - { name: entephoto-museum-config, method: tar }
-    - { name: entephoto-garage-data, method: rsync, nas_share: photos }
-    - { name: entephoto-garage-meta, method: rsync, nas_share: photos }
+    - { name: entephoto-garage-data, method: rsync }
+    - { name: entephoto-garage-meta, method: rsync }
   databases:
     - { container: entephoto-postgres, db_user: pguser, db_name: ente_db, method: pgdump }
   post_restore_tasks: restore.yml

--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -74,4 +74,4 @@ backup_manifest:
   service_unit: jellyfin
   volumes:
     - { name: systemd-jellyfin-config, method: tar }
-    - { name: systemd-jellyfin-media, method: rsync, nas_share: jellyfin-media, restore_opt_in: true }
+    - { name: systemd-jellyfin-media, method: rsync, restore_opt_in: true }

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -39,7 +39,7 @@ backup_manifest:
   service_unit: nextcloud-pod
   volumes:
     - { name: nextcloud-config, method: tar }
-    - { name: nextcloud-data, method: rsync, nas_share: nextcloud }
+    - { name: nextcloud-data, method: rsync }
   databases:
     - { container: nextcloud-postgres, db_user: ncuser, db_name: nextcloud, method: pgdump }
   post_restore_tasks: restore.yml

--- a/roles/paperless-ngx/defaults/main.yml
+++ b/roles/paperless-ngx/defaults/main.yml
@@ -100,7 +100,7 @@ backup_manifest:
     - { name: paperless-redis-data, method: tar }
     - { name: paperless-data, method: tar }
     - { name: paperless-export, method: tar }
-    - { name: paperless-media, method: rsync, nas_share: paperless-media }
+    - { name: paperless-media, method: rsync }
   databases:
     - { container: paperless-db, db_user: paperless, db_name: paperless, method: pgdump }
   post_restore_tasks: restore.yml

--- a/roles/syncthing/defaults/main.yml
+++ b/roles/syncthing/defaults/main.yml
@@ -11,4 +11,4 @@ backup_manifest:
   service_unit: syncthing
   volumes:
     - { name: systemd-syncthing-config, method: tar }
-    - { name: systemd-syncthing-data, method: rsync, nas_share: syncthing }
+    - { name: systemd-syncthing-data, method: rsync }


### PR DESCRIPTION
## Summary

Restructures NAS backup so one host = one NAS share = one Btrfs subvolume = one snapshot scope. Closes the cross-share consistency hole and makes restore-from-snapshot deterministic.

Layout change:
- old: `backup-tar/<host>/<vol>/…` + `backup-<share>/<host>/<vol>/…`
- new: `backup-<host>/<app>/{tar,rsync,pgdump}/<vol>/…`

After a successful run, the script SSHs to the NAS and creates a Btrfs snapshot via `synosharesnapshot create` — fires only on `ERRORS=0`, locked into authorized_keys per host. Snapshot failure is logged-but-non-fatal; DSM-scheduled 05:00 fallback covers regressions.

Failure alert email via project `smtp_*` vars.

## Operator setup (one-time, per host)

See [docs/NAS-Setup.md](../blob/feat/backup-per-host-share-snapshots/docs/NAS-Setup.md):
- create `backup-<host>` shared folder, NFS export
- Snapshot Replication policy (24h × 7d × 4w + DSM-scheduled 05:00 fallback)
- `homeserver-backup` DSM user, sudoers drop-in, SSH key + locked authorized_keys

## Migration

Existing hosts: [playbooks/backup-layout-migrate.yml](../blob/feat/backup-per-host-share-snapshots/playbooks/backup-layout-migrate.yml) stops the timer, prompts the operator to either move existing NAS trees into the new layout OR accept a fresh-start (orphan old trees deletable after one verified cycle), redeploys the role, runs one backup to populate the new tree.

## Test plan

On `homeserver2` (new install, snapshot share exists, SSH key not yet provisioned):

- [x] Re-deploy backup role → script renders with new path math, `backup_nas_snapshot_user` empty → snapshot step skipped.
- [x] `sudo systemctl start home-server-backup.service` → completes 0 errors; NAS layout matches new format: `backup-homeserver2/<app>/{tar,rsync,pgdump}/…`.
- [x] Add SSH key per docs/NAS-Setup.md, set `backup_nas_snapshot_user: homeserver-backup` in inventory, redeploy → snapshot fires after next backup, visible in DSM.
- [ ] Trigger a failure path (e.g. wrong NAS_HOST) to verify the email alert lands.

Then prod (`homeserver`) via the migration playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)