### PR TITLE
refactor(backup): drop redundant method tier from NAS layout

### DIFF
--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -28,7 +28,7 @@
 # --- Find latest tar backups ---
 - name: "{{ svc._role_name | upper }}: find latest tar backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/{{ svc._role_name }}/tar/{{ item.name }}/*.tar.gz | head -1
+    ls -t {{ restore_root }}/{{ svc._role_name }}/{{ item.name }}/*.tar.gz | head -1
   register: _tar_latest
   loop: "{{ svc.volumes | selectattr('method', 'equalto', 'tar') | list }}"
   loop_control:
@@ -38,7 +38,7 @@
 # --- Find latest pgdump backups ---
 - name: "{{ svc._role_name | upper }}: find latest pgdump backups"
   ansible.builtin.shell: >
-    ls -t {{ restore_root }}/{{ svc._role_name }}/pgdump/{{ item.container }}/*.sql.gz | head -1
+    ls -t {{ restore_root }}/{{ svc._role_name }}/{{ item.container }}/*.sql.gz | head -1
   register: _pgdump_latest
   loop: "{{ svc.databases | default([]) }}"
   loop_control:
@@ -76,7 +76,7 @@
         --format='{% raw %}{{.Mountpoint}}{% endraw %}')
     sudo -u {{ svc.service_user }} podman unshare rsync -a --delete \
         --no-owner --no-group --numeric-ids \
-        "{{ restore_root }}/{{ svc._role_name }}/rsync/{{ item.name }}/" "$MP/"
+        "{{ restore_root }}/{{ svc._role_name }}/{{ item.name }}/" "$MP/"
   loop: >-
     {{ svc.volumes
        | selectattr('method', 'equalto', 'rsync')

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -58,13 +58,15 @@ host has backed up. Layout inside the share:
 ```
 backup-<host>/
   <app>/
-    tar/
-      <volume>/<volume>-YYYYMMDD-HHMMSS.tar.gz
-    rsync/
-      <volume>/...
-    pgdump/
-      <container>/<container>-YYYYMMDD-HHMMSS.sql.gz
+    <volume>/<volume>-YYYYMMDD-HHMMSS.tar.gz      ← tar method
+    <volume>/                                     ← rsync method (mirror tree)
+    <container>/<container>-YYYYMMDD-HHMMSS.sql.gz  ← pgdump method
 ```
+
+Method is derivable from the file extension (`.tar.gz` / `.sql.gz` /
+neither). One flat tier under `<app>` keeps paths intuitive — `ls
+backup-<host>/entephoto/` shows every backed-up artifact for that
+service at a glance.
 
 `<app>` is the role name (entephoto, paperless-ngx, …). One share per
 host eliminates the prior cross-share consistency problem (DB dump on
@@ -90,7 +92,7 @@ history is cheap and useful.
 - The container is stopped first (consistent on-disk state).
 - `podman volume export <vol>` streams the volume contents as tar,
   piped through `gzip`, saved as
-  `backup-<host>/<app>/tar/<vol>/<vol>-YYYYMMDD-HHMMSS.tar.gz`.
+  `backup-<host>/<app>/<vol>/<vol>-YYYYMMDD-HHMMSS.tar.gz`.
 - **Retention:** last 7 daily snapshots are kept on the share.
   Older NAS-side snapshots (Snapshot Replication) extend history
   further.
@@ -104,7 +106,7 @@ wasteful and history isn't needed (the data is the data).
 - The container is stopped first.
 - `podman volume inspect` gives the mount path on the host.
 - `rsync -rltD --delete --no-owner --no-group --numeric-ids` mirrors
-  the volume's contents into `backup-<host>/<app>/rsync/<vol>/`.
+  the volume's contents into `backup-<host>/<app>/<vol>/`.
 - Ownership is **not** preserved (NFS `all_squash` rejects chowns;
   rootless container UIDs differ per host). On restore, ownership is
   re-applied with `podman unshare chown`.
@@ -118,7 +120,7 @@ Used for **PostgreSQL databases**.
 - Runs **with the container up** (`pg_dump` is a consistent logical
   snapshot, no need to stop the database).
 - `podman exec <container> pg_dump …` is piped through gzip and saved
-  as `backup-<host>/<app>/pgdump/<container>/<container>-YYYYMMDD-HHMMSS.sql.gz`.
+  as `backup-<host>/<app>/<container>/<container>-YYYYMMDD-HHMMSS.sql.gz`.
 - **Retention:** last 7 daily snapshots on the share.
 
 ## Cross-volume consistency (and why)

--- a/roles/backup/templates/home-server-backup.sh.j2
+++ b/roles/backup/templates/home-server-backup.sh.j2
@@ -13,10 +13,11 @@ set -euo pipefail
 #
 # Backup target: ONE NFS share per host on the NAS
 #   (e.g. /volume1/backup-<host>/).
-#   Layout inside:
-#       <app>/tar/<volume>/<volume>-<ts>.tar.gz
-#       <app>/rsync/<volume>/…
-#       <app>/pgdump/<container>/<container>-<ts>.sql.gz
+#   Layout inside (method derivable from file extension —
+#   .tar.gz = tar, .sql.gz = pgdump, no extension = rsync tree):
+#       <app>/<volume>/<volume>-<ts>.tar.gz
+#       <app>/<volume>/…
+#       <app>/<container>/<container>-<ts>.sql.gz
 #   One share = one Btrfs subvolume = one snapshot scope, so a Synology
 #   snapshot of this share captures ALL of this host's backups at once.
 #
@@ -89,12 +90,12 @@ start_service() {
 
 # --- Backup functions ---
 # Path layout under $BACKUP_ROOT (== the NAS host share):
-#     <app>/tar/<volume>/<volume>-<ts>.tar.gz
-#     <app>/rsync/<volume>/…
-#     <app>/pgdump/<container>/<container>-<ts>.sql.gz
+#     <app>/<volume>/<volume>-<ts>.tar.gz
+#     <app>/<volume>/…
+#     <app>/<container>/<container>-<ts>.sql.gz
 backup_tar_volume() {
   local user=$1 uid=$2 volume=$3 app=$4
-  local dest="$BACKUP_ROOT/$app/tar/$volume"
+  local dest="$BACKUP_ROOT/$app/$volume"
   mkdir -p "$dest"
   log "  Tar backup: $volume"
   if su - "$user" -c "podman volume export $volume" \
@@ -116,9 +117,9 @@ backup_rsync_volume() {
     log_error "Cannot inspect volume $volume"
     return 1
   fi
-  local dest="$BACKUP_ROOT/$app/rsync/$volume"
+  local dest="$BACKUP_ROOT/$app/$volume"
   mkdir -p "$dest"
-  log "  Rsync backup: $volume → $app/rsync/$volume"
+  log "  Rsync backup: $volume → $app/$volume"
   # --no-owner --no-group --numeric-ids: NFS all_squash maps every UID to the
   #   share's anon user, so chowns from rsync would fail. Drop ownership
   #   preservation here. On restore, container-native UIDs are re-applied
@@ -134,7 +135,7 @@ backup_rsync_volume() {
 
 backup_pgdump() {
   local user=$1 container=$2 db_user=$3 db_name=$4 app=$5
-  local dest="$BACKUP_ROOT/$app/pgdump/$container"
+  local dest="$BACKUP_ROOT/$app/$container"
   mkdir -p "$dest"
   log "  pg_dump: $container ($db_name)"
   if su - "$user" -c "podman exec $container pg_dump -U $db_user $db_name" \


### PR DESCRIPTION
File extension already tells you the method (.tar.gz / .sql.gz / none). Flatter paths, no schema change for role manifests.