### PR TITLE
fix(homeserver.sh): guard add/remove TypeError + stabilise ansible.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ vault.pw
 .vscode/
 .claude/settings.local.json
 .ansible/
+# ansible.cfg is bootstrapped from ansible.cfg.example (dev workstations)
+# or written by homeserver.sh install (deployed hosts). It MUST stay
+# untracked so a `git pull` / `git reset` doesn't clobber the local
+# vault_password_file path each tool wrote.
+ansible.cfg
 
 # Private inventory and secrets (use *.example files as templates)
 inventory/hosts.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ ansible-galaxy install -r roles/requirements.yml -p .ansible/roles/
 ansible-lint
 ```
 
-`ansible.cfg` already points at `inventory/hosts.yml` and `vault.pw`, so no `-i` / `--vault-password-file` flags are needed.
+`ansible.cfg` is gitignored — homeserver.sh writes it on install (pointing at `$HOME/.vaultpw`), and dev workstations bootstrap it once via `cp ansible.cfg.example ansible.cfg`. The tracked template points at `inventory/hosts.yml` and `vault.pw` (relative), so no `-i` / `--vault-password-file` flags are needed.
 
 SSH to hosts by alias only (`ssh homeserver`, `ssh ans-test`) — never with raw IPs + key flags.
 

--- a/ansible.cfg.example
+++ b/ansible.cfg.example
@@ -1,3 +1,16 @@
+# ansible.cfg — copy to ansible.cfg before running ansible commands.
+#
+# This file is the source-of-truth template for ansible.cfg. The real
+# ansible.cfg is gitignored because homeserver.sh rewrites the vault
+# path on each install, and an untracked file keeps that local mutation
+# safe from `git pull` / `git reset --hard` clobbering.
+#
+# Bootstrap for dev workstations:
+#   cp ansible.cfg.example ansible.cfg
+#   ln -s ~/path/to/vault.pw vault.pw   # or edit vault_password_file below
+#
+# `homeserver.sh install` writes its own ansible.cfg (pointing at
+# $HOME/.vaultpw) — operators don't need to touch this file.
 [defaults]
 inventory = inventory/hosts.yml
 roles_path = ./roles/platform:./roles/apps:./roles:./.ansible/roles:~/.ansible/roles:/usr/share/ansible/roles

--- a/homeserver.sh
+++ b/homeserver.sh
@@ -407,6 +407,33 @@ ensure_install_dir() {
     fi
 }
 
+# Make sure $INSTALL_DIR/ansible.cfg exists and points at a real vault
+# password file. Used by `add` / `remove` / `upgrade` so a clobbered
+# ansible.cfg (e.g. after a git pull on a host where the install-time
+# rewrite was previously tracked) self-heals without forcing a full
+# `install` re-run. Idempotent and safe to call on every verb entry.
+ensure_ansible_cfg() {
+    local cfg="$INSTALL_DIR/ansible.cfg"
+    local example="$INSTALL_DIR/ansible.cfg.example"
+    local target_vault="${VAULT_PW_FILE:-$HOME/.vaultpw}"
+    if [[ -f "$cfg" ]]; then
+        # Already pointing at a usable vault file? Nothing to do.
+        local current
+        current=$(awk -F'= *' '/^vault_password_file/ {print $2; exit}' "$cfg")
+        if [[ -n "$current" && -r "$current" ]]; then
+            return 0
+        fi
+        # cfg is present but points somewhere broken — rewrite below.
+    fi
+    if [[ ! -f "$example" ]]; then
+        # Pre-PR-269 checkout without the example template; bail.
+        return 0
+    fi
+    sed "s|^vault_password_file = .*|vault_password_file = $target_vault|" \
+        "$example" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+    info "Regenerated $cfg (vault_password_file → $target_vault)"
+}
+
 resolve_target_host() {
     # Use -h flag if given; otherwise system hostname.
     printf '%s' "${HOSTNAME_FLAG:-$(hostname -s)}"
@@ -523,6 +550,7 @@ case "$VERB" in
         TARGET=$(resolve_target_host)
         cd "$INSTALL_DIR"
         VAULT_PW_FILE="$HOME/.vaultpw"
+        ensure_ansible_cfg
         # Resolve the "current" tag in priority order:
         #   1. inventory's home_server_release (the durable record)
         #   2. git describe --exact-match (whatever's checked out now)
@@ -619,6 +647,7 @@ PY
             err "$VAULT_PW_FILE not readable. Run \`homeserver.sh install\` first."
             exit 1
         fi
+        ensure_ansible_cfg
         TARGET=$(resolve_target_host)
         # inv_get reads $EXISTING_VARS_JSON, populate it from inventory first.
         EXISTING_VARS_JSON=$(ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
@@ -659,12 +688,16 @@ PY
             err "$VAULT_PW_FILE not readable. Run \`homeserver.sh install\` first."
             exit 1
         fi
+        ensure_ansible_cfg
         # Idempotency check: is the service already deployed?
-        # ansible-inventory returns raw Jinja for the group_vars-computed
-        # `deploy_services`, so union platform_services + apps ourselves.
+        # ansible-inventory returns `deploy_services` as the raw Jinja
+        # template string from inventory/group_vars/all.yml (it doesn't
+        # template), so `or []` against it would yield a non-empty string
+        # and `list + str` raises TypeError. Union platform_services + apps
+        # only — that's the actual source of truth post-PR-262.
         if ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
                 ansible-inventory --host "$TARGET" 2>/dev/null \
-                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or []) + (d.get('deploy_services') or [])) else 1)"; then
+                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or [])) else 1)"; then
             warn "$SERVICE is already deployed on $TARGET."
             warn "Use \`homeserver.sh upgrade\` to re-deploy with latest images."
             exit 1
@@ -831,12 +864,14 @@ PY
             err "$VAULT_PW_FILE not readable. Is the host installed?"
             exit 1
         fi
+        ensure_ansible_cfg
         # Idempotency check: is the service in platform_services or apps?
-        # (Union both lists — group_vars-computed deploy_services would
-        # come back as a raw Jinja string from ansible-inventory --host.)
+        # (group_vars-computed deploy_services comes back as a raw Jinja
+        # string from ansible-inventory --host, so unioning it would raise
+        # TypeError — see the matching comment in the `add` verb above.)
         if ! ANSIBLE_VAULT_PASSWORD_FILE="$VAULT_PW_FILE" \
                 ansible-inventory --host "$TARGET" 2>/dev/null \
-                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or []) + (d.get('deploy_services') or [])) else 1)"; then
+                | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$SERVICE' in ((d.get('platform_services') or []) + (d.get('apps') or [])) else 1)"; then
             warn "$SERVICE is not deployed on $TARGET — nothing to remove."
             exit 1
         fi


### PR DESCRIPTION
## Summary

Two regressions surfaced while testing `homeserver.sh add paperless-ngx` / `add jellyfin` on homeserver2:

### Bug 1 — TypeError on `add`/`remove`

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: can only concatenate list (not "str") to list
==> Resolving inventory updates for jellyfin from /home/ansible/home-server/roles/apps/jellyfin/meta/install.yml...
```

The python one-liner at `homeserver.sh:667,839` unions `platform_services + apps + deploy_services` to answer "is this service already deployed?" but `ansible-inventory --host` returns `deploy_services` as the raw Jinja template string from `inventory/group_vars/all.yml` (it never templates inventory values), and `or []` against a non-empty string is a no-op — so the union becomes `list + str` and raises.

Drop the `deploy_services` term entirely. `platform_services + apps` is the actual source of truth post-PR-262; the legacy term was belt-and-suspenders for pre-split hosts that no longer exist.

### Bug 2 — ansible.cfg clobbered by `git pull` / `git reset`

```
[WARNING]: Error getting vault password file (default): The vault password file /home/ansible/home-server/vault.pw was not found
==> ERROR: Playbook playbooks/jellyfin.yml failed.
```

The repo shipped a tracked `ansible.cfg` with `vault_password_file = vault.pw` (a relative path useful for dev workstations). `homeserver.sh install` rewrote it to `$HOME/.vaultpw` on the host, but any subsequent git operation that updated the file reverted it to the tracked default — breaking later `add`/`remove`/`upgrade` calls.

Fix:
- `ansible.cfg` is now **gitignored**, with `git rm --cached` so existing checkouts pick up the change without losing the file.
- `ansible.cfg.example` is the source-of-truth template (dev workstations bootstrap via `cp ansible.cfg.example ansible.cfg`).
- New helper `ensure_ansible_cfg` self-heals a missing or broken `ansible.cfg` by writing one from the example with `vault_password_file` rewritten to the resolved vault path. Wired into `add` / `remove` / `upgrade` / `secret` verbs so any future clobber recovers automatically on the next run.

## Test plan

- [x] Local unit-test of `ensure_ansible_cfg` (3 branches: missing cfg → regenerate; good cfg → no-op; broken vault path → regenerate)
- [x] `bash -n homeserver.sh` clean
- [x] Manual repair of homeserver2 + `ansible-playbook playbooks/jellyfin.yml --limit homeserver2` succeeded (`ok=73 failed=0`)
- [ ] Reviewer: pull this branch on homeserver2 and run `homeserver.sh add syncthing` — should succeed without TypeError, ansible.cfg should self-heal if missing
- [ ] Reviewer: `homeserver.sh remove syncthing` round-trip cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)