### PR TITLE
homeserver.sh: include roles/platform + roles/apps in generated ansible.cfg

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -1164,7 +1164,7 @@ fi
 cat > ansible.cfg << EOF
 [defaults]
 inventory = inventory/hosts.yml
-roles_path = ./roles:./.ansible/roles:~/.ansible/roles:/usr/share/ansible/roles
+roles_path = ./roles/platform:./roles/apps:./roles:./.ansible/roles:~/.ansible/roles:/usr/share/ansible/roles
 stdout_callback = default
 host_key_checking = False
 vault_password_file = $VAULT_PW_FILE


### PR DESCRIPTION
## Summary

Fixes a regression from the platform/apps split: `homeserver.sh install` overwrites the repo's `ansible.cfg` with a heredoc that still has the pre-split `roles_path`, missing the `./roles/platform` and `./roles/apps` prefixes. Install completes, then `ansible-playbook` fails at the first role lookup:

```
[ERROR]: the role 'os-base' was not found in
/home/ansible/home-server/playbooks/roles:/home/ansible/home-server/roles:...
```

The repo's checked-in `ansible.cfg` was updated correctly during the split — only the heredoc was missed.

## Test plan

- [x] Diff verified
- [ ] Re-run install on homeserver2 — playbook proceeds past `os-base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)