### PR TITLE
docs(inventory): tell user to uncomment apps they want to deploy

### DIFF
--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -41,7 +41,7 @@ deploy_services:
   - pihole           # platform — LAN DNS, resolves *.<caddy_domain>
   - backup           # platform — nightly NAS backup (optional)
   - os-tailscale     # platform — mesh VPN (optional)
-  # ── apps ──
+  # ── apps — uncomment each one you want to deploy on this host ──
   # - nextcloud
   # - paperless-ngx
   # - entephoto


### PR DESCRIPTION
Tiny clarification on the deploy_services apps block so a first-time reader sees the instruction at the same place as the commented list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)