### PR TITLE
inventory: split deploy_services into platform_services + apps; <svc>_enabled flags; dashboard mandatory

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -608,10 +608,12 @@ PY
             exit 1
         fi
         # Idempotency check: is the service already deployed?
+        # ansible-inventory returns raw Jinja for the group_vars-computed
+        # `deploy_services`, so union platform_services + apps ourselves.
         if ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
                 ansible-inventory --host "$TARGET" 2>/dev/null \
-                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in (d.get('deploy_services') or []) else 1)"; then
-            warn "$SERVICE is already in deploy_services for $TARGET."
+                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or []) + (d.get('deploy_services') or [])) else 1)"; then
+            warn "$SERVICE is already deployed on $TARGET."
             warn "Use \`homeserver.sh upgrade\` to re-deploy with latest images."
             exit 1
         fi
@@ -759,11 +761,13 @@ PY
             err "$VAULT_PW_FILE not readable. Is the host installed?"
             exit 1
         fi
-        # Idempotency check: IS the service in deploy_services?
+        # Idempotency check: is the service in platform_services or apps?
+        # (Union both lists — group_vars-computed deploy_services would
+        # come back as a raw Jinja string from ansible-inventory --host.)
         if ! ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
                 ansible-inventory --host "$TARGET" 2>/dev/null \
-                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in (d.get('deploy_services') or []) else 1)"; then
-            warn "$SERVICE is not in deploy_services for $TARGET — nothing to remove."
+                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or []) + (d.get('deploy_services') or [])) else 1)"; then
+            warn "$SERVICE is not deployed on $TARGET — nothing to remove."
             exit 1
         fi
         # Extract service user + uid + volumes from meta + role defaults
@@ -1367,15 +1371,31 @@ declare -A SERVICE_DEFAULT_YES=(
     [paperless-ngx]=1
 )
 
-# If inventory has a deploy_services list, prefer it: a service is
-# defaulted Y iff it's in the existing list.
-EXISTING_DEPLOY_SERVICES=$(inv_get deploy_services)
+# If inventory has the platform_services / apps split (or a legacy
+# deploy_services list), prefer it: a service is defaulted Y iff it's
+# in the existing union.
+EXISTING_PLATFORM=$(inv_get platform_services)
+EXISTING_APPS=$(inv_get apps)
+EXISTING_LEGACY=$(inv_get deploy_services)
 declare -A INV_DEPLOY=()
-if [[ -n "$EXISTING_DEPLOY_SERVICES" ]]; then
+_have_existing=""
+for _src in "$EXISTING_PLATFORM" "$EXISTING_APPS" "$EXISTING_LEGACY"; do
+    [[ -z "$_src" ]] && continue
+    # inv_get returns a literal Jinja string ("{{ ... }}") for the
+    # group_vars-computed deploy_services — skip those.
+    [[ "$_src" == \{\{*\}\}* || "$_src" == *\{\{* ]] && continue
+    _have_existing=1
     while IFS= read -r svc; do
         [[ -n "$svc" ]] && INV_DEPLOY[$svc]=1
-    done < <(echo "$EXISTING_DEPLOY_SERVICES" | python3 -c "import json,sys; print('\n'.join(json.load(sys.stdin)))")
-fi
+    done < <(echo "$_src" | python3 -c "import json,sys
+try:
+    d = json.load(sys.stdin)
+    if isinstance(d, list):
+        print('\n'.join(d))
+except Exception:
+    pass")
+done
+EXISTING_DEPLOY_SERVICES="$_have_existing"
 
 for svc in "${SERVICE_ORDER[@]}"; do
     desc="${SERVICES[$svc]}"
@@ -1563,7 +1583,28 @@ fi
 
 _split_header='# DO NOT EDIT — managed by homeserver.sh'
 
-# --- 00-services.yml: host identity + deploy_services list ---
+# --- 00-services.yml: host identity + platform_services + apps lists ---
+# Split SELECTED_SERVICES into platform infrastructure vs application
+# roles. `deploy_services` is computed in inventory/group_vars/all.yml
+# as the concatenation of the two — playbooks keep iterating that name.
+PLATFORM_SERVICES_CANON=(caddy dashboard pihole backup os-tailscale)
+_is_platform() {
+    local needle=$1 p
+    for p in "${PLATFORM_SERVICES_CANON[@]}"; do
+        [[ "$p" == "$needle" ]] && return 0
+    done
+    return 1
+}
+PLATFORM_SELECTED=()
+APPS_SELECTED=()
+for svc in "${SELECTED_SERVICES[@]}"; do
+    if _is_platform "$svc"; then
+        PLATFORM_SELECTED+=("$svc")
+    else
+        APPS_SELECTED+=("$svc")
+    fi
+done
+
 {
 cat << YAML
 $_split_header
@@ -1580,12 +1621,30 @@ os_base_hostname: $SERVER_HOSTNAME
 home_server_release: $HOME_SERVER_RELEASE
 
 ##################################################################################################
-### Services to deploy on this host (used by playbooks/site.yml)
-deploy_services:
+### Platform services — mandatory + optional infrastructure roles
+# caddy + dashboard are mandatory (asserted in playbooks/site.yml).
+# pihole / backup / os-tailscale are optional and additionally gated by
+# their <svc>_enabled flag (defaults to true when listed).
+platform_services:
 YAML
-for svc in "${SELECTED_SERVICES[@]}"; do
+for svc in "${PLATFORM_SELECTED[@]}"; do
     echo "  - $svc"
 done
+
+cat << YAML
+
+##################################################################################################
+### Apps — user-managed list. Add via \`homeserver.sh add <name>\`;
+### remove via \`homeserver.sh remove <name>\`.
+apps:
+YAML
+if [[ ${#APPS_SELECTED[@]} -eq 0 ]]; then
+    echo "  []"
+else
+    for svc in "${APPS_SELECTED[@]}"; do
+        echo "  - $svc"
+    done
+fi
 } > "$HOST_VARS_DIR/00-services.yml"
 
 # --- 01-linux-users.yml: my_linux_users dict ---
@@ -1849,6 +1908,7 @@ python3 scripts/split_inventory_extras.py \
     --old "$_unmanaged_snapshot" \
     --host-vars-dir "$HOST_VARS_DIR" \
     --extras "$HOST_VARS_DIR/20-extras.yml" \
+    --ignore deploy_services \
     2> >(while IFS= read -r line; do info "$line"; done >&2) \
     || warn "split_inventory_extras.py failed — check for lost operator-added keys"
 rm -f "$_unmanaged_snapshot"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,0 +1,10 @@
+# Public group_vars — applies to every host in the inventory.
+#
+# Bridges the platform_services + apps inventory split (PR-B and beyond)
+# to the legacy `deploy_services` name that all playbooks still reference.
+# Host_vars precedence means this is silently overridden on any host that
+# still has a hand-written `deploy_services:` block — keeps unmigrated
+# inventories working until `homeserver.sh install` re-runs and writes
+# the split-layout 00-services.yml.
+
+deploy_services: "{{ (platform_services | default([])) + (apps | default([])) }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,15 +1,18 @@
 ---
-# Unified playbook: deploys all services listed in deploy_services for each host.
+# Unified playbook: deploys all services listed in platform_services + apps
+# for each host. The legacy `deploy_services` name is the concatenation of
+# the two — computed in inventory/group_vars/all.yml so unmigrated
+# inventories keep working.
 #
 # Usage:
 #   ansible-playbook playbooks/site.yml --limit homeserver       # production
 #   ansible-playbook playbooks/site.yml --limit homeserver-test  # test
 #   ansible-playbook playbooks/site.yml                          # all hosts
 #
-# Each host defines its own deploy_services list in host_vars.
-# If deploy_services is not defined, nothing is deployed (safe default).
-# Individual playbooks (e.g. playbooks/syncthing.yml) still work for
-# targeted single-service deploys.
+# Each host defines its own platform_services + apps lists in host_vars.
+# Mandatory platform roles (caddy, dashboard) are asserted below.
+# Optional platform roles (pihole, backup, os-tailscale) are additionally
+# gated by <svc>_enabled (defaults to true when the service is listed).
 
 - name: Deploy all selected services
   hosts: homeservers
@@ -17,17 +20,18 @@
   gather_facts: true
 
   pre_tasks:
-    # Caddy is mandatory: every web UI in the project is reverse-proxied
-    # through Caddy on https://*.<caddy_domain>. Without Caddy + a
-    # configured domain, services have no externally trusted access path.
-    - name: Assert Caddy is in deploy_services
+    # Caddy + dashboard are mandatory: every web UI in the project is
+    # reverse-proxied through Caddy on https://*.<caddy_domain>, and the
+    # dashboard is the front-door landing page that surfaces them.
+    - name: Assert mandatory platform services are in platform_services
       ansible.builtin.assert:
         that:
           - "'caddy' in (deploy_services | default([]))"
+          - "'dashboard' in (deploy_services | default([]))"
         fail_msg: >-
-          'caddy' must be in deploy_services. Caddy is the mandatory
-          front-door reverse proxy for this project — direct per-service
-          HTTP ports are no longer exposed.
+          'caddy' and 'dashboard' are mandatory platform roles and must
+          appear in platform_services. Caddy is the front-door reverse
+          proxy; the dashboard surfaces the deployed services to users.
     - name: Assert caddy_domain is set
       ansible.builtin.assert:
         that:
@@ -42,11 +46,14 @@
     - { role: os-base }
     - role: os-tailscale
       when: >-
-        (os_tailscale_auth_key | default('') | length > 0)
-        or ('os-tailscale' in (deploy_services | default([])))
+        ('os-tailscale' in (deploy_services | default([])))
+        and (tailscale_enabled | default(true))
     - { role: caddy }
-    - { role: dashboard,     when: "'dashboard' in (deploy_services | default([]))" }
-    - { role: pihole,        when: "'pihole' in (deploy_services | default([]))" }
+    - { role: dashboard }
+    - role: pihole
+      when: >-
+        ('pihole' in (deploy_services | default([])))
+        and (pihole_enabled | default(true))
     - { role: syncthing,     when: "'syncthing' in (deploy_services | default([]))" }
     - { role: shairportsync, when: "'shairportsync' in (deploy_services | default([]))" }
     - { role: entephoto,     when: "'entephoto' in (deploy_services | default([]))" }
@@ -55,4 +62,7 @@
     - { role: jellyfin,        when: "'jellyfin' in (deploy_services | default([]))" }
     - { role: music-assistant, when: "'music-assistant' in (deploy_services | default([]))" }
     - { role: nextcloud,       when: "'nextcloud' in (deploy_services | default([]))" }
-    - { role: backup,          when: "'backup' in (deploy_services | default([]))" }
+    - role: backup
+      when: >-
+        ('backup' in (deploy_services | default([])))
+        and (backup_enabled | default(true))

--- a/scripts/build_add_update.py
+++ b/scripts/build_add_update.py
@@ -241,8 +241,12 @@ def main():
     dicts = {}
     side = meta.get("side_effects") or {}
 
-    # deploy_services always gets the service name appended
-    lists["deploy_services"] = {"items": [args.service]}
+    # Post platform/apps split: append the service name to whichever list
+    # it belongs to. Platform service names are canonical (see
+    # PLATFORM_SERVICES_CANON in homeserver.sh); everything else is an app.
+    _PLATFORM = {"caddy", "dashboard", "pihole", "backup", "os-tailscale"}
+    _list_name = "platform_services" if args.service in _PLATFORM else "apps"
+    lists[_list_name] = {"items": [args.service]}
 
     if "caddy_reverse_proxy_services" in side:
         lists["caddy_reverse_proxy_services"] = {

--- a/scripts/build_remove_update.py
+++ b/scripts/build_remove_update.py
@@ -45,8 +45,10 @@ def main():
     # so a placeholder is fine — we just need the keys)
     scalars = {k: {"value": "_"} for k in on_remove.get("inventory_vars_to_clear", []) or []}
 
-    # lists — remove the items this role added (deploy_services + caddy entries)
-    lists = {"deploy_services": {"items": [args.service]}}
+    # lists — remove the items this role added (platform_services/apps + caddy entries)
+    _PLATFORM = {"caddy", "dashboard", "pihole", "backup", "os-tailscale"}
+    _list_name = "platform_services" if args.service in _PLATFORM else "apps"
+    lists = {_list_name: {"items": [args.service]}}
     # side_effect_reversals: "auto" (default) reverses side_effects.
     # "none" skips reversal (operator wants the caddy/user entries
     # preserved even after the role is gone — rare; documented opt-out).

--- a/scripts/split_inventory_extras.py
+++ b/scripts/split_inventory_extras.py
@@ -78,6 +78,9 @@ def main() -> int:
     ap.add_argument("--host-vars-dir", required=True,
                     help="Directory containing the freshly-emitted split files")
     ap.add_argument("--extras", required=True, help="Target file for unmanaged keys")
+    ap.add_argument("--ignore", action="append", default=[],
+                    help="Top-level key to drop from migration (deprecated keys "
+                         "that have been semantically replaced). May be repeated.")
     args = ap.parse_args()
 
     yaml = make_yaml()
@@ -98,7 +101,8 @@ def main() -> int:
         return 0
 
     managed = collect_managed_keys(yaml, args.host_vars_dir)
-    unmanaged = [k for k in old_doc.keys() if k not in managed]
+    ignore = set(args.ignore)
+    unmanaged = [k for k in old_doc.keys() if k not in managed and k not in ignore]
 
     if not unmanaged:
         if not os.path.exists(args.extras):


### PR DESCRIPTION
Stacked on top of #261 (PR-A) — review/merge after PR-A lands. GitHub will rebase the base automatically once PR-A merges to main.

## Summary

- **Inventory split**: `deploy_services` → `platform_services` (caddy, dashboard, pihole, backup, os-tailscale) + `apps` (everything else). `deploy_services` lives on as a computed alias in the new `inventory/group_vars/all.yml`.
- **`<svc>_enabled` flags** gate optional platform roles (pihole, backup, os-tailscale). Default-true preserves existing behavior; operators opt out explicitly.
- **`dashboard` is mandatory** alongside `caddy` — asserted in `site.yml` pre_tasks; `when:` gate dropped.
- **Tool updates**: homeserver.sh emits the split, `add`/`remove` idempotency checks union both lists, `split_inventory_extras.py` gains `--ignore`, `build_add/remove_update.py` mutate `apps`/`platform_services` based on service name.
- **Backward compat**: unmigrated inventories with explicit `deploy_services:` keep working via host_vars > group_vars precedence.

Closes #262.

## Test plan

- [x] `bash -n homeserver.sh`
- [x] `ansible-playbook` against synthetic inventory — `deploy_services` resolves to the union at play time
- [x] `scripts/test_inventory_merge.sh` — 13/13 pass
- [ ] Bundle test with PR-A/C/D on homeserver2

🤖 Generated with [Claude Code](https://claude.com/claude-code)