### PR TITLE
fix(backup): configurable NAS SSH port

### DIFF
--- a/docs/NAS-Setup.md
+++ b/docs/NAS-Setup.md
@@ -72,8 +72,10 @@ Station, etc.). Only SSH is needed.
 
 ## 5. Enable SSH on the NAS
 
-Control Panel → Terminal & SNMP → **Enable SSH service**. Default port
-22 is fine unless you've moved it.
+Control Panel → Terminal & SNMP → **Enable SSH service**. Take note
+of the configured port — many Synology setups use **1022** (default
+when DSM auto-configures around an existing service on 22). If yours
+isn't 22, set `backup_nas_snapshot_port` in inventory accordingly.
 
 ## 6. Sudoers entry for the snapshot CLI
 
@@ -128,8 +130,10 @@ User & Group → Advanced → User Home.)
 ## 8. Smoke test from the host
 
 ```bash
-ssh -i /root/.ssh/nas-snapshot homeserver-backup@nas
+ssh -p <nas-ssh-port> -i /root/.ssh/nas-snapshot homeserver-backup@nas
 ```
+
+(`<nas-ssh-port>` defaults to 22; many Synology setups use 1022 — match what step 5 showed.)
 
 Should print a `Snapshot created` line and exit 0. Snapshot Replication
 in DSM should immediately show one new snapshot in the share's history.
@@ -145,6 +149,8 @@ In `inventory/host_vars/<host>/main.yml`:
 
 ```yaml
 backup_nas_snapshot_user: homeserver-backup
+# Override if NAS sshd isn't on the default port 22:
+backup_nas_snapshot_port: 1022
 # backup_nas_snapshot_key_path: defaults to /root/.ssh/nas-snapshot
 ```
 

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -30,6 +30,7 @@ rootless container volumes via `podman unshare`.
 | `backup_alert_recipient`       | `{{ smtp_from }}`      | Email address that receives failure alerts.                        |
 | `backup_nas_snapshot_user`     | *empty (off)*          | SSH username on the NAS for the post-backup snapshot trigger. Empty = no snapshot. |
 | `backup_nas_snapshot_key_path` | `/root/.ssh/nas-snapshot` | Path to the private key authenticating as `backup_nas_snapshot_user`. |
+| `backup_nas_snapshot_port`     | `22`                   | SSH port on the NAS. Many Synology setups use `1022`.              |
 
 Override all NAS variables per-host in inventory.
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -35,3 +35,7 @@ backup_alert_recipient: "{{ smtp_from | default('') }}"
 # See docs/NAS-Setup.md for the one-time setup.
 backup_nas_snapshot_user: ""
 backup_nas_snapshot_key_path: /root/.ssh/nas-snapshot
+# SSH port on the NAS — Synology DSM commonly runs sshd on 1022 (default
+# 22 reserved for other use). Override per-host if your NAS uses a
+# different port.
+backup_nas_snapshot_port: 22

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -48,6 +48,7 @@ ERRORS=0
 # Snapshot trigger config (optional — empty user = skip).
 NAS_SNAPSHOT_USER="{{ backup_nas_snapshot_user | default('') }}"
 NAS_SNAPSHOT_KEY="{{ backup_nas_snapshot_key_path | default('/root/.ssh/nas-snapshot') }}"
+NAS_SNAPSHOT_PORT="{{ backup_nas_snapshot_port | default(22) }}"
 
 # --- Logging (off the NFS mount, so logs survive mount failures) ---
 LOG_FILE="/var/log/home-server-backup.log"
@@ -187,6 +188,7 @@ if [ "$ERRORS" -eq 0 ] && [ -n "$NAS_SNAPSHOT_USER" ]; then
   log "Triggering NAS snapshot of $HOST_SHARE"
   if ssh -o StrictHostKeyChecking=accept-new \
          -o BatchMode=yes \
+         -p "$NAS_SNAPSHOT_PORT" \
          -i "$NAS_SNAPSHOT_KEY" \
          "$NAS_SNAPSHOT_USER@$NAS_HOST" \
          >>"$LOG_FILE" 2>&1; then


### PR DESCRIPTION
Synology DSM often runs sshd on 1022, not 22. Add `backup_nas_snapshot_port` (default 22) and thread it through the SSH call.