### PR TITLE
feat(dashboard): auto-discover services + per-service mobile-friendly tables

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -2024,143 +2024,9 @@ fi
 
 ok "Generated split host_vars under inventory/host_vars/$SERVER_HOSTNAME/ (with vault-encrypted secrets)"
 
-# --- Generate dashboard config ---
-# Only include services that were actually selected for deployment, so
-# the dashboard doesn't display stale "Stopped" rows for un-deployed
-# services.
-
-{
-echo "services:"
-
-if is_selected shairportsync; then
-cat << EOF
-  - name: Shairport-sync
-    user: root
-    service: shairport-sync
-    rootful: true
-    volumes: []
-
-EOF
-fi
-
-if is_selected pihole; then
-cat << EOF
-  - name: Pi-hole
-    user: pihole
-    uid: 1005
-    service: pihole
-    urls:
-      - label: Admin UI
-        url: https://pihole.${CADDY_DOMAIN}/admin
-    volumes:
-      - systemd-pihole-etc
-      - systemd-pihole-dnsmasq
-
-EOF
-fi
-
-if is_selected syncthing; then
-cat << EOF
-  - name: Syncthing
-    user: syncthg
-    uid: 1003
-    service: syncthing
-    urls:
-      - label: Web UI
-        url: https://syncthing.${CADDY_DOMAIN}
-    volumes:
-      - systemd-syncthing
-
-EOF
-fi
-
-if is_selected entephoto; then
-cat << EOF
-  - name: Ente Photos
-    user: entephoto
-    uid: 1008
-    service: entephoto-pod
-    urls:
-      - label: Photos
-        url: https://photos.${CADDY_DOMAIN}
-      - label: API
-        url: https://photos-api.${CADDY_DOMAIN}/ping
-    volumes:
-      - entephoto-postgres-data
-      - entephoto-garage-data
-      - entephoto-garage-meta
-      - entephoto-garage-config
-      - entephoto-museum-config
-
-EOF
-fi
-
-if is_selected paperless-ngx; then
-cat << EOF
-  - name: Paperless-NGX
-    user: paperless
-    uid: 1007
-    service: paperless-ngx-pod
-    urls:
-      - label: Web UI
-        url: https://paperless.${CADDY_DOMAIN}
-    volumes:
-      - paperless-db-data
-      - paperless-media
-      - paperless-data
-
-EOF
-fi
-
-if is_selected jellyfin; then
-cat << EOF
-  - name: Jellyfin
-    user: jellyfin
-    uid: 1012
-    service: jellyfin
-    urls:
-      - label: Web UI
-        url: https://jellyfin.${CADDY_DOMAIN}
-    volumes:
-      - jellyfin-config
-      - jellyfin-media
-
-EOF
-fi
-
-if is_selected music-assistant; then
-cat << EOF
-  - name: Music Assistant
-    user: music-assistant
-    uid: 1014
-    service: music-assistant-pod
-    urls:
-      - label: Web UI
-        url: https://music.${CADDY_DOMAIN}
-    volumes:
-      - music-assistant-data
-
-EOF
-fi
-
-if is_selected nextcloud; then
-cat << EOF
-  - name: Nextcloud
-    user: nextcloud
-    uid: 1015
-    service: nextcloud-pod
-    urls:
-      - label: Web UI
-        url: https://cloud.${CADDY_DOMAIN}
-    volumes:
-      - nextcloud-config
-      - nextcloud-data
-
-EOF
-fi
-} > inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml
-
-ok "Generated inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
+# Dashboard auto-discovers what to render by reading the split host_vars +
+# each role's meta/install.yml at generation time; no dashboard-config.yaml
+# is written here. See roles/platform/dashboard/README.md.
 
 # ============================================================================
 # Step 6.5: deSEC API — upsert A records + clear stale ACME challenge TXT
@@ -2272,7 +2138,6 @@ echo "Without it you cannot re-deploy this host or decrypt its inventory."
 echo
 echo "Configuration files:"
 echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/  (split host_vars: 00-services.yml … 60-tailscale.yml, apps/<svc>.yml)"
-echo "  $INSTALL_DIR/inventory/host_vars/$SERVER_HOSTNAME/dashboard-config.yaml"
 echo
 
 if [[ -n "${OVERLAY_URL:-}" && "$USE_EXISTING_INVENTORY" != "true" ]]; then

--- a/roles/apps/entephoto/meta/install.yml
+++ b/roles/apps/entephoto/meta/install.yml
@@ -46,12 +46,16 @@ inventory_vars:
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: photos, port: 3000 }
-    - { subdomain: accounts, port: 3001 }
-    - { subdomain: cast, port: 3002 }
-    - { subdomain: auth, port: 3003 }
-    - { subdomain: photos-api, port: 8080 }
-    - { subdomain: photos-s3, port: 3900 }
+    # `path` / `label` / `hidden` are dashboard hints — caddy ignores them.
+    # hidden: true keeps the caddy route but hides the link from the
+    # dashboard. accounts/cast/auth/photos-s3 are internal Ente
+    # backplanes that Caddy must proxy but the operator doesn't browse.
+    - { subdomain: photos, port: 3000, label: "Photos" }
+    - { subdomain: accounts, port: 3001, hidden: true }
+    - { subdomain: cast, port: 3002, hidden: true }
+    - { subdomain: auth, port: 3003, hidden: true }
+    - { subdomain: photos-api, port: 8080, path: /ping, label: "API" }
+    - { subdomain: photos-s3, port: 3900, hidden: true }
   my_linux_users:
     entephoto:
       uid: 1008

--- a/roles/apps/jellyfin/meta/install.yml
+++ b/roles/apps/jellyfin/meta/install.yml
@@ -11,7 +11,7 @@ inventory_vars:
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: jellyfin, port: 8096 }
+    - { subdomain: jellyfin, port: 8096, label: "Web UI" }  # label is a dashboard hint
   my_linux_users:
     jellyfin:
       uid: 1012

--- a/roles/apps/music-assistant/meta/install.yml
+++ b/roles/apps/music-assistant/meta/install.yml
@@ -13,7 +13,7 @@ inventory_vars:
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: music, port: 8095 }
+    - { subdomain: music, port: 8095, label: "Web UI" }  # label is a dashboard hint
   my_linux_users:
     music-assistant:
       uid: 1014

--- a/roles/apps/nextcloud/meta/install.yml
+++ b/roles/apps/nextcloud/meta/install.yml
@@ -15,7 +15,7 @@ inventory_vars:
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: cloud, port: 8090 }
+    - { subdomain: cloud, port: 8090, label: "Web UI" }  # label is a dashboard hint
   my_linux_users:
     nextcloud:
       uid: 1015

--- a/roles/apps/paperless-ngx/meta/install.yml
+++ b/roles/apps/paperless-ngx/meta/install.yml
@@ -22,7 +22,7 @@ inventory_vars:
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: paperless, port: 8000 }
+    - { subdomain: paperless, port: 8000, label: "Web UI" }  # label is a dashboard hint
   my_linux_users:
     paperless:
       uid: 1007

--- a/roles/apps/syncthing/meta/install.yml
+++ b/roles/apps/syncthing/meta/install.yml
@@ -9,7 +9,7 @@ inventory_vars: []
 
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: syncthing, port: 8384, proto: https }
+    - { subdomain: syncthing, port: 8384, proto: https, label: "Web UI" }  # label is a dashboard hint
   my_linux_users:
     syncthg:
       uid: 1003

--- a/roles/platform/dashboard/README.md
+++ b/roles/platform/dashboard/README.md
@@ -1,13 +1,56 @@
 # dashboard
 
-Generates a static HTML status page summarizing every deployed
-service: container status, image and image age, available updates,
-volume sizes, last backup timestamp, and a clickable link to each
-service's web UI. Driven by a `systemd` timer that re-renders every
-15 minutes.
+Generates a static HTML status page summarizing every deployed service:
+container status, image and image age, available updates, per-container
+mounted volumes, last backup timestamp, and a clickable link to each
+service's web UI. Driven by a `systemd` timer that re-renders every 15
+minutes.
 
-The HTML is written to `/var/www/dashboard/index.html` and served by
-the [caddy](../caddy/README.md) role.
+The HTML is written to `/var/www/dashboard/index.html` and served by the
+[caddy](../caddy/README.md) role.
+
+## Auto-discovery contract
+
+There is **no per-host config file** for the dashboard. Every 15 minutes
+the generator (`/usr/local/bin/home-server-dashboard.py`) reads:
+
+- `inventory/host_vars/<host>/00-services.yml` →
+  `platform_services + apps` decides what to render.
+- `inventory/host_vars/<host>/10-caddy.yml` → `caddy_domain` builds the
+  public URLs.
+- `roles/{platform,apps}/<svc>/meta/install.yml` of each enabled
+  service:
+  - `display_name` → table heading
+  - `side_effects.my_linux_users` (sole entry) → rootless user (the
+    generator `su`s into this user for podman queries)
+  - `side_effects.caddy_reverse_proxy_services` → public URLs (one
+    per non-hidden entry)
+- Per container (live, via `podman inspect`): image, image age, update
+  status, and the volumes actually mounted in *that* container (volume-
+  type mounts only; bind mounts are filtered out).
+
+Adding a service: `homeserver.sh add <svc>` updates `platform_services`/
+`apps`. The dashboard picks it up on the next 15-min tick. No
+dashboard-specific work needed in the role beyond what's already there.
+
+## URL hints on `caddy_reverse_proxy_services` entries
+
+Each route entry accepts three optional fields that Caddy ignores and
+the dashboard consumes:
+
+| Field    | Default                           | Effect |
+|----------|-----------------------------------|--------|
+| `label`  | subdomain, title-cased            | Link text on the dashboard. |
+| `path`   | `/`                               | Appended to the URL — useful for apps whose root isn't the UI (e.g. Pi-hole → `/admin`). |
+| `hidden` | `false`                           | `true` keeps the Caddy reverse-proxy route but hides the link from the dashboard. Used for internal subdomains (Ente's `accounts`/`cast`/`auth`/`photos-s3` backplanes). |
+
+Example (`roles/platform/pihole/meta/install.yml`):
+
+```yaml
+side_effects:
+  caddy_reverse_proxy_services:
+    - { subdomain: pihole, port: 8443, proto: https, path: /admin, label: "Admin UI" }
+```
 
 ## Container image
 
@@ -18,34 +61,10 @@ None. Pure host-level Python script + systemd unit + timer.
 None. The generator runs as root via systemd so it can `su` into each
 service user and call `podman ps`.
 
-## Variables
-
-| Variable                  | Default                                                                       | Purpose |
-|---------------------------|-------------------------------------------------------------------------------|---------|
-| `dashboard_config_file`   | `{{ inventory_dir }}/host_vars/{{ inventory_hostname }}/dashboard-config.yaml`| Per-host service definition consumed by the generator. |
-
-The config file is the source of truth for which services appear on
-the dashboard. `homeserver.sh` writes it from your service selection so
-unselected services don't show up as `Stopped`.
-
-Shape of `dashboard-config.yaml`:
-
-```yaml
-services:
-  - name: Pi-hole
-    user: pihole
-    uid: 1005
-    service: pihole
-    urls:
-      - { label: Admin UI, url: "https://<server-ip>:8443/admin" }
-    volumes:
-      - systemd-pihole-etc
-      - systemd-pihole-dnsmasq
-```
-
 ## Secrets
 
-None.
+None. The `!vault` tag on `caddy_acme_token` (in `10-caddy.yml`) is
+parsed as a no-op — the dashboard never needs decrypted values.
 
 ## Firewall ports
 
@@ -57,8 +76,8 @@ None — served via [caddy](../caddy/README.md) on port 80.
 
 ## Volumes
 
-None of its own. Reads from each service's volumes to size them.
-Writes HTML to the host directory `/var/www/dashboard`.
+None of its own. Per-service volumes are listed by querying each
+container's `Mounts[]` directly.
 
 ## Deployment
 
@@ -72,11 +91,18 @@ home-server-dashboard.service`) and enables the timer
 
 `homeserver.sh` also runs a manual refresh ~30 s after the playbook
 finishes so the first page view shows real container state instead of
-"all stopped" (rootless containers are still pulling/starting when
-the playbook returns).
+"all stopped" (rootless containers are still pulling/starting when the
+playbook returns).
+
+## Back-compat
+
+If `/etc/home-server-dashboard.yaml` exists and the inventory layout
+isn't reachable, the generator falls back to the legacy file. The
+back-compat path is intended for one release only — re-running
+`playbooks/dashboard.yml` removes the file.
 
 ## Cross-role dependencies
 
-Pairs with [caddy](../caddy/README.md), which serves the generated
-HTML. The dashboard works best when most other roles are also
-deployed — there's nothing to display otherwise.
+Pairs with [caddy](../caddy/README.md), which serves the generated HTML.
+The dashboard works best when most other roles are also deployed —
+there's nothing to display otherwise.

--- a/roles/platform/dashboard/defaults/main.yml
+++ b/roles/platform/dashboard/defaults/main.yml
@@ -1,4 +1,2 @@
-# Path to the dashboard config file. By convention, each host keeps its
-# config at inventory/host_vars/<hostname>/dashboard-config.yaml in the
-# private repo.
-dashboard_config_file: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}/dashboard-config.yaml"
+# Dashboard auto-discovers what to render from the split host_vars layout
+# and each role's meta/install.yml. No per-host config file. See README.

--- a/roles/platform/dashboard/files/home-server-dashboard.py
+++ b/roles/platform/dashboard/files/home-server-dashboard.py
@@ -2,32 +2,47 @@
 """
 Home Server Dashboard Generator
 
-Generates a static HTML dashboard showing:
-- Service name, status, container image + version
-- Image update availability (local vs registry digest)
-- Volume list per service
-- Last backup timestamp per service
-- Clickable URLs for each service
+Generates a static HTML dashboard showing one table per deployed service:
+- Service name, aggregate status, public links, last backup
+- Per-container: image, image age, podman-auto-update status, mounted volumes
+
+Auto-discovery contract (no per-host config file):
+- Enabled services come from
+  inventory/host_vars/<host>/00-services.yml -> platform_services + apps.
+- Display metadata comes from each role's roles/<layer>/<svc>/meta/install.yml:
+    display_name                                        -> dashboard heading
+    side_effects.my_linux_users (first entry)           -> rootless user / uid
+    side_effects.caddy_reverse_proxy_services           -> public URLs
+- Per-URL hints (optional on each caddy_reverse_proxy_services entry):
+    path:  appended to the URL (e.g. /admin); default "".
+    label: link text;             default = subdomain title-cased.
+- Volume attribution comes from `podman inspect <container>` Mounts[],
+  filtered to volume-type mounts. Bind mounts (timezone files etc.) hidden.
 
 Runs as root (needs to su to each service user for podman queries).
 Output: /var/www/dashboard/index.html
+
+Back-compat: if /etc/home-server-dashboard.yaml exists and the inventory
+layout isn't reachable, fall back to the legacy config-driven path.
 """
 
+import argparse
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
+from glob import glob
 
-# Try to import yaml, fall back to simple parser
 try:
     import yaml
 except ImportError:
     yaml = None
 
-CONFIG_PATH = "/etc/home-server-dashboard.yaml"
+
+LEGACY_CONFIG_PATH = "/etc/home-server-dashboard.yaml"
 OUTPUT_DIR = "/var/www/dashboard"
 BACKUP_LOG = "/var/log/home-server-backup.log"
 BACKUP_DIR = "/var/log"
@@ -36,23 +51,133 @@ BACKUP_DIR = "/var/log"
 # rate limit) instead of falling back to "Unknown".
 STATE_PATH = "/var/lib/home-server-dashboard/state.json"
 
+# Default install layout: homeserver.sh deploys to /home/ansible/home-server,
+# inventory is symlinked into the overlay. Both paths are overridable via
+# CLI args / env vars for non-default installs.
+DEFAULT_INVENTORY_DIR = "/home/ansible/home-server/inventory"
+DEFAULT_ROLES_DIR = "/home/ansible/home-server/roles"
 
-def load_config(path):
-    """Load YAML config file."""
+# Services that have no UI / no dashboard tile. caddy fronts everything and
+# isn't itself a "service" the operator cares to watch from the dashboard;
+# os-* are pure host-config roles; backup runs from a timer.
+DASHBOARD_HIDDEN_SERVICES = {
+    "caddy", "dashboard", "os-base", "os-audio", "os-tailscale", "backup",
+}
+
+
+# ---------------------------------------------------------------------------
+# Inventory + meta loading
+# ---------------------------------------------------------------------------
+
+def _vault_constructor(loader, node):  # noqa: ARG001
+    """Treat !vault tags as opaque None — the dashboard never needs
+    decrypted secrets, so we just skip them without erroring out."""
+    return None
+
+
+def _safe_yaml_load(path):
+    """yaml.safe_load with a !vault constructor that returns None.
+    Returns the parsed doc, or None if the file is missing / empty."""
+    if not os.path.exists(path):
+        return None
+    if yaml is None:
+        raise SystemExit(
+            "PyYAML required: `dnf install python3-pyyaml` (the dashboard "
+            "role's tasks/main.yml installs this on deploy)."
+        )
+    Loader = yaml.SafeLoader  # noqa: N806
+    Loader.add_constructor("!vault", _vault_constructor)
     with open(path) as f:
-        if yaml:
-            return yaml.safe_load(f)
-        # Minimal YAML parser fallback — use PyYAML if available
-        import json as _json
-        # Convert simple YAML to JSON-ish (only works for flat structures)
-        raise SystemExit("PyYAML required: pip install pyyaml")
+        return yaml.load(f, Loader=Loader)
 
+
+def load_host_inventory(inventory_dir, host):
+    """Return {platform_services, apps, caddy_domain, nas_host_display}
+    by reading the split host_vars layout directly off disk. Each value
+    defaults to a sensible empty if its file is missing."""
+    base = os.path.join(inventory_dir, "host_vars", host)
+    services_doc = _safe_yaml_load(os.path.join(base, "00-services.yml")) or {}
+    caddy_doc = _safe_yaml_load(os.path.join(base, "10-caddy.yml")) or {}
+    # 20-extras.yml is operator-managed; it can carry nas_host_display
+    # (cosmetic, shown next to backup_share paths) and future
+    # dashboard_overrides hooks.
+    extras_doc = _safe_yaml_load(os.path.join(base, "20-extras.yml")) or {}
+    return {
+        "platform_services": services_doc.get("platform_services") or [],
+        "apps": services_doc.get("apps") or [],
+        "caddy_domain": caddy_doc.get("caddy_domain") or "",
+        "nas_host_display": extras_doc.get("nas_host_display") or "",
+    }
+
+
+def load_role_meta(roles_dir, service):
+    """Return meta/install.yml for a service (searching platform/ then apps/),
+    or None if neither exists."""
+    for layer in ("platform", "apps"):
+        path = os.path.join(roles_dir, layer, service, "meta", "install.yml")
+        if os.path.exists(path):
+            return _safe_yaml_load(path) or {}
+    return None
+
+
+def build_service_specs(inventory, roles_dir):
+    """Translate inventory + role meta into the per-service display spec
+    consumed by the rest of the generator. One entry per visible service."""
+    specs = []
+    enabled = list(inventory["platform_services"]) + list(inventory["apps"])
+    caddy_domain = inventory["caddy_domain"]
+    for svc in enabled:
+        if svc in DASHBOARD_HIDDEN_SERVICES:
+            continue
+        meta = load_role_meta(roles_dir, svc)
+        if meta is None:
+            # No meta/install.yml — surface the service anyway with the
+            # raw service id so the operator notices something's off.
+            specs.append({
+                "name": svc,
+                "user": None,
+                "urls": [],
+                "_warn": f"No meta/install.yml found for {svc}",
+            })
+            continue
+        side = meta.get("side_effects") or {}
+        users = side.get("my_linux_users") or {}
+        user = next(iter(users.keys()), None) if users else None
+        routes = side.get("caddy_reverse_proxy_services") or []
+        urls = []
+        for r in routes:
+            sub = r.get("subdomain")
+            if not sub:
+                continue
+            # `hidden: true` keeps the caddy route but skips the dashboard
+            # link — useful for internal subdomains (e.g. Ente's auth/cast/
+            # accounts/photos-s3 backplanes that Caddy must proxy but the
+            # operator doesn't browse to).
+            if r.get("hidden"):
+                continue
+            label = r.get("label") or sub.replace("-", " ").title()
+            path = r.get("path") or ""
+            urls.append({
+                "label": label,
+                "url": f"https://{sub}.{caddy_domain}{path}",
+            })
+        specs.append({
+            "name": meta.get("display_name") or svc,
+            "user": user,
+            "urls": urls,
+        })
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Podman helpers (unchanged from the pre-rewrite generator)
+# ---------------------------------------------------------------------------
 
 def run_cmd(cmd, timeout=30):
     """Run a shell command and return stdout."""
     try:
         result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=timeout
+            cmd, shell=True, capture_output=True, text=True, timeout=timeout,
         )
         return result.stdout.strip()
     except (subprocess.TimeoutExpired, Exception):
@@ -61,9 +186,7 @@ def run_cmd(cmd, timeout=30):
 
 def get_containers(user):
     """Get running containers for a rootless user."""
-    output = run_cmd(
-        "su - %s -c 'podman ps --format json' 2>/dev/null" % user
-    )
+    output = run_cmd("su - %s -c 'podman ps --format json' 2>/dev/null" % user)
     if not output:
         return []
     try:
@@ -100,19 +223,6 @@ def get_image_inspect(user, image_id):
         return None
 
 
-def get_volumes(user):
-    """Get volumes for a rootless user."""
-    output = run_cmd(
-        "su - %s -c 'podman volume ls --format json' 2>/dev/null" % user
-    )
-    if not output:
-        return []
-    try:
-        return json.loads(output)
-    except json.JSONDecodeError:
-        return []
-
-
 def get_volume_size(user, volume_name):
     """Return the on-disk size of a volume in bytes, or None on failure.
 
@@ -134,8 +244,51 @@ def get_volume_size(user, volume_name):
         return None
 
 
+def get_auto_update_status(user):
+    """Get update status using podman auto-update --dry-run.
+
+    Returns a dict mapping container name to update status:
+    'pending' = update available, 'false' = up to date, 'true' = updated,
+    'failed' = registry check failed (e.g. Docker Hub anonymous rate limit).
+    """
+    output = run_cmd(
+        "su - %s -c 'podman auto-update --dry-run --format json' 2>/dev/null"
+        % user,
+        timeout=60,
+    )
+    if not output:
+        return {}
+    try:
+        data = json.loads(output)
+        return {item["ContainerName"]: item["Updated"] for item in data}
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
+def get_last_backup(service_name, backup_log):
+    """Get last backup timestamp for a service from the log file."""
+    if not os.path.exists(backup_log):
+        return None
+    last_ts = None
+    try:
+        with open(backup_log) as f:
+            for line in f:
+                if ("--- %s ---" % service_name) in line:
+                    match = re.match(
+                        r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]", line,
+                    )
+                    if match:
+                        last_ts = match.group(1)
+    except Exception:
+        pass
+    return last_ts
+
+
+# ---------------------------------------------------------------------------
+# State (persistent update-status fallback)
+# ---------------------------------------------------------------------------
+
 def load_state(path):
-    """Load persistent state (last-known update status per container)."""
     if not os.path.exists(path):
         return {}
     try:
@@ -146,7 +299,6 @@ def load_state(path):
 
 
 def save_state(path, state):
-    """Persist state. Best-effort; failure to save is non-fatal."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
@@ -155,8 +307,11 @@ def save_state(path, state):
         pass
 
 
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
 def format_size(num_bytes):
-    """Format a byte count as a human-readable string."""
     if num_bytes is None:
         return "?"
     size = float(num_bytes)
@@ -169,60 +324,15 @@ def format_size(num_bytes):
     return "%.1f PB" % size
 
 
-def get_auto_update_status(user):
-    """Get update status using podman auto-update --dry-run.
-
-    Returns a dict mapping container name to update status:
-    'pending' = update available, 'false' = up to date, 'true' = updated.
-    """
-    output = run_cmd(
-        "su - %s -c 'podman auto-update --dry-run --format json' 2>/dev/null"
-        % user,
-        timeout=60,
-    )
-    if not output:
-        return {}
-    try:
-        data = json.loads(output)
-        return {
-            item["ContainerName"]: item["Updated"]
-            for item in data
-        }
-    except (json.JSONDecodeError, KeyError):
-        return {}
-
-
-def get_last_backup(service_name, backup_log, backup_dir):
-    """Get last backup timestamp for a service from the log file."""
-    if not os.path.exists(backup_log):
-        return None
-
-    last_ts = None
-    try:
-        with open(backup_log) as f:
-            for line in f:
-                if ("--- %s ---" % service_name) in line:
-                    # Extract timestamp from log line
-                    match = re.match(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]", line)
-                    if match:
-                        last_ts = match.group(1)
-    except Exception:
-        pass
-
-    return last_ts
-
-
 def format_date(iso_str):
-    """Format ISO date string to readable format."""
     if not iso_str:
         return "unknown"
     try:
-        # Handle various formats
-        for fmt in [
+        for fmt in (
             "%Y-%m-%dT%H:%M:%S.%f",
             "%Y-%m-%dT%H:%M:%S",
             "%Y-%m-%d %H:%M:%S",
-        ]:
+        ):
             try:
                 dt = datetime.strptime(iso_str[:26], fmt)
                 return dt.strftime("%Y-%m-%d %H:%M")
@@ -233,252 +343,388 @@ def format_date(iso_str):
         return str(iso_str)[:19]
 
 
-def generate_html(services_data, generated_at, nas_host_display):
-    """Generate the HTML dashboard page."""
-    rows = []
-    for svc in services_data:
-        # URLs
-        url_links = ""
-        for u in svc.get("urls", []):
-            url_links += '<a href="%s" target="_blank">%s</a> ' % (
-                u["url"], u["label"]
-            )
+def html_escape(s):
+    return (
+        str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
 
-        # Volumes (name + size + optional backup share path)
-        vol_entries = []
-        for v in svc.get("volumes_info", []):
-            entry = "%s <small>(%s)</small>" % (
-                v["name"], format_size(v.get("size"))
-            )
-            share = v.get("backup_share")
-            if share:
-                if nas_host_display:
-                    entry += ' <small class="backup-path">→ %s/%s</small>' % (
-                        nas_host_display, share
-                    )
-                else:
-                    entry += ' <small class="backup-path">→ %s</small>' % share
-            vol_entries.append(entry)
-        vol_list = "<br>".join(vol_entries)
 
-        # Container status
-        if svc.get("running"):
-            status_badge = '<span class="badge running">Running</span>'
-        else:
-            status_badge = '<span class="badge stopped">Stopped</span>'
+# ---------------------------------------------------------------------------
+# Per-service data gathering
+# ---------------------------------------------------------------------------
 
-        # Backup status
-        backup_ts = svc.get("last_backup", "")
-        if backup_ts:
-            backup_str = backup_ts
-        else:
-            backup_str = "No backup"
+def gather_service(spec, last_known, backup_log, nas_host_display):
+    """Resolve a service spec into rendered display data: aggregate status,
+    container rows (each with its own image / update status / volumes), and
+    last-backup."""
+    user = spec.get("user")
+    if user is None:
+        return {
+            "name": spec["name"],
+            "warn": spec.get("_warn", "no rootless user declared in meta"),
+            "urls": spec.get("urls", []),
+            "running": False,
+            "containers": [],
+            "last_backup": None,
+        }
 
-        for ct in svc.get("containers", [{}]):
-            # Per-container update status
-            ct_update = ct.get("update_available")
-            if ct_update is True:
-                update_badge = '<span class="badge update">Update available</span>'
-            elif ct_update is False:
-                update_badge = '<span class="badge current">Up to date</span>'
+    containers = get_containers(user)
+    update_status = get_auto_update_status(user)
+    container_rows = []
+    for ct in containers:
+        ct_names = ct.get("Names")
+        ct_name = (
+            ct_names[0] if isinstance(ct_names, list) and ct_names
+            else ct_names or ""
+        )
+        if "infra" in ct_name:
+            # Pod infra containers carry no useful info for the operator.
+            continue
+        image = ct.get("Image", "")
+        image_id = ct.get("ImageID", "")
+
+        img_info = get_image_inspect(user, image_id) or {}
+        created = img_info.get("Created", "")
+
+        # Per-container mounted volumes — filter to volume-type (not bind),
+        # since bind mounts are typically host config files (timezone, etc.)
+        # the operator doesn't track on the dashboard.
+        inspect = get_container_inspect(user, ct_name) or {}
+        ct_volumes = []
+        for m in inspect.get("Mounts") or []:
+            if m.get("Type") != "volume":
+                continue
+            name = m.get("Name")
+            if name:
+                ct_volumes.append({
+                    "name": name,
+                    "size": get_volume_size(user, name),
+                })
+
+        # Update status with persistent-state fallback: see the long comment
+        # in the previous generator main(). 'failed' means the registry check
+        # errored (rate limit etc.); reuse the last known status rather than
+        # flipping the badge to Unknown.
+        raw = update_status.get(ct_name, "")
+        if raw == "pending":
+            update_available = True
+            last_known[ct_name] = "pending"
+        elif raw in ("false", "true"):
+            update_available = False
+            last_known[ct_name] = raw
+        elif raw == "failed":
+            fallback = last_known.get(ct_name)
+            if fallback == "pending":
+                update_available = True
+            elif fallback in ("false", "true"):
+                update_available = False
             else:
-                update_badge = '<span class="badge unknown">Unknown</span>'
+                update_available = None
+        else:
+            update_available = None
 
-            rows.append("""
-        <tr>
-            <td><strong>%s</strong></td>
-            <td>%s</td>
-            <td><code>%s</code></td>
-            <td>%s</td>
-            <td>%s</td>
-            <td>%s</td>
-            <td><small>%s</small></td>
-            <td>%s</td>
-        </tr>""" % (
-                svc["name"],
-                status_badge,
-                ct.get("image", "—"),
-                format_date(ct.get("created", "")),
-                update_badge,
-                url_links or "—",
-                vol_list or "—",
-                backup_str,
-            ))
+        container_rows.append({
+            "name": ct_name,
+            "image": image,
+            "created": created,
+            "update_available": update_available,
+            "volumes": ct_volumes,
+        })
 
-    html = """<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Home Server Dashboard</title>
-<style>
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-         margin: 20px; background: #f5f5f5; color: #333; }
-  h1 { color: #2c3e50; }
-  table { border-collapse: collapse; width: 100%%; background: white;
-          box-shadow: 0 1px 3px rgba(0,0,0,0.1); border-radius: 8px;
-          overflow: hidden; }
-  th { background: #2c3e50; color: white; padding: 12px 15px;
-       text-align: left; font-weight: 500; }
-  td { padding: 10px 15px; border-bottom: 1px solid #eee; }
-  tr:hover { background: #f8f9fa; }
-  code { background: #e8e8e8; padding: 2px 6px; border-radius: 3px;
+    return {
+        "name": spec["name"],
+        "urls": spec.get("urls", []),
+        "running": bool(container_rows),
+        "containers": container_rows,
+        "last_backup": get_last_backup(spec["name"], backup_log),
+        "nas_host_display": nas_host_display,
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTML render — one table per service
+# ---------------------------------------------------------------------------
+
+CSS = """
+  :root { color-scheme: light; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+         sans-serif; margin: 16px; background: #f5f5f5; color: #333; }
+  h1 { color: #2c3e50; margin-bottom: 0.4em; }
+  .footer { margin-top: 16px; color: #888; font-size: 0.85em; }
+  .svc { width: 100%; max-width: 1200px; border-collapse: collapse;
+         background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+         border-radius: 8px; overflow: hidden; margin: 0 0 18px 0; }
+  .svc caption { caption-side: top; text-align: left;
+                 background: #2c3e50; color: white;
+                 padding: 10px 14px; font-weight: 500; font-size: 1.05em; }
+  .svc caption .links { float: right; }
+  .svc caption .links a { color: #d9eaf6; margin-left: 10px;
+                          text-decoration: none; font-weight: 400; }
+  .svc caption .links a:hover { text-decoration: underline; }
+  .svc caption .last-backup { display: block; font-size: 0.8em;
+                              color: #cdd7e0; font-weight: 400;
+                              margin-top: 2px; }
+  .svc th { background: #ecf0f1; color: #2c3e50; text-align: left;
+            font-weight: 600; font-size: 0.85em; padding: 8px 12px;
+            border-bottom: 1px solid #d0d7dc; }
+  .svc td { padding: 10px 12px; border-bottom: 1px solid #eee;
+            vertical-align: top; font-size: 0.9em; }
+  .svc tr:last-child td { border-bottom: none; }
+  .svc tr:hover td { background: #f8f9fa; }
+  code { background: #eef1f4; padding: 1px 5px; border-radius: 3px;
          font-size: 0.85em; }
-  a { color: #3498db; text-decoration: none; margin-right: 8px; }
-  a:hover { text-decoration: underline; }
-  .badge { padding: 3px 8px; border-radius: 12px; font-size: 0.8em;
-           font-weight: 500; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 10px;
+           font-size: 0.78em; font-weight: 500; vertical-align: middle; }
   .running { background: #d4edda; color: #155724; }
   .stopped { background: #f8d7da; color: #721c24; }
   .update { background: #fff3cd; color: #856404; }
   .current { background: #d4edda; color: #155724; }
   .unknown { background: #e2e3e5; color: #383d41; }
-  .backup-path { color: #6c757d; font-style: italic; }
-  .footer { margin-top: 15px; color: #888; font-size: 0.85em; }
-</style>
-</head>
-<body>
-<h1>Home Server Dashboard</h1>
-<table>
-  <thead>
-    <tr>
-      <th>Service</th>
-      <th>Status</th>
-      <th>Image</th>
-      <th>Image Date</th>
-      <th>Updates</th>
-      <th>Links</th>
-      <th>Volumes</th>
-      <th>Last Backup</th>
-    </tr>
-  </thead>
-  <tbody>
-    %s
-  </tbody>
-</table>
-<p class="footer">Generated: %s</p>
-</body>
-</html>""" % ("\n".join(rows), generated_at)
+  .img-date { color: #6c757d; font-size: 0.82em; display: block; }
+  .vol { display: block; }
+  .vol-size { color: #6c757d; font-size: 0.82em; }
+  .empty { color: #888; font-style: italic; }
+  .warn-row td { background: #fff8e1; color: #856404; }
 
-    return html
+  /* Mobile: stack each row as label/value pairs */
+  @media (max-width: 640px) {
+    body { margin: 8px; }
+    .svc { box-shadow: none; border-radius: 6px; }
+    .svc caption .links { float: none; display: block; margin-top: 6px; }
+    .svc caption .links a { margin: 0 10px 0 0; }
+    .svc thead { display: none; }
+    .svc, .svc tbody, .svc tr, .svc td { display: block; width: 100%; }
+    .svc tr { border-bottom: 1px solid #ddd; padding: 6px 0; }
+    .svc tr:last-child { border-bottom: none; }
+    .svc td { border: none; padding: 4px 12px; }
+    .svc td::before { content: attr(data-label) ":"; display: inline-block;
+                      min-width: 95px; color: #6c757d;
+                      font-size: 0.8em; font-weight: 600; margin-right: 6px;
+                      text-transform: uppercase; }
+    .svc td.ct-name::before { display: none; }
+    .svc td.ct-name { font-weight: 600; font-size: 1em; padding-top: 8px; }
+  }
+"""
 
 
-def main():
-    config = load_config(CONFIG_PATH)
-    state = load_state(STATE_PATH)
-    # Map of container_name -> "true"/"false" (string), the last fresh status
-    # we've ever seen. Used as a fallback when this run gets "failed" (e.g.
-    # Docker Hub anonymous rate limit) so the dashboard keeps showing the
-    # last known good status instead of flipping to "Unknown".
-    last_known = state.get("update_status", {})
-    services_data = []
+def render_status_badge(running):
+    cls, text = ("running", "Running") if running else ("stopped", "Stopped")
+    return '<span class="badge %s">%s</span>' % (cls, text)
 
-    for svc in config.get("services", []):
-        user = svc["user"]
-        # Volumes config supports two forms:
-        #   - bare string: "vol-name"
-        #   - object: {name: "vol-name", backup_share: "backup-tar"}
-        volumes_info = []
-        for v in svc.get("volumes", []):
-            if isinstance(v, dict):
-                vname = v["name"]
-                backup_share = v.get("backup_share")
-            else:
-                vname = v
-                backup_share = None
-            volumes_info.append({
-                "name": vname,
-                "size": get_volume_size(user, vname),
-                "backup_share": backup_share,
-            })
-        svc_data = {
-            "name": svc["name"],
+
+def render_update_badge(state):
+    if state is True:
+        return '<span class="badge update">Update available</span>'
+    if state is False:
+        return '<span class="badge current">Up to date</span>'
+    return '<span class="badge unknown">Unknown</span>'
+
+
+def render_volumes_cell(volumes):
+    if not volumes:
+        return '<span class="empty">—</span>'
+    parts = []
+    for v in volumes:
+        parts.append(
+            '<span class="vol"><code>%s</code> '
+            '<span class="vol-size">(%s)</span></span>'
+            % (html_escape(v["name"]), html_escape(format_size(v.get("size"))))
+        )
+    return "".join(parts)
+
+
+def render_service_table(svc):
+    name = html_escape(svc["name"])
+    status = render_status_badge(svc.get("running"))
+    links_html = ""
+    if svc.get("urls"):
+        anchors = [
+            '<a href="%s" target="_blank" rel="noopener">%s</a>'
+            % (html_escape(u["url"]), html_escape(u["label"]))
+            for u in svc["urls"]
+        ]
+        links_html = '<span class="links">%s</span>' % "".join(anchors)
+    backup_html = ""
+    last_backup = svc.get("last_backup")
+    if last_backup:
+        backup_html = (
+            '<span class="last-backup">Last backup: %s</span>'
+            % html_escape(last_backup)
+        )
+
+    caption = (
+        '<caption>%s &nbsp;·&nbsp; %s%s%s</caption>'
+        % (name, status, links_html, backup_html)
+    )
+
+    # Warn row (no rootless user / no meta): render the caption + a single
+    # warn row so the operator notices something needs fixing.
+    if svc.get("warn"):
+        body = (
+            '<tr class="warn-row"><td colspan="4">'
+            '%s</td></tr>' % html_escape(svc["warn"])
+        )
+        return (
+            '<table class="svc">%s'
+            '<thead><tr><th>Container</th><th>Image</th>'
+            '<th>Updates</th><th>Volumes</th></tr></thead>'
+            '<tbody>%s</tbody></table>'
+            % (caption, body)
+        )
+
+    rows = []
+    if not svc.get("containers"):
+        rows.append(
+            '<tr><td colspan="4" class="empty">'
+            'No containers running for this service.</td></tr>'
+        )
+    else:
+        for ct in svc["containers"]:
+            rows.append(
+                '<tr>'
+                '<td class="ct-name" data-label="Container"><code>%s</code></td>'
+                '<td data-label="Image"><code>%s</code>'
+                '<span class="img-date">%s</span></td>'
+                '<td data-label="Updates">%s</td>'
+                '<td data-label="Volumes">%s</td>'
+                '</tr>' % (
+                    html_escape(ct["name"]),
+                    html_escape(ct["image"] or "—"),
+                    html_escape(format_date(ct.get("created"))),
+                    render_update_badge(ct.get("update_available")),
+                    render_volumes_cell(ct.get("volumes", [])),
+                )
+            )
+
+    return (
+        '<table class="svc">%s'
+        '<thead><tr><th>Container</th><th>Image</th>'
+        '<th>Updates</th><th>Volumes</th></tr></thead>'
+        '<tbody>%s</tbody></table>'
+        % (caption, "".join(rows))
+    )
+
+
+def render_dashboard(services, generated_at):
+    tables = "\n".join(render_service_table(s) for s in services)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n'
+        '<meta charset="UTF-8">\n'
+        '<meta name="viewport" content="width=device-width, '
+        'initial-scale=1.0">\n'
+        '<title>Home Server Dashboard</title>\n'
+        '<style>%s</style>\n</head>\n<body>\n'
+        '<h1>Home Server Dashboard</h1>\n%s\n'
+        '<p class="footer">Generated: %s</p>\n'
+        '</body>\n</html>\n'
+        % (CSS, tables, html_escape(generated_at))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy config-driven path (back-compat, deleted next release)
+# ---------------------------------------------------------------------------
+
+def legacy_specs_from_config(config):
+    """Translate the old /etc/home-server-dashboard.yaml schema into the
+    spec shape build_service_specs returns. Used only when the inventory
+    layout can't be read (pre-migration host)."""
+    specs = []
+    for svc in config.get("services", []) or []:
+        specs.append({
+            "name": svc.get("name", "?"),
+            "user": svc.get("user"),
             "urls": svc.get("urls", []),
-            "volumes_info": volumes_info,
-            "running": False,
-            "containers": [],
-            "last_backup": get_last_backup(
-                svc["name"], BACKUP_LOG, BACKUP_DIR
-            ),
-        }
+            "_legacy_volumes": svc.get("volumes", []),
+        })
+    return specs
 
-        # Get containers
-        containers = get_containers(user)
-        if containers:
-            svc_data["running"] = True
 
-        # Get update status via podman auto-update --dry-run
-        update_status = get_auto_update_status(user)
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
-        for ct in containers:
-            ct_name = ct.get("Names", [""])[0] if isinstance(ct.get("Names"), list) else ct.get("Names", "")
-            image = ct.get("Image", "")
-            image_id = ct.get("ImageID", "")
+def parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument(
+        "--inventory-dir",
+        default=os.environ.get("HOMESERVER_INVENTORY_DIR", DEFAULT_INVENTORY_DIR),
+        help="Path to inventory/ (default: %(default)s)",
+    )
+    p.add_argument(
+        "--roles-dir",
+        default=os.environ.get("HOMESERVER_ROLES_DIR", DEFAULT_ROLES_DIR),
+        help="Path to roles/ (default: %(default)s)",
+    )
+    p.add_argument(
+        "--host",
+        default=os.environ.get("HOMESERVER_HOST", socket.gethostname().split(".")[0]),
+        help="Hostname to render (default: this machine's short hostname)",
+    )
+    p.add_argument(
+        "--output-dir", default=OUTPUT_DIR,
+        help="Where to write index.html (default: %(default)s)",
+    )
+    return p.parse_args(argv)
 
-            # Skip infra containers
-            if "infra" in ct_name:
-                continue
 
-            # Get image details
-            img_info = get_image_inspect(user, image_id)
-            created = ""
-            if img_info:
-                created = img_info.get("Created", "")
+def main(argv=None):
+    args = parse_args(argv)
 
-            # Check update status from podman auto-update.
-            # On "failed" (typically Docker Hub rate limit), reuse the last
-            # known fresh status from persistent state instead of flipping
-            # the badge to "Unknown".
-            ct_update = update_status.get(ct_name, "")
-            if ct_update == "pending":
-                update_available = True
-                last_known[ct_name] = "pending"
-            elif ct_update in ("false", "true"):
-                update_available = False
-                last_known[ct_name] = ct_update
-            elif ct_update == "failed":
-                fallback = last_known.get(ct_name)
-                if fallback == "pending":
-                    update_available = True
-                elif fallback in ("false", "true"):
-                    update_available = False
-                else:
-                    update_available = None
-            else:
-                update_available = None
+    state = load_state(STATE_PATH)
+    last_known = state.get("update_status", {}) or {}
 
-            svc_data["containers"].append({
-                "name": ct_name,
-                "image": image,
-                "created": created,
-                "update_available": update_available,
-            })
+    inventory = load_host_inventory(args.inventory_dir, args.host)
+    have_inventory = bool(
+        inventory["platform_services"] or inventory["apps"]
+    )
 
-        if not svc_data["containers"]:
-            svc_data["containers"] = [{"name": "", "image": "—", "created": ""}]
+    if have_inventory:
+        specs = build_service_specs(inventory, args.roles_dir)
+        nas_host_display = inventory["nas_host_display"]
+    elif os.path.exists(LEGACY_CONFIG_PATH):
+        # Pre-migration host — fall back to the old config file. This path
+        # will be removed in a future release; the warning helps operators
+        # notice they should re-deploy the dashboard role.
+        print(
+            "WARN: inventory not reachable at %s for %s; "
+            "falling back to legacy %s"
+            % (args.inventory_dir, args.host, LEGACY_CONFIG_PATH),
+            file=sys.stderr,
+        )
+        legacy = _safe_yaml_load(LEGACY_CONFIG_PATH) or {}
+        specs = legacy_specs_from_config(legacy)
+        nas_host_display = legacy.get("nas_host_display", "")
+    else:
+        print(
+            "ERROR: no inventory found at %s and no legacy config at %s — "
+            "nothing to render."
+            % (args.inventory_dir, LEGACY_CONFIG_PATH),
+            file=sys.stderr,
+        )
+        return 1
 
-        services_data.append(svc_data)
+    services = [
+        gather_service(spec, last_known, BACKUP_LOG, nas_host_display)
+        for spec in specs
+    ]
 
-    # Generate HTML. nas_host_display is an optional top-level key in the
-    # dashboard YAML config — e.g. "nas:/volume1" — shown as a prefix next
-    # to each volume's backup_share. Kept out of the script source because
-    # it's environment-specific.
-    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    nas_host_display = config.get("nas_host_display", "")
-    html = generate_html(services_data, now, nas_host_display)
+    generated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    html = render_dashboard(services, generated_at)
 
-    # Write output
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    output_path = os.path.join(OUTPUT_DIR, "index.html")
-    with open(output_path, "w") as f:
+    os.makedirs(args.output_dir, exist_ok=True)
+    out = os.path.join(args.output_dir, "index.html")
+    with open(out, "w") as f:
         f.write(html)
 
-    # Persist last-known update statuses for the next run.
     state["update_status"] = last_known
     save_state(STATE_PATH, state)
 
-    print("Dashboard generated: %s" % output_path)
+    print("Dashboard generated: %s" % out)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/roles/platform/dashboard/files/home-server-dashboard.service
+++ b/roles/platform/dashboard/files/home-server-dashboard.service
@@ -3,6 +3,12 @@ Description=Generate home server dashboard HTML
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 /usr/local/bin/home-server-dashboard.py
+# --inventory-dir / --roles-dir / --host fall back to env vars then
+# sensible defaults baked into the script (see home-server-dashboard.py).
+# Hosts that install home-server somewhere other than /home/ansible/home-server
+# can override these via drop-in: /etc/systemd/system/home-server-dashboard.service.d/*.conf
+ExecStart=/usr/bin/python3 /usr/local/bin/home-server-dashboard.py \
+    --inventory-dir /home/ansible/home-server/inventory \
+    --roles-dir /home/ansible/home-server/roles
 StandardOutput=journal
 StandardError=journal

--- a/roles/platform/dashboard/tasks/main.yml
+++ b/roles/platform/dashboard/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # Deploy the home server dashboard: static HTML generator.
-# The dashboard script runs every 15 minutes via systemd timer.
-# HTML is served by the Caddy container (see caddy role).
+# The dashboard script runs every 15 minutes via systemd timer and
+# auto-discovers what to render by reading the split inventory + each
+# role's meta/install.yml (see role README for the contract).
 
 - name: Install PyYAML for dashboard script
   become: true
@@ -16,12 +17,11 @@
     dest: /usr/local/bin/home-server-dashboard.py
     mode: "0755"
 
-- name: Deploy dashboard configuration
+- name: Drop legacy /etc/home-server-dashboard.yaml (now auto-discovered from inventory)
   become: true
-  ansible.builtin.copy:
-    src: "{{ dashboard_config_file }}"
-    dest: /etc/home-server-dashboard.yaml
-    mode: "0644"
+  ansible.builtin.file:
+    path: /etc/home-server-dashboard.yaml
+    state: absent
 
 - name: Create dashboard output directory
   become: true

--- a/roles/platform/pihole/meta/install.yml
+++ b/roles/platform/pihole/meta/install.yml
@@ -32,7 +32,8 @@ inventory_vars:
 # `homeserver.sh add` merges these in; `homeserver.sh remove` reverses them.
 side_effects:
   caddy_reverse_proxy_services:
-    - { subdomain: pihole, port: 8443, proto: https }
+    # `path`/`label` are dashboard hints — caddy ignores them.
+    - { subdomain: pihole, port: 8443, proto: https, path: /admin, label: "Admin UI" }
   my_linux_users:
     pihole:
       uid: 1005


### PR DESCRIPTION
## Summary

Rewrites the dashboard to derive its content from inventory + each role's existing `meta/install.yml`, and lays it out as one `<table>` per service with per-container volume attribution. Mobile-friendly via `@media` stack-as-key/value below 640 px.

## Why

Two related issues with the dashboard today:

1. **No auto-discovery.** `homeserver.sh add <svc>` updates `platform_services`/`apps` + caddy routes + `my_linux_users`, but never touched `dashboard-config.yaml` — so newly-added services never appeared until the operator hand-edited the file. Hit on homeserver2 (2026-05-29) after `add paperless-ngx`: zero paperless rows for a healthy install.

2. **Per-container row layout duplicated info and over-reported volumes.** The generator emitted one `<tr>` per container, repeating service name / status / links / *all role-owned volumes* on every row. Nextcloud's three containers each listed all five volumes; no signal about which volume was mounted in which container.

`dashboard-config.yaml` was duplicating data already present elsewhere:
- `name` → `meta.display_name` (already in every role)
- `user` + `uid` → `meta.side_effects.my_linux_users` (sole entry per role)
- `urls` → `meta.side_effects.caddy_reverse_proxy_services` + `caddy_domain`
- `service` (pod/container target) → never read by the generator (zero references)
- `volumes` → discoverable via `podman inspect <container>` `Mounts[]`

## Changes

### Generator (`roles/platform/dashboard/files/home-server-dashboard.py`)
- Reads enabled services from `inventory/host_vars/<host>/00-services.yml` and `caddy_domain` from `10-caddy.yml`. `!vault` tags parsed as no-op (the dashboard never needs decrypted secrets).
- For each enabled service: reads `roles/{platform,apps}/<svc>/meta/install.yml` → derives display name, rootless user, public URLs.
- Per-container volumes via the existing `podman inspect` call — filter to `Mounts[].Type == volume` and render under that container's row.
- One `<table>` per service with a caption (name + status + links + last backup) and four columns (Container, Image, Updates, Volumes).
- Mobile CSS: `@media (max-width: 640px)` stacks each `<td>` as a labelled key/value pair.
- New CLI args: `--inventory-dir` / `--roles-dir` / `--host` / `--output-dir` with env-var fallbacks.

### Optional URL hints on `caddy_reverse_proxy_services` entries
Three new fields Caddy ignores and the dashboard consumes:
| Field    | Default                | Effect |
|----------|------------------------|--------|
| `label`  | subdomain title-cased  | Link text. |
| `path`   | `/`                    | Appended to URL (e.g. pihole → `/admin`). |
| `hidden` | `false`                | Keeps the Caddy route, hides the dashboard link (Ente's internal backplanes). |

Applied to:
- `pihole` → `path: /admin, label: "Admin UI"`
- `entephoto` → `photos` (Photos), `photos-api` (`/ping`, API), `accounts`/`cast`/`auth`/`photos-s3` (hidden)
- `nextcloud`/`paperless-ngx`/`jellyfin`/`music-assistant`/`syncthing` → explicit `label: "Web UI"`

### Other
- `homeserver.sh`: deleted the ~135-line dashboard-config write block (`is_selected <svc>` heredocs) and the closing-summary line that pointed at the file.
- Dashboard role: removed the `Deploy dashboard configuration` task, added `state: absent` for the legacy `/etc/home-server-dashboard.yaml` so old hosts clean up on re-deploy. Dropped `dashboard_config_file` from `defaults/main.yml`. Systemd unit gains `--inventory-dir`/`--roles-dir` args.
- Dashboard role README rewritten to document the auto-discovery contract + the new URL hints.
- Back-compat: if `/etc/home-server-dashboard.yaml` exists and the inventory layout isn't reachable, the generator falls back to the legacy file (one-release window for unmigrated hosts).

## Verification

Locally:
- Synthetic test (temp inventory + roles tree): stopped-state rendering correct, `!vault` parsed cleanly, URL hints applied, `hidden: true` skips routes, one table per service.
- `python3 -m py_compile` clean, `bash -n homeserver.sh` clean.

On homeserver2 (`ansible-playbook playbooks/dashboard.yml`):
- ✅ Legacy `/etc/home-server-dashboard.yaml` removed
- ✅ 4 services rendered (Pi-hole, Nextcloud, Ente Photos, Paperless-NGX) — paperless appears WITHOUT any hand-edit (the original symptom)
- ✅ Nextcloud's 3 containers each show only their own mounted volumes (redis → `nextcloud-redis-data`; postgres → `nextcloud-postgres-data`; server → `nextcloud-html/data/config`)
- ✅ Ente Photos shows 2 links (Photos + API), 4 containers each with their own volumes (web shows `—`)
- ✅ Pi-hole link goes to `/admin` with label "Admin UI"
- ✅ Dashboard reachable: `HTTP 200`, 10.7 KB, served by Caddy

## Test plan

- [x] Synthetic local test (jinja-free Python only)
- [x] Real-host smoke test on homeserver2
- [ ] Reviewer: open `https://<your-caddy-domain>/` on a phone and confirm the layout stacks cleanly
- [ ] Reviewer: `homeserver.sh add jellyfin && homeserver.sh remove jellyfin` round-trip — confirm it appears + disappears within one 15-min tick (or trigger `sudo systemctl start home-server-dashboard.service` for an immediate refresh) with zero dashboard-specific manual steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)