### PR TITLE
fix(build_add_update): stop mangling computed templates without jinja2

### DIFF
--- a/scripts/build_add_update.py
+++ b/scripts/build_add_update.py
@@ -37,6 +37,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -61,16 +62,27 @@ def load_existing_inventory(target, vault_pw, inventory_dir):
     return json.loads(result.stdout)
 
 
+_JINJA_VAR_RE = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
+
+
 def render_template(template_str, ctx):
     """Render a small Jinja-like template. Uses jinja2 if available
-    (ansible-core depends on it so it should be on PATH), otherwise
-    falls back to str.format-style {key} substitution."""
+    (ansible-core depends on it but its jinja2 lives in a pipx venv
+    that /usr/bin/python3 doesn't see), otherwise falls back to a
+    regex that handles `{{ var }}` substitution — same syntax as the
+    jinja path, just no filters / logic. Computed vars in
+    meta/install.yml are simple `{{ name }}` interpolations, so this
+    covers every current use without dragging jinja2 in as a hard dep.
+
+    str.format is NOT used: it treats `{{` as escaped `{` and would
+    silently mangle `{{ caddy_domain }}` into `{ caddy_domain }`."""
     try:
         from jinja2 import Template
         return Template(template_str).render(**ctx)
     except ImportError:
-        # Crude fallback — operators using `computed` vars need jinja2.
-        return template_str.format(**ctx)
+        return _JINJA_VAR_RE.sub(
+            lambda m: str(ctx.get(m.group(1), "")), template_str,
+        )
 
 
 def resolve_secret(generator):


### PR DESCRIPTION
## Summary

`scripts/build_add_update.py:render_template` tries `import jinja2` first and falls back to `str.format(**ctx)`. The fallback was wrong: `str.format` treats `{{` as an escaped `{`, so the `paperless` meta/install.yml template

```yaml
- name: paperless_url
  type: computed
  template: \"https://paperless.{{ caddy_domain }}\"
```

silently rendered as the literal `https://paperless.{ caddy_domain }`. Django then 403'd every login on the Caddy-fronted URL because `PAPERLESS_URL` never matched the request Origin.

## Why this fires now

ansible-core ships its own jinja2 inside the pipx venv, so a host that installed Ansible via pipx (the default for AlmaLinux 9 + Fedora paths in `homeserver.sh`) doesn't have jinja2 on `/usr/bin/python3`'s path. `build_add_update.py` runs as plain `python3` from the cloned repo, hits `ImportError`, and silently falls through to the broken fallback.

Hit on a fresh `homeserver.sh add paperless-ngx` on homeserver2 today (2026-05-29): paperless login UI returned

> Verboten (403) — CSRF-Verifizierung fehlgeschlagen. Anfrage abgebrochen.

## Fix

Replace the str.format fallback with a regex that handles the `{{ var }}` substitution used by every `computed` `inventory_var` in the repo's `meta/install.yml` files. No filters / no logic — same coverage as the jinja path for our actual templates, none of the silent-mangling failure mode.

## Test plan

- [x] Unit-test the regex fallback with jinja2 blocked: `https://paperless.{{ caddy_domain }}` → `https://paperless.simsons-t.dedyn.io`; multi-var, extra whitespace, unknown var → empty.
- [x] Reviewer: on a fresh host where ansible was installed via pipx, run `homeserver.sh add paperless-ngx` and confirm `apps/paperless-ngx.yml` lands with `paperless_url: https://paperless.<caddy_domain>` (fully expanded), and the login page works without CSRF error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)