### PR TITLE
docs(inventory): comment out os-tailscale in deploy_services example

### DIFF
--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -40,7 +40,7 @@ deploy_services:
   - dashboard        # platform — service-launcher landing page
   - pihole           # platform — LAN DNS, resolves *.<caddy_domain>
   - backup           # platform — nightly NAS backup (optional)
-  - os-tailscale     # platform — mesh VPN (optional)
+  # - os-tailscale   # platform — mesh VPN (still under construction, leave commented for now)
   # ── apps — uncomment each one you want to deploy on this host ──
   # - nextcloud
   # - paperless-ngx


### PR DESCRIPTION
Tailscale role is still under active development; flag it as not-ready in the template so new operators don't enable it by default.