### PR TITLE
fix(install): split host_vars layout + selective overlay symlink

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -1262,14 +1262,32 @@ pipelining = True
 use_tty = False
 EOF
 
-# Replace the public repo's inventory/ stub with a symlink into the
-# overlay so generated (Case 2) or existing (Case 3) inventory lives
-# in the overlay repo.
+# Point the public repo's inventory/ at the overlay for host-specific
+# data (hosts.yml + host_vars/<host>/) while keeping inventory/group_vars/
+# from the public repo intact — that's where deploy_services is
+# computed from platform_services + apps. The old scheme (whole-dir
+# symlink) shadowed group_vars/ and broke `deploy_services` at runtime.
 if [[ -n "$OVERLAY_URL" ]]; then
-    if [[ ! -L inventory ]]; then
-        rm -rf inventory
-        ln -s "$OVERLAY_DIR/inventory" inventory
-        ok "Symlinked inventory/ → $OVERLAY_DIR/inventory"
+    # Migrate any pre-existing whole-dir symlink to the new selective
+    # scheme. Idempotent — does nothing if already selective.
+    if [[ -L inventory ]]; then
+        rm inventory
+        git checkout -- inventory/ 2>/dev/null || true
+    fi
+    # Ensure the public inventory/ dir is there with its group_vars.
+    if [[ ! -d inventory ]]; then
+        git checkout -- inventory/ 2>/dev/null || mkdir -p inventory
+    fi
+    # Selective symlinks: hosts.yml + host_vars → overlay.
+    if [[ ! -L inventory/hosts.yml ]]; then
+        rm -f inventory/hosts.yml
+        ln -s "$OVERLAY_DIR/inventory/hosts.yml" inventory/hosts.yml
+        ok "Symlinked inventory/hosts.yml → $OVERLAY_DIR/inventory/hosts.yml"
+    fi
+    if [[ ! -L inventory/host_vars ]]; then
+        rm -rf inventory/host_vars
+        ln -s "$OVERLAY_DIR/inventory/host_vars" inventory/host_vars
+        ok "Symlinked inventory/host_vars → $OVERLAY_DIR/inventory/host_vars"
     fi
 fi
 

--- a/homeserver.sh
+++ b/homeserver.sh
@@ -53,6 +53,49 @@ resolve_meta_install() {
     return 1
 }
 
+# --- Split-layout helpers (post-PR-260 host_vars layout) ---
+# host_vars/<host>/ contains 00-services.yml … 60-tailscale.yml plus
+# apps/<svc>.yml — no monolithic main.yml. These helpers replace the
+# old `[[ -f .../main.yml ]]` existence/lookup checks that survived
+# the split.
+
+# Source of truth for platform-vs-app classification. Add/remove verbs
+# and the install flow both need this, so it lives at the top.
+PLATFORM_SERVICES_CANON=(caddy dashboard pihole backup os-tailscale)
+is_platform_service() {
+    local needle=$1 p
+    for p in "${PLATFORM_SERVICES_CANON[@]}"; do
+        [[ "$p" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# True if <dir> contains at least one *.yml file (top-level or under
+# apps/). Used to decide whether a host has an existing inventory in
+# the split layout, replacing the old `-f main.yml` check.
+host_vars_dir_has_content() {
+    local dir=$1
+    [[ -d "$dir" ]] || return 1
+    compgen -G "$dir"/*.yml >/dev/null 2>&1 && return 0
+    compgen -G "$dir"/apps/*.yml >/dev/null 2>&1 && return 0
+    return 1
+}
+
+# Print path to the first *.yml file under <dir> containing a
+# $ANSIBLE_VAULT block. Used by the install flow to verify the
+# supplied vault password decrypts the existing inventory.
+find_vault_yml() {
+    local dir=$1 f
+    [[ -d "$dir" ]] || return 1
+    while IFS= read -r -d '' f; do
+        if grep -q '\$ANSIBLE_VAULT' "$f" 2>/dev/null; then
+            printf '%s' "$f"
+            return 0
+        fi
+    done < <(find "$dir" -maxdepth 2 -type f -name '*.yml' -print0 2>/dev/null)
+    return 1
+}
+
 if [[ "${1:-}" =~ ^(install|add|remove|upgrade|backup|restore|uninstall|secret)$ ]]; then
     VERB="$1"
     shift
@@ -505,11 +548,17 @@ case "$VERB" in
                 info "Bumping release: $current_tag → $latest_in_major"
                 git checkout --quiet "$latest_in_major"
                 # Persist the new tag back to inventory so subsequent
-                # operations agree with the on-disk state.
+                # operations agree with the on-disk state. In the split
+                # layout home_server_release lives in 00-services.yml
+                # (next to platform_services + apps); fall back to the
+                # legacy main.yml if a pre-split host hasn't migrated.
                 NEW_TAG="$latest_in_major"
                 if [[ -r "$VAULT_PW_FILE" ]] && python3 -c "import ruamel.yaml" 2>/dev/null; then
-                    info "Updating inventory's home_server_release → $NEW_TAG"
-                    python3 - "$INSTALL_DIR/inventory/host_vars/$TARGET/main.yml" "$NEW_TAG" <<'PY' 2>/dev/null || warn "Could not auto-update inventory home_server_release; do it by hand."
+                    REL_FILE="$INSTALL_DIR/inventory/host_vars/$TARGET/00-services.yml"
+                    [[ -f "$REL_FILE" ]] || REL_FILE="$INSTALL_DIR/inventory/host_vars/$TARGET/main.yml"
+                    if [[ -f "$REL_FILE" ]]; then
+                        info "Updating inventory's home_server_release → $NEW_TAG ($REL_FILE)"
+                        python3 - "$REL_FILE" "$NEW_TAG" <<'PY' 2>/dev/null || warn "Could not auto-update inventory home_server_release; do it by hand."
 import sys
 from ruamel.yaml import YAML
 inv_path, new_tag = sys.argv[1], sys.argv[2]
@@ -520,6 +569,9 @@ data['home_server_release'] = new_tag
 with open(inv_path, 'w') as f:
     yaml.dump(data, f)
 PY
+                    else
+                        warn "Could not find a host_vars file to persist home_server_release; do it by hand."
+                    fi
                 fi
             else
                 ok "Already on latest v${major}.x release ($current_tag) — refreshing images + ansible state."
@@ -693,15 +745,33 @@ PY
                 exit 1
             fi
         fi
-        INV_FILE="$INSTALL_DIR/inventory/host_vars/$TARGET/main.yml"
-        info "Merging into $INV_FILE..."
-        if ! python3 scripts/inventory_merge.py \
-                --inventory "$INV_FILE" \
-                --vault-password-file "$VAULT_PW_FILE" \
-                --update "$UPDATE_JSON" \
-                --mode add; then
-            err "Failed to merge inventory."
-            exit 1
+        HV_DIR="$INSTALL_DIR/inventory/host_vars/$TARGET"
+        # Post-PR-260 layout: route the update across split files
+        # (00-services.yml / 01-linux-users.yml / 10-caddy.yml / apps/<svc>.yml).
+        # If the host hasn't migrated yet (only main.yml exists), fall
+        # back to the legacy single-file merge so the verb keeps working.
+        if [[ -f "$HV_DIR/main.yml" ]] && ! compgen -G "$HV_DIR"/*.yml | grep -qv '/main\.yml$'; then
+            INV_FILE="$HV_DIR/main.yml"
+            info "Merging into $INV_FILE (legacy layout)..."
+            if ! python3 scripts/inventory_merge.py \
+                    --inventory "$INV_FILE" \
+                    --vault-password-file "$VAULT_PW_FILE" \
+                    --update "$UPDATE_JSON" \
+                    --mode add; then
+                err "Failed to merge inventory."
+                exit 1
+            fi
+        else
+            info "Merging into $HV_DIR/ (split layout)..."
+            if ! python3 scripts/inventory_merge.py \
+                    --host-vars-dir "$HV_DIR" \
+                    --service "$SERVICE" \
+                    --vault-password-file "$VAULT_PW_FILE" \
+                    --update "$UPDATE_JSON" \
+                    --mode add; then
+                err "Failed to merge inventory."
+                exit 1
+            fi
         fi
         ok "Inventory updated."
         # Run the role's playbooks
@@ -841,14 +911,28 @@ print(' '.join(on_remove.get('volumes_to_preserve_unless_purge') or []))
             err "Failed to build remove spec for $SERVICE."
             exit 1
         fi
-        INV_FILE="$INSTALL_DIR/inventory/host_vars/$TARGET/main.yml"
-        if ! python3 scripts/inventory_merge.py \
-                --inventory "$INV_FILE" \
-                --vault-password-file "$VAULT_PW_FILE" \
-                --update "$UPDATE_JSON" \
-                --mode remove; then
-            err "Failed to update inventory."
-            exit 1
+        HV_DIR="$INSTALL_DIR/inventory/host_vars/$TARGET"
+        # Same legacy/split layout dispatch as `add` above.
+        if [[ -f "$HV_DIR/main.yml" ]] && ! compgen -G "$HV_DIR"/*.yml | grep -qv '/main\.yml$'; then
+            INV_FILE="$HV_DIR/main.yml"
+            if ! python3 scripts/inventory_merge.py \
+                    --inventory "$INV_FILE" \
+                    --vault-password-file "$VAULT_PW_FILE" \
+                    --update "$UPDATE_JSON" \
+                    --mode remove; then
+                err "Failed to update inventory."
+                exit 1
+            fi
+        else
+            if ! python3 scripts/inventory_merge.py \
+                    --host-vars-dir "$HV_DIR" \
+                    --service "$SERVICE" \
+                    --vault-password-file "$VAULT_PW_FILE" \
+                    --update "$UPDATE_JSON" \
+                    --mode remove; then
+                err "Failed to update inventory."
+                exit 1
+            fi
         fi
         ok "Inventory updated."
         info "Refreshing caddy + dashboard..."
@@ -1074,7 +1158,7 @@ if [[ -n "$OVERLAY_URL" ]]; then
         chmod 400 "$OVERLAY_DIR/vault.pw"
     fi
 
-    if [[ -f "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml" ]]; then
+    if host_vars_dir_has_content "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME"; then
         USE_EXISTING_INVENTORY=true
         ok "Overlay has existing inventory for '$SERVER_HOSTNAME' — will reuse as defaults."
     else
@@ -1103,10 +1187,13 @@ if [[ -n "$OVERLAY_URL" ]]; then
     if [[ "$USE_EXISTING_INVENTORY" == "true" ]]; then
         # Verify vault password works against the existing inventory.
         # `ansible-vault view` only handles whole-file-encrypted files;
-        # our main.yml uses inline `!vault |` blocks. Extract the first
-        # such block, decrypt it standalone, check exit code.
+        # the split files use inline `!vault |` blocks (typically
+        # 10-caddy.yml's caddy_acme_token). Find the first split file
+        # carrying a vault block, extract that block, decrypt it
+        # standalone, check the exit code.
         verify_tmp=$(mktemp)
-        python3 - "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml" > "$verify_tmp" <<'PY'
+        if vault_yml=$(find_vault_yml "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME"); then
+            python3 - "$vault_yml" > "$verify_tmp" <<'PY'
 import sys
 with open(sys.argv[1]) as f:
     lines = f.readlines()
@@ -1122,12 +1209,13 @@ while i < len(lines):
         break
     i += 1
 PY
+        fi
         if [[ -s "$verify_tmp" ]]; then
             if ! ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
                     ansible-vault decrypt --output - "$verify_tmp" &>/dev/null; then
                 rm -f "$verify_tmp"
                 err "Vault password doesn't decrypt the existing inventory at"
-                err "  $OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml"
+                err "  ${vault_yml:-$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME/}"
                 err "Re-run homeserver.sh with the correct vault password."
                 exit 1
             fi
@@ -1189,7 +1277,9 @@ info "Step 5/7: Configuring your server..."
 
 # Load existing inventory (if any) so every prompt below can default
 # from its previous value. Decrypts vault blocks in the dict.
-if [[ -f "inventory/host_vars/$SERVER_HOSTNAME/main.yml" ]]; then
+# ansible-inventory --host walks every *.yml under host_vars/<host>/
+# (and the apps/ subdir), so any split-layout file present counts.
+if host_vars_dir_has_content "inventory/host_vars/$SERVER_HOSTNAME"; then
     EXISTING_VARS_JSON=$(ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
         ansible-inventory --host "$SERVER_HOSTNAME" 2>/dev/null) || EXISTING_VARS_JSON='{}'
     if [[ "$EXISTING_VARS_JSON" != "{}" ]]; then
@@ -1587,18 +1677,12 @@ _split_header='# DO NOT EDIT — managed by homeserver.sh'
 # Split SELECTED_SERVICES into platform infrastructure vs application
 # roles. `deploy_services` is computed in inventory/group_vars/all.yml
 # as the concatenation of the two — playbooks keep iterating that name.
-PLATFORM_SERVICES_CANON=(caddy dashboard pihole backup os-tailscale)
-_is_platform() {
-    local needle=$1 p
-    for p in "${PLATFORM_SERVICES_CANON[@]}"; do
-        [[ "$p" == "$needle" ]] && return 0
-    done
-    return 1
-}
+# (Platform classification helper `is_platform_service` is defined at
+# the top of this script so add/remove verbs can use it too.)
 PLATFORM_SELECTED=()
 APPS_SELECTED=()
 for svc in "${SELECTED_SERVICES[@]}"; do
-    if _is_platform "$svc"; then
+    if is_platform_service "$svc"; then
         PLATFORM_SELECTED+=("$svc")
     else
         APPS_SELECTED+=("$svc")
@@ -1920,7 +2004,7 @@ if [[ -f "$HOST_VARS_DIR/main.yml" ]]; then
     info "Archived pre-split main.yml → $HOST_VARS_DIR/main.yml.pre-split.bak"
 fi
 
-ok "Generated inventory/host_vars/$SERVER_HOSTNAME/main.yml (with vault-encrypted secrets)"
+ok "Generated split host_vars under inventory/host_vars/$SERVER_HOSTNAME/ (with vault-encrypted secrets)"
 
 # --- Generate dashboard config ---
 # Only include services that were actually selected for deployment, so
@@ -2169,7 +2253,7 @@ echo -e "${BOLD}Back up ${VAULT_PW_FILE} into your password manager now.${NC}"
 echo "Without it you cannot re-deploy this host or decrypt its inventory."
 echo
 echo "Configuration files:"
-echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/main.yml"
+echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/  (split host_vars: 00-services.yml … 60-tailscale.yml, apps/<svc>.yml)"
 echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
 echo
 

--- a/scripts/inventory_merge.py
+++ b/scripts/inventory_merge.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 """
-scripts/inventory_merge.py — additively merge into an inventory main.yml.
+scripts/inventory_merge.py — additively merge into a host's inventory.
 
-Used by `setup.sh add <service>` and `setup.sh remove <service>` to mutate
-host_vars/<host>/main.yml without disturbing operator-added unmanaged
+Used by `homeserver.sh add <service>` and `homeserver.sh remove <service>`
+to mutate host_vars/<host>/ without disturbing operator-added unmanaged
 keys, comments, or formatting.
+
+Two layout modes:
+
+  --inventory <path>          legacy: write a single monolithic file
+                              (host_vars/<host>/main.yml).
+  --host-vars-dir <dir>       split layout (post-PR-260): route updates
+  --service <name>            across 00-services.yml / 01-linux-users.yml /
+                              10-caddy.yml / apps/<svc>.yml etc. according
+                              to which file owns each top-level key.
 
 Round-trip safety: built on ruamel.yaml's typ='rt' mode, which preserves
 comments, blank-line groupings, key order, and YAML tags (including
@@ -13,6 +22,12 @@ produce zero git diff.
 
 Usage:
     inventory_merge.py --inventory <main.yml>
+                       --vault-password-file <vault.pw>
+                       --update <update.json>
+                       --mode add|remove
+
+    inventory_merge.py --host-vars-dir <host_vars/<host>/>
+                       --service <name>
                        --vault-password-file <vault.pw>
                        --update <update.json>
                        --mode add|remove
@@ -339,40 +354,190 @@ def cmd_remove(data, update):
             _remove_dict_entry_preserving_comments(existing, k)
 
 
+# ----- Split-layout routing -----
+#
+# In the split host_vars layout (post-PR-260), shared keys live in
+# fixed files and service-specific scalars live in per-service files.
+# The map below is the source of truth for the "shared" half; everything
+# else falls through to the service's own file (apps/<svc>.yml for apps;
+# the dedicated <NN>-<svc>.yml for platform services that have one).
+
+KEY_TO_SPLIT_FILE = {
+    # 00-services.yml
+    "platform_services": "00-services.yml",
+    "apps": "00-services.yml",
+    "home_server_release": "00-services.yml",
+    "os_base_hostname": "00-services.yml",
+    # 01-linux-users.yml
+    "my_linux_users": "01-linux-users.yml",
+    # 10-caddy.yml
+    "caddy_domain": "10-caddy.yml",
+    "caddy_acme_provider": "10-caddy.yml",
+    "caddy_acme_subdomain": "10-caddy.yml",
+    "caddy_acme_token": "10-caddy.yml",
+    "caddy_reverse_proxy_services": "10-caddy.yml",
+    # 30-smtp.yml
+    "smtp_host": "30-smtp.yml",
+    "smtp_port": "30-smtp.yml",
+    "smtp_username": "30-smtp.yml",
+    "smtp_password": "30-smtp.yml",
+    "smtp_encryption": "30-smtp.yml",
+    "smtp_from": "30-smtp.yml",
+    # 40-pihole.yml
+    "pihole_enabled": "40-pihole.yml",
+    "pihole_local_network": "40-pihole.yml",
+    "pihole_local_router": "40-pihole.yml",
+    "pihole_api_password": "40-pihole.yml",
+    # 50-backup.yml
+    "backup_enabled": "50-backup.yml",
+    "backup_nas_hostname": "50-backup.yml",
+    "backup_nas_ip": "50-backup.yml",
+    "backup_nas_volume": "50-backup.yml",
+    "backup_time": "50-backup.yml",
+    # 60-tailscale.yml
+    "tailscale_enabled": "60-tailscale.yml",
+    "os_tailscale_auth_key": "60-tailscale.yml",
+}
+
+# Platform services that own a dedicated split-file. Their service-
+# specific scalars (e.g. pihole_api_password) land in that file rather
+# than apps/<svc>.yml. Most are listed in KEY_TO_SPLIT_FILE already, but
+# this mapping is used when a service-specific scalar from meta/install.yml
+# isn't in the static map (e.g. a future tailscale_X secret).
+PLATFORM_SVC_FILE = {
+    "pihole": "40-pihole.yml",
+    "backup": "50-backup.yml",
+    "os-tailscale": "60-tailscale.yml",
+}
+
+SPLIT_FILE_HEADER = "# DO NOT EDIT — managed by homeserver.sh\n"
+
+
+def service_specific_file(service):
+    """Return the split-file (relative to host_vars dir) where <service>'s
+    own scalars/lists/dicts land when the key isn't in KEY_TO_SPLIT_FILE."""
+    return PLATFORM_SVC_FILE.get(service, f"apps/{service}.yml")
+
+
+def slice_update_by_file(update, service):
+    """Slice update.json into per-file update dicts based on which split
+    file owns each key. Returns {relative_path: per_file_update}. Empty
+    slices are omitted."""
+    svc_file = service_specific_file(service)
+    slices = {}
+
+    def for_file(rel):
+        return slices.setdefault(rel, {"scalars": {}, "lists": {}, "dicts": {}})
+
+    for k, v in (update.get("scalars") or {}).items():
+        rel = KEY_TO_SPLIT_FILE.get(k, svc_file)
+        for_file(rel)["scalars"][k] = v
+    for k, v in (update.get("lists") or {}).items():
+        rel = KEY_TO_SPLIT_FILE.get(k, svc_file)
+        for_file(rel)["lists"][k] = v
+    for k, v in (update.get("dicts") or {}).items():
+        rel = KEY_TO_SPLIT_FILE.get(k, svc_file)
+        for_file(rel)["dicts"][k] = v
+    return slices
+
+
+def _load_doc(path, yaml):
+    """Load an existing YAML doc as a CommentedMap. Returns (doc, existed).
+    Missing or empty file → (CommentedMap(), False)."""
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        return CommentedMap(), False
+    with open(path) as f:
+        data = yaml.load(f)
+    if data is None:
+        return CommentedMap(), True
+    if not isinstance(data, CommentedMap):
+        return CommentedMap(data), True
+    return data, True
+
+
+def _write_doc(path, data, yaml, write_header):
+    """Atomically write <data> to <path>. Prepends SPLIT_FILE_HEADER if
+    write_header=True (a freshly-created file)."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        if write_header:
+            f.write(SPLIT_FILE_HEADER)
+        yaml.dump(data, f)
+    os.replace(tmp, path)
+
+
+def merge_split_file(path, slice_update, mode, vault_pw_file, yaml):
+    """Apply a per-file slice to <path>. In add mode, missing files are
+    created (with header). In remove mode, missing files are skipped, and
+    files that become empty after the merge are deleted."""
+    data, existed = _load_doc(path, yaml)
+
+    if mode == "add":
+        cmd_add(data, slice_update, vault_pw_file)
+        _write_doc(path, data, yaml, write_header=not existed)
+        return
+
+    # remove mode
+    if not existed:
+        return  # nothing to remove from a non-existent file
+    cmd_remove(data, slice_update)
+    if len(data) == 0:
+        os.remove(path)
+    else:
+        _write_doc(path, data, yaml, write_header=False)
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("--inventory", required=True, help="path to main.yml")
+    p.add_argument("--inventory", help="path to legacy monolithic main.yml")
+    p.add_argument("--host-vars-dir",
+                   help="path to host_vars/<host>/ for split-layout merge")
+    p.add_argument("--service",
+                   help="service name (required with --host-vars-dir)")
     p.add_argument("--vault-password-file", required=True, help="path to vault.pw")
     p.add_argument("--update", required=True, help="path to update.json")
     p.add_argument("--mode", choices=["add", "remove"], required=True)
     args = p.parse_args()
 
-    yaml = make_yaml()
-
-    if not os.path.exists(args.inventory):
-        data = CommentedMap()
-    else:
-        with open(args.inventory) as f:
-            data = yaml.load(f)
-        if data is None:
-            data = CommentedMap()
-        elif not isinstance(data, CommentedMap):
-            # Plain dict from an empty-ish doc — wrap so .ca works.
-            data = CommentedMap(data)
+    if bool(args.inventory) == bool(args.host_vars_dir):
+        sys.exit("ERROR: pass exactly one of --inventory or --host-vars-dir")
+    if args.host_vars_dir and not args.service:
+        sys.exit("ERROR: --service is required with --host-vars-dir")
 
     with open(args.update) as f:
         update = json.load(f)
 
-    if args.mode == "add":
-        cmd_add(data, update, args.vault_password_file)
-    else:
-        cmd_remove(data, update)
+    yaml = make_yaml()
 
-    # Write atomically to dodge half-written files on crash.
-    tmp = args.inventory + ".tmp"
-    with open(tmp, "w") as f:
-        yaml.dump(data, f)
-    os.replace(tmp, args.inventory)
+    if args.inventory:
+        # Legacy monolithic-file path. Preserved so a host that hasn't
+        # migrated yet can still run add/remove against its main.yml.
+        if not os.path.exists(args.inventory):
+            data = CommentedMap()
+        else:
+            with open(args.inventory) as f:
+                data = yaml.load(f)
+            if data is None:
+                data = CommentedMap()
+            elif not isinstance(data, CommentedMap):
+                data = CommentedMap(data)
+        if args.mode == "add":
+            cmd_add(data, update, args.vault_password_file)
+        else:
+            cmd_remove(data, update)
+        tmp = args.inventory + ".tmp"
+        with open(tmp, "w") as f:
+            yaml.dump(data, f)
+        os.replace(tmp, args.inventory)
+        return
+
+    # Split-layout path.
+    slices = slice_update_by_file(update, args.service)
+    for rel, slice_update in slices.items():
+        path = os.path.join(args.host_vars_dir, rel)
+        merge_split_file(path, slice_update, args.mode,
+                         args.vault_password_file, yaml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two related install-flow regressions exposed by re-installing on a host whose overlay already has split-layout inventory.

**Bug 1 — stale `main.yml` checks (left over from PR #260's host_vars split):**
Re-installing against an overlay that has the split layout (no `main.yml`) made the script report *"Overlay has no inventory for '<host>' yet"*, skip vault-password verification, leave `EXISTING_VARS_JSON='{}'`, and propose empty defaults for every prompt — silently inviting the operator to regenerate every secret on top of the existing ones. Same stale check broke the `add`/`remove` verbs (they passed `--inventory main.yml` to `inventory_merge.py`) and the `upgrade` verb's `home_server_release` auto-update.

**Bug 2 — overlay symlink shadowed `inventory/group_vars/all.yml`:**
PR #262 introduced `inventory/group_vars/all.yml` to compute `deploy_services = platform_services + apps`, but the install script's `inventory/` → `overlay/inventory/` whole-dir symlink (older code) shadowed it. Result: `deploy_services` evaluated to `None` and the mandatory-services assert at the top of `site.yml` failed with `'caddy' in (deploy_services | default([]))` evaluating false — even though `platform_services` correctly contained `caddy`.

## Changes

`homeserver.sh`:
- Lift `PLATFORM_SERVICES_CANON` + `is_platform_service` to the top of the script; add `host_vars_dir_has_content` and `find_vault_yml` helpers.
- Replace three stale `[[ -f .../main.yml ]]` checks (overlay detection, vault verification, `EXISTING_VARS_JSON` load) with the new helpers.
- Upgrade verb persists `home_server_release` to `00-services.yml` (split layout) with `main.yml` fallback.
- `add`/`remove` verbs call `inventory_merge.py --host-vars-dir … --service …`, with legacy `--inventory` fallback for unmigrated hosts.
- Selective overlay symlink scheme: keep public `inventory/` intact (so `group_vars/all.yml` stays reachable), only symlink `inventory/hosts.yml` + `inventory/host_vars` into the overlay. Idempotent migration step rewrites any pre-existing whole-dir symlink in place.

`scripts/inventory_merge.py`:
- New `--host-vars-dir` + `--service` flags (mutually exclusive with `--inventory`).
- `KEY_TO_SPLIT_FILE` maps 27 well-known shared keys to their owning files; service-specific scalars fall through to `apps/<svc>.yml` (or `<NN>-<svc>.yml` for the three platform services with dedicated files).
- Per-file slices reuse the existing comment-preserving `cmd_add` / `cmd_remove`. New files get a `# DO NOT EDIT — managed by homeserver.sh` header; files that become empty after a remove are deleted.

## Test plan

- [x] `bash -n homeserver.sh` clean
- [x] `python3 -m py_compile scripts/inventory_merge.py` clean
- [x] Synthetic round-trip on a temp split-layout dir: add + remove for an app (`nextcloud`) and a platform service (`pihole`) — zero diff after round-trip, `ansible-inventory --host` reads back cleanly
- [x] End-to-end install on a real host (homeserver2) with pre-existing overlay inventory: prompts pre-fill from existing values, no secrets clobbered, full `site.yml` deploy succeeds (`ok=363 changed=42 failed=0` across caddy / dashboard / pihole / nextcloud / entephoto)
- [ ] Reviewer: confirm the selective-symlink migration is what you want (vs. e.g. moving `deploy_services` to `playbooks/group_vars/`)
- [ ] Reviewer: `homeserver.sh add <svc>` + `homeserver.sh remove <svc>` round-trip on homeserver2 against the split layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)