### PR TITLE
docs(inventory): rename example SSH user youruser → ansible

### DIFF
--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -46,7 +46,7 @@ deploy_services:
 ### the reference deployment. Only adjust if a UID/GID already collides
 ### with existing accounts on your host.
 my_linux_users:
-  youruser:       {uid: 1000, gid: 1000}
+  ansible:        {uid: 1000, gid: 1000}   # the SSH user ansible connects as
   webproxy:       {uid: 1001, gid: 1001}   # caddy
   pihole:         {uid: 1005, gid: 1005}
   syncthg:        {uid: 1003, gid: 1003}

--- a/inventory/hosts.yml.example
+++ b/inventory/hosts.yml.example
@@ -12,7 +12,7 @@
 #
 #   Host homeserver
 #       Hostname 192.168.1.10
-#       User youruser
+#       User ansible
 #       IdentityFile ~/.ssh/id_ed25519
 
 all:
@@ -21,11 +21,11 @@ all:
       hosts:
         homeserver:                            # Production server
           ansible_host: 192.168.1.10           # LAN IP (set as DHCP reservation)
-          ansible_user: youruser               # SSH user with passwordless sudo
+          ansible_user: ansible               # SSH user with passwordless sudo
           ansible_ssh_private_key_file: ~/.ssh/id_ed25519
 
         # Optional: a second host for testing playbook changes safely.
         # homeserver-test:
         #   ansible_host: 192.168.1.11
-        #   ansible_user: youruser
+        #   ansible_user: ansible
         #   ansible_ssh_private_key_file: ~/.ssh/id_ed25519


### PR DESCRIPTION
Rename `youruser` → `ansible` in the inventory examples so the SSH user's role (Ansible's connection user) is obvious from its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)