### PR TITLE
docs(inventory): warn against editing platform deploy_services lines

### DIFF
--- a/inventory/host_vars/homeserver.yml.example
+++ b/inventory/host_vars/homeserver.yml.example
@@ -36,11 +36,11 @@
 ###
 ### >>> YOU MUST SET — pick the services you want on this host:
 deploy_services:
-  - caddy            # platform — mandatory reverse proxy
-  - dashboard        # platform — service-launcher landing page
-  - pihole           # platform — LAN DNS, resolves *.<caddy_domain>
-  - backup           # platform — nightly NAS backup (optional)
-  # - os-tailscale   # platform — mesh VPN (still under construction, leave commented for now)
+  - caddy            # platform DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO — mandatory reverse proxy
+  - dashboard        # platform DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO — service-launcher landing page
+  - pihole           # platform DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO — LAN DNS, resolves *.<caddy_domain>
+  - backup           # platform DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO — nightly NAS backup (optional)
+  # - os-tailscale   # platform DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO — mesh VPN (still under construction, leave commented for now)
   # ── apps — uncomment each one you want to deploy on this host ──
   # - nextcloud
   # - paperless-ngx


### PR DESCRIPTION
Flag every platform entry in the example `deploy_services` list with `DO NOT CHANGE UNTIL YOU EXACTLY KNOW WHAT YOU DO` so a new operator doesn't accidentally strip out caddy / pihole / backup / dashboard while picking the apps they want.