### PR TITLE
chore: remove deprecated setup.sh shim

### DIFF
--- a/scripts/clean-host.sh
+++ b/scripts/clean-host.sh
@@ -16,7 +16,7 @@
 #   - Deployed scripts and configs
 #   - Firewall rules added by the roles
 #   - Resolved/modprobe overrides
-#   - The cloned repo and vault password (if from setup.sh)
+#   - The cloned repo and vault password (if from homeserver.sh)
 #
 # Does NOT remove:
 #   - The primary user (ds)
@@ -112,7 +112,7 @@ info "Removing setup artifacts..."
 
 rm -rf "$HOME/home-server"
 rm -f "$HOME/.vaultpw"
-rm -f /tmp/home-server-setup.sh
+rm -f /tmp/homeserver.sh /tmp/home-server-setup.sh  # legacy + current curl-pipe locations
 
 # ---- Verify ----
 info "Verifying clean state..."

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Deprecated entry point — renamed to homeserver.sh. Shim kept for one
-# release so the curl-pipe Quickstart URL keeps working. Remove after.
-echo "==> NOTE: setup.sh has been renamed to homeserver.sh. This shim will be removed in the next release." >&2
-exec bash "$(dirname "$0")/homeserver.sh" "$@"


### PR DESCRIPTION
## Summary

`setup.sh` has been a one-line shim that `exec`s into `homeserver.sh` ever since the rename. Its own header comment says *"Shim kept for one release so the curl-pipe Quickstart URL keeps working. Remove after."* — we've been through several releases since (currently v2.6.0). Drop it.

Also brings the two leftover `setup.sh` references in `scripts/clean-host.sh` up to date:
- Doc comment now names `homeserver.sh`.
- `rm -f /tmp/home-server-setup.sh` cleanup gains `/tmp/homeserver.sh` (the actual curl-pipe target post-rename); both kept as `rm -f` so absence is a no-op.

## Test plan

- [x] `bash -n scripts/clean-host.sh` clean.
- [x] Confirmed no other in-repo references to `setup.sh` (only the shim itself + the two clean-host.sh lines this PR updates).
- [ ] Reviewer: any external docs / bookmarks pointing at `raw.githubusercontent.com/.../setup.sh`? README / Setup-Guide use `homeserver.sh` already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)