### PR TITLE
docs(inventory): note that linux users and caddy proxy list rarely need edits

### DIFF
--- a/docs/Setup-Guide/01-deSEC-account.md
+++ b/docs/Setup-Guide/01-deSEC-account.md
@@ -1,7 +1,7 @@
 # Step 1 — Set up your deSEC account
 
-> **Setup Guide** · Step 1 of 5 · ▰▱▱▱▱ 20% · ~0 min spent · ~50 min to go
-> **Step 1: deSEC account** · [Step 2: Install OS →](02-install-os.md)
+> **Setup Guide** · Step 1 of 6 · ▰▱▱▱▱▱ 17% · ~0 min spent · ~55 min to go
+> **Step 1: deSEC account** · [Step 2: SMTP account →](02-smtp-account.md)
 
 This is the only manual sign-up in the whole guide. ~5 minutes.
 
@@ -66,7 +66,7 @@ of Let's Encrypt SSL certificates.
 
 ## Keep these two values
 
-You'll paste them into `homeserver.sh` in Step 4:
+You'll paste them into `homeserver.sh` in Step 5:
 
 | | Example |
 |---|---|
@@ -78,9 +78,10 @@ You'll paste them into `homeserver.sh` in Step 4:
 | Step | Status | Time |
 |---|---|---|
 | 1 — deSEC account | ✅ done | ~5 min |
-| 2 — Install OS | next | ~20–60 min |
-| 3 — SSH & sudo | | ~3 min |
-| 4 — Run homeserver.sh | | ~20 min |
-| 5 — Verify & explore | | ~2 min |
+| 2 — SMTP account | next | ~5 min |
+| 3 — Install OS | | ~20–60 min |
+| 4 — SSH & sudo | | ~3 min |
+| 5 — Run homeserver.sh | | ~20 min |
+| 6 — Verify & explore | | ~2 min |
 
-➡️ **[Step 2: Install the OS](02-install-os.md)**
+➡️ **[Step 2: Set up an SMTP relay account](02-smtp-account.md)**

--- a/docs/Setup-Guide/02-smtp-account.md
+++ b/docs/Setup-Guide/02-smtp-account.md
@@ -1,0 +1,56 @@
+# Step 2 — Set up an SMTP relay account
+
+> **Setup Guide** · Step 2 of 6 · ▰▰▱▱▱▱ 33% · ~5 min spent · ~50 min to go
+> [← Step 1: deSEC account](01-deSEC-account.md) · **Step 2: SMTP account** · [Step 3: Install OS →](03-install-os.md)
+
+The homeserver sends email for things like Nextcloud invitations,
+Paperless password resets, Ente verification codes, and (in the
+future) backup-failure alerts. It does that through a real mail
+provider — no Postfix on the box, no fighting residential-IP
+blocklists.
+
+If you already have a personal Mailbox.org / Posteo / IONOS account,
+just generate an app-specific password and reuse it. Otherwise pick
+one below.
+
+## Pick a provider
+
+| Provider | App password / SMTP user | SMTP host & port |
+|---|---|---|
+| **Mailbox.org** (recommended) | [Change e-mail password / app password](https://kb.mailbox.org/de/privat/sicherheit-privatsphaere/e-mail-passwort/) | [Server, ports, encryption](https://kb.mailbox.org/de/privat/e-mail/e-mail-konfiguration/#3-postausgangsserver-ports-und-verschl%C3%BCsselung) |
+| **Posteo** | [Account password / 2FA setup](https://posteo.de/hilfe/wie-andere-mein-passwort) | [SMTP server settings](https://posteo.de/hilfe/welche-einstellungen-brauche-ich-fuer-imap-pop3-und-smtp) |
+| **IONOS Mail** | [Mailbox password](https://www.ionos.de/hilfe/e-mail/allgemeine-themen/mailbox-passwort-aendern/) | [Server data for mail programs](https://www.ionos.de/hilfe/e-mail/allgemeine-themen/serverdaten-fuer-e-mail-programme/) |
+
+> [!TIP]
+> Use an **app-specific password** wherever the provider supports it
+> (Mailbox.org does). It's scoped, named, and individually revocable
+> — so if the homeserver is ever rebuilt or lost, you can revoke just
+> that one credential without touching your main account.
+
+For a deeper write-up, including provider comparison and per-app
+notes, see **[docs/SMTP-Setup.md](../SMTP-Setup.md)**.
+
+## Keep these five values
+
+You'll paste them into `homeserver.sh` in Step 5:
+
+| | Example |
+|---|---|
+| **smtp_host** | `smtp.mailbox.org` |
+| **smtp_port** | `587` |
+| **smtp_username** | `you@example.org` |
+| **smtp_from** | `you@example.org` (usually the same as username) |
+| **smtp_password** | the app password from the table above |
+
+## Time check
+
+| Step | Status | Time |
+|---|---|---|
+| 1 — deSEC account | ✅ done | ~5 min |
+| 2 — SMTP account | in progress | ~5 min |
+| 3 — Install OS | next | ~20–60 min |
+| 4 — SSH & sudo | | ~3 min |
+| 5 — Run homeserver.sh | | ~20 min |
+| 6 — Verify & explore | | ~2 min |
+
+➡️ **[Step 3: Install the OS](03-install-os.md)**

--- a/docs/Setup-Guide/02-smtp-account.md
+++ b/docs/Setup-Guide/02-smtp-account.md
@@ -20,6 +20,7 @@ one below.
 | **Mailbox.org** (recommended) | [Change e-mail password / app password](https://kb.mailbox.org/de/privat/sicherheit-privatsphaere/e-mail-passwort/) | [Server, ports, encryption](https://kb.mailbox.org/de/privat/e-mail/e-mail-konfiguration/#3-postausgangsserver-ports-und-verschl%C3%BCsselung) |
 | **Posteo** | [Account password / 2FA setup](https://posteo.de/hilfe/wie-andere-mein-passwort) | [SMTP server settings](https://posteo.de/hilfe/welche-einstellungen-brauche-ich-fuer-imap-pop3-und-smtp) |
 | **IONOS Mail** | [Mailbox password](https://www.ionos.de/hilfe/e-mail/allgemeine-themen/mailbox-passwort-aendern/) | [Server data for mail programs](https://www.ionos.de/hilfe/e-mail/allgemeine-themen/serverdaten-fuer-e-mail-programme/) |
+| **Google Mail** | [App password (requires 2-Step Verification)](https://support.google.com/mail/answer/185833) | [SMTP server settings](https://support.google.com/mail/answer/7126229) |
 
 > [!TIP]
 > Use an **app-specific password** wherever the provider supports it

--- a/docs/Setup-Guide/03-install-os.md
+++ b/docs/Setup-Guide/03-install-os.md
@@ -1,7 +1,7 @@
-# Step 2 — Install the OS
+# Step 3 — Install the OS
 
-> **Setup Guide** · Step 2 of 5 · ▰▰▱▱▱ 40% · ~5 min spent · ~45 min to go
-> [← Step 1: deSEC account](01-deSEC-account.md) · **Step 2: Install OS** · [Step 3: SSH & sudo →](03-ssh-and-sudo.md)
+> **Setup Guide** · Step 3 of 6 · ▰▰▰▱▱▱ 50% · ~10 min spent · ~45 min to go
+> [← Step 2: SMTP account](02-smtp-account.md) · **Step 3: Install OS** · [Step 4: SSH & sudo →](04-ssh-and-sudo.md)
 
 You'll install **AlmaLinux 9** on your hardware (or VPS). Pick the
 sub-method that fits your situation — each is a separate detailed
@@ -52,7 +52,7 @@ yet implemented — tracked in
 
 ## What you'll have when you come back
 
-Whichever path you pick, you should end Step 2 with:
+Whichever path you pick, you should end Step 3 with:
 
 - AlmaLinux 9 booted on the machine.
 - An **IP address** for the server (note it down).
@@ -64,9 +64,10 @@ Whichever path you pick, you should end Step 2 with:
 | Step | Status | Time |
 |---|---|---|
 | 1 — deSEC account | ✅ done | ~5 min |
-| 2 — Install OS | in progress | ~20–60 min |
-| 3 — SSH & sudo | next | ~3 min |
-| 4 — Run homeserver.sh | | ~20 min |
-| 5 — Verify & explore | | ~2 min |
+| 2 — SMTP account | ✅ done | ~5 min |
+| 3 — Install OS | in progress | ~20–60 min |
+| 4 — SSH & sudo | next | ~3 min |
+| 5 — Run homeserver.sh | | ~20 min |
+| 6 — Verify & explore | | ~2 min |
 
-➡️ **[Step 3: SSH in & verify sudo](03-ssh-and-sudo.md)**
+➡️ **[Step 4: SSH in & verify sudo](04-ssh-and-sudo.md)**

--- a/docs/Setup-Guide/04-ssh-and-sudo.md
+++ b/docs/Setup-Guide/04-ssh-and-sudo.md
@@ -1,7 +1,7 @@
-# Step 3 — SSH in & verify sudo
+# Step 4 — SSH in & verify sudo
 
-> **Setup Guide** · Step 3 of 5 · ▰▰▰▱▱ 60% · ~25 min spent · ~25 min to go
-> [← Step 2: Install OS](02-install-os.md) · **Step 3: SSH & sudo** · [Step 4: Run homeserver.sh →](04-run-setup.md)
+> **Setup Guide** · Step 4 of 6 · ▰▰▰▰▱▱ 67% · ~30 min spent · ~25 min to go
+> [← Step 3: Install OS](03-install-os.md) · **Step 4: SSH & sudo** · [Step 5: Run homeserver.sh →](05-run-setup.md)
 
 The shortest step. ~3 minutes — confirm you can SSH in and that
 your user can run `sudo` without a password.
@@ -63,9 +63,10 @@ You should now be:
 | Step | Status | Time |
 |---|---|---|
 | 1 — deSEC account | ✅ done | ~5 min |
-| 2 — Install OS | ✅ done | ~20–60 min |
-| 3 — SSH & sudo | ✅ done | ~3 min |
-| 4 — Run homeserver.sh | next | ~20 min |
-| 5 — Verify & explore | | ~2 min |
+| 2 — SMTP account | ✅ done | ~5 min |
+| 3 — Install OS | ✅ done | ~20–60 min |
+| 4 — SSH & sudo | ✅ done | ~3 min |
+| 5 — Run homeserver.sh | next | ~20 min |
+| 6 — Verify & explore | | ~2 min |
 
-➡️ **[Step 4: Run homeserver.sh](04-run-setup.md)**
+➡️ **[Step 5: Run homeserver.sh](05-run-setup.md)**

--- a/docs/Setup-Guide/05-run-setup.md
+++ b/docs/Setup-Guide/05-run-setup.md
@@ -1,7 +1,7 @@
-# Step 4 — Run homeserver.sh
+# Step 5 — Run homeserver.sh
 
-> **Setup Guide** · Step 4 of 5 · ▰▰▰▰▱ 80% · ~28 min spent · ~22 min to go
-> [← Step 3: SSH & sudo](03-ssh-and-sudo.md) · **Step 4: Run homeserver.sh** · [Step 5: Verify →](05-verify-and-explore.md)
+> **Setup Guide** · Step 5 of 6 · ▰▰▰▰▰▱ 83% · ~33 min spent · ~22 min to go
+> [← Step 4: SSH & sudo](04-ssh-and-sudo.md) · **Step 5: Run homeserver.sh** · [Step 6: Verify →](06-verify-and-explore.md)
 
 The longest step (~20 min), but most of it is unattended. ~3
 minutes of your attention up front, ~17 minutes of "container
@@ -39,7 +39,7 @@ curl -fsSL https://raw.githubusercontent.com/luckynrslevin/home-server/main/home
 
 > [!IMPORTANT]
 > Run this **on the server** (i.e. inside the SSH session from
-> Step 3) — not on your laptop. **The script provisions the
+> Step 4) — not on your laptop. **The script provisions the
 > machine it runs on.**
 
 ### What you'll see
@@ -77,9 +77,10 @@ Roughly in order:
 | Step | Status | Time |
 |---|---|---|
 | 1 — deSEC account | ✅ done | ~5 min |
-| 2 — Install OS | ✅ done | ~20–60 min |
-| 3 — SSH & sudo | ✅ done | ~3 min |
-| 4 — Run homeserver.sh | in progress | ~20 min |
-| 5 — Verify & explore | next | ~2 min |
+| 2 — SMTP account | ✅ done | ~5 min |
+| 3 — Install OS | ✅ done | ~20–60 min |
+| 4 — SSH & sudo | ✅ done | ~3 min |
+| 5 — Run homeserver.sh | in progress | ~20 min |
+| 6 — Verify & explore | next | ~2 min |
 
-➡️ **[Step 5: Verify & explore](05-verify-and-explore.md)**
+➡️ **[Step 6: Verify & explore](06-verify-and-explore.md)**

--- a/docs/Setup-Guide/06-verify-and-explore.md
+++ b/docs/Setup-Guide/06-verify-and-explore.md
@@ -1,7 +1,7 @@
-# Step 5 — Verify & explore
+# Step 6 — Verify & explore
 
-> **Setup Guide** · Step 5 of 5 · ▰▰▰▰▰ 100% · ~48 min spent · ~2 min to go
-> [← Step 4: Run homeserver.sh](04-run-setup.md) · **Step 5: Verify & explore**
+> **Setup Guide** · Step 6 of 6 · ▰▰▰▰▰▰ 100% · ~53 min spent · ~2 min to go
+> [← Step 5: Run homeserver.sh](05-run-setup.md) · **Step 6: Verify & explore**
 
 You're ~2 minutes from a working homeserver. ☕
 
@@ -55,7 +55,7 @@ good first stops:
   in with the admin credentials from your vault, drop a PDF into
   the consume folder, watch OCR + tagging happen.
 - **Jellyfin** (`https://jellyfin.<sub>.dedyn.io/`) — point it at
-  your media library (if you set up NFS in Step 2 / inventory),
+  your media library (if you set up NFS in Step 3 / inventory),
   install the iOS / tvOS / Android client.
 - **Music Assistant** (`https://music.<sub>.dedyn.io/`) — point
   it at your music collection in Jellyfin (built-in provider) and
@@ -77,12 +77,13 @@ admin-console click-through)
 | Step | Status | Time |
 |---|---|---|
 | 1 — deSEC account | ✅ done | ~5 min |
-| 2 — Install OS | ✅ done | ~20–60 min |
-| 3 — SSH & sudo | ✅ done | ~3 min |
-| 4 — Run homeserver.sh | ✅ done | ~20 min |
-| 5 — Verify & explore | ✅ done | ~2 min |
+| 2 — SMTP account | ✅ done | ~5 min |
+| 3 — Install OS | ✅ done | ~20–60 min |
+| 4 — SSH & sudo | ✅ done | ~3 min |
+| 5 — Run homeserver.sh | ✅ done | ~20 min |
+| 6 — Verify & explore | ✅ done | ~2 min |
 
-Total: **~50–90 min** to your own homeserver. Welcome to owning
+Total: **~55–95 min** to your own homeserver. Welcome to owning
 your data.
 
 ## Where to next

--- a/docs/Setup-Guide/README.md
+++ b/docs/Setup-Guide/README.md
@@ -1,6 +1,6 @@
 # Setup Guide
 
-> **Setup Guide** · Index · ▱▱▱▱▱ 0% · ~50–90 min total
+> **Setup Guide** · Index · ▱▱▱▱▱▱ 0% · ~55–95 min total
 
 Welcome. By the end of this guide you'll have a fully-deployed
 homeserver reachable from your laptop at
@@ -18,13 +18,14 @@ Paperless, Ente Photos, Jellyfin, Music Assistant.
 | # | Step | Time | What you'll have at the end |
 |---|---|---|---|
 | 1 | [deSEC account](01-deSEC-account.md) | ~5 min | A free `*.dedyn.io` subdomain + an API token in your clipboard. |
-| 2 | [Install the OS](02-install-os.md) | ~20–60 min | AlmaLinux 9 booted on your hardware or VPS, SSH-reachable. |
-| 3 | [SSH & sudo](03-ssh-and-sudo.md) | ~3 min | A working SSH session as a non-root user with passwordless sudo. |
-| 4 | [Run homeserver.sh](04-run-setup.md) | ~20 min | The full stack deployed, certs issued, services running. |
-| 5 | [Verify & explore](05-verify-and-explore.md) | ~2 min | You're logged into the dashboard. Done. |
+| 2 | [SMTP account](02-smtp-account.md) | ~5 min | A mail provider + app-specific password for the homeserver to send notifications. |
+| 3 | [Install the OS](03-install-os.md) | ~20–60 min | AlmaLinux 9 booted on your hardware or VPS, SSH-reachable. |
+| 4 | [SSH & sudo](04-ssh-and-sudo.md) | ~3 min | A working SSH session as a non-root user with passwordless sudo. |
+| 5 | [Run homeserver.sh](05-run-setup.md) | ~20 min | The full stack deployed, certs issued, services running. |
+| 6 | [Verify & explore](06-verify-and-explore.md) | ~2 min | You're logged into the dashboard. Done. |
 
-**Total budget:** ~50–90 min depending on which OS install method you
-pick in Step 2.
+**Total budget:** ~55–95 min depending on which OS install method you
+pick in Step 3.
 
 ## Prerequisites
 

--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -61,6 +61,7 @@ my_linux_users:
 ##################################################################################################
 ### Caddy reverse proxy — TLS for *.<caddy_domain> via DNS-01 (deSEC example).
 ### Every web UI is exposed only via Caddy; per-service ports stay unpublished.
+### For deSEC account + token setup see docs/Setup-Guide/01-deSEC-account.md.
 caddy_domain: "example.dedyn.io"               # your public domain
 caddy_acme_provider: "desec"                   # see Caddy DNS provider docs
 caddy_acme_subdomain: "example"                # for deSEC: dynDNS subname

--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -42,6 +42,9 @@ deploy_services:
 ##################################################################################################
 ### Linux users — pin UID/GID per service for rootless container isolation.
 ### Add an entry for every service you enable in deploy_services.
+### Usually no need to change: the defaults below are the values used in
+### the reference deployment. Only adjust if a UID/GID already collides
+### with existing accounts on your host.
 my_linux_users:
   youruser:       {uid: 1000, gid: 1000}
   webproxy:       {uid: 1001, gid: 1001}   # caddy
@@ -70,6 +73,9 @@ os_base_hostname: "homeserver"
 # One entry per app you want fronted by Caddy. <subdomain>.<caddy_domain>.
 # Default proto is http (container-internal); set https for self-signed
 # upstreams (pihole, syncthing).
+# Usually no need to change: the defaults below match the apps shipped
+# in this project. Remove rows for apps you do not deploy; add a row
+# only if you front a custom service through Caddy.
 caddy_reverse_proxy_services:
   - {subdomain: pihole,      port: 8443, proto: https}
   - {subdomain: syncthing,   port: 8384, proto: https}

--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -28,14 +28,14 @@ deploy_services:
   - backup           # platform — nightly NAS backup (optional)
   - os-tailscale     # platform — mesh VPN (optional)
   # ── apps ──
-  # - syncthing
-  # - shairportsync
+  # - nextcloud
+  # - paperless-ngx
   # - entephoto
   # - entephoto-export
-  # - paperless-ngx
   # - jellyfin
   # - music-assistant
-  # - nextcloud
+  # - shairportsync
+  # - syncthing
 ##################################################################################################
 
 
@@ -94,6 +94,19 @@ caddy_reverse_proxy_services:
 
 
 ##################################################################################################
+### SMTP relay (project-level — consumed by Nextcloud, Ente, Paperless, backup alerts).
+### See docs/SMTP-Setup.md for provider setup. Leave undefined to disable.
+smtp_host: "smtp.example.org"
+smtp_port: 587
+smtp_encryption: "starttls"
+smtp_username: "you@example.org"
+smtp_from: "you@example.org"
+smtp_password: !vault |
+  <ansible-vault-encrypted SMTP password>
+##################################################################################################
+
+
+##################################################################################################
 ### Pi-hole — LAN DNS that resolves *.<caddy_domain> to this host.
 pihole_container_dns: "9.9.9.9"                 # upstream fallback inside the container
 pihole_domain_name: "lan"
@@ -128,19 +141,6 @@ backup_nas_snapshot_port: 1022                  # NAS sshd port if non-default
 
 
 ##################################################################################################
-### SMTP relay (project-level — consumed by Nextcloud, Ente, Paperless, backup alerts).
-### See docs/SMTP-Setup.md for provider setup. Leave undefined to disable.
-smtp_host: "smtp.example.org"
-smtp_port: 587
-smtp_encryption: "starttls"
-smtp_username: "you@example.org"
-smtp_from: "you@example.org"
-smtp_password: !vault |
-  <ansible-vault-encrypted SMTP password>
-##################################################################################################
-
-
-##################################################################################################
 ### Tailscale (optional) — leave os_tailscale_auth_key empty to skip.
 # os_tailscale_auth_key: !vault |
 #   <ansible-vault-encrypted Tailscale auth key>
@@ -148,16 +148,44 @@ smtp_password: !vault |
 
 
 ##################################################################################################
-### Shairport-sync (AirPlay receiver, optional).
-shairportsync_airplay_name: "living-room"
+##################################################################################################
+###                                       APPS                                                 ###
+##################################################################################################
 ##################################################################################################
 
 
 ##################################################################################################
-### Syncthing
-### No role-level secrets. Identity (device ID, cert, API key) lives in the
-### config volume and survives redeploys via the NAS backup/restore flow.
-### See roles/apps/syncthing/README.md for restoring an existing identity.
+### Nextcloud
+nextcloud_admin_password: !vault |
+  <ansible-vault-encrypted admin password>
+nextcloud_db_password: !vault |
+  <ansible-vault-encrypted postgres password>
+##################################################################################################
+
+
+##################################################################################################
+### Paperless-NGX
+paperless_url: "https://paperless.example.dedyn.io"
+paperless_secret_key: !vault |
+  <ansible-vault-encrypted — openssl rand -hex 32>
+paperless_db_password: !vault |
+  <ansible-vault-encrypted postgres password>
+paperless_admin_password: !vault |
+  <ansible-vault-encrypted admin password>
+
+paperless_consumer_recursive: true
+paperless_consumer_subdirs_as_tags: true
+paperless_consumer_delete_duplicates: true
+# Subdirs created inside the SFTP scan-drop volume — one per person/scanner.
+paperless_sftp_scan_subdirs:
+  - alice
+  - bob
+
+# Optional SFTP sidecar so a network scanner can drop PDFs directly.
+# See roles/apps/paperless-ngx/README.md.
+paperless_sftp_ingest_enabled: false
+paperless_sftp_ingest_authorized_keys: []
+#   - "ssh-ed25519 AAAA... scanner@brother"
 ##################################################################################################
 
 
@@ -204,32 +232,6 @@ entephoto_export_account_password: !vault |
 
 
 ##################################################################################################
-### Paperless-NGX
-paperless_url: "https://paperless.example.dedyn.io"
-paperless_secret_key: !vault |
-  <ansible-vault-encrypted — openssl rand -hex 32>
-paperless_db_password: !vault |
-  <ansible-vault-encrypted postgres password>
-paperless_admin_password: !vault |
-  <ansible-vault-encrypted admin password>
-
-paperless_consumer_recursive: true
-paperless_consumer_subdirs_as_tags: true
-paperless_consumer_delete_duplicates: true
-# Subdirs created inside the SFTP scan-drop volume — one per person/scanner.
-paperless_sftp_scan_subdirs:
-  - alice
-  - bob
-
-# Optional SFTP sidecar so a network scanner can drop PDFs directly.
-# See roles/apps/paperless-ngx/README.md.
-paperless_sftp_ingest_enabled: false
-paperless_sftp_ingest_authorized_keys: []
-#   - "ssh-ed25519 AAAA... scanner@brother"
-##################################################################################################
-
-
-##################################################################################################
 ### Jellyfin
 # NFS-mount video shares from the NAS (or omit and use a local path).
 jellyfin_nas_mounts:
@@ -258,9 +260,14 @@ music_assistant_internal_hosts:
 
 
 ##################################################################################################
-### Nextcloud
-nextcloud_admin_password: !vault |
-  <ansible-vault-encrypted admin password>
-nextcloud_db_password: !vault |
-  <ansible-vault-encrypted postgres password>
+### Shairport-sync (AirPlay receiver, optional).
+shairportsync_airplay_name: "living-room"
+##################################################################################################
+
+
+##################################################################################################
+### Syncthing
+### No role-level secrets. Identity (device ID, cert, API key) lives in the
+### config volume and survives redeploys via the NAS backup/restore flow.
+### See roles/apps/syncthing/README.md for restoring an existing identity.
 ##################################################################################################


### PR DESCRIPTION
Add short "usually no need to change" hints to the two example sections that ship sensible defaults — `my_linux_users` and `caddy_reverse_proxy_services` — so a new operator copying the template into their private overlay can tell at a glance which sections are pure defaults vs. ones that demand real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)