### PR TITLE
docs: surface the existing _enabled flags for optional platform services

### DIFF
--- a/inventory/host_vars/homeserver.example/00-services.yml.example
+++ b/inventory/host_vars/homeserver.example/00-services.yml.example
@@ -17,8 +17,14 @@ home_server_release: v2.7.1
 ##################################################################################################
 ### Platform services — mandatory + optional infrastructure roles.
 ### caddy + dashboard are mandatory (asserted in playbooks/site.yml).
-### pihole / backup / os-tailscale are optional infrastructure —
-### keep them in this list to deploy, remove to skip.
+### pihole / backup / os-tailscale are optional infrastructure — keep them
+### in this list to deploy, remove to skip.
+###
+### Each optional role also has a master enable flag (`<svc>_enabled`,
+### defaults to true) you can set to false in its per-service file
+### (40-pihole.yml, 50-backup.yml, 60-tailscale.yml) to pause deployment
+### without removing from this list. Useful for staging config before
+### the dependencies are ready (e.g. NAS not on the LAN yet).
 platform_services:
   - caddy            # mandatory — reverse proxy + LE certs
   - dashboard        # mandatory — static landing page

--- a/inventory/host_vars/homeserver.example/40-pihole.yml.example
+++ b/inventory/host_vars/homeserver.example/40-pihole.yml.example
@@ -15,3 +15,9 @@ pihole_api_password: !vault |
 
 # Static A records for LAN hosts not covered by the wildcard go in
 # 20-extras.yml — pihole_local_dns_records: [{ip: ..., hostname: ...}, ...]
+
+###
+### Defaults — usually no need to change:
+# Master enable flag. Defaults to true. Set to false to pause pihole
+# deployment without removing it from platform_services.
+# pihole_enabled: true

--- a/inventory/host_vars/homeserver.example/50-backup.yml.example
+++ b/inventory/host_vars/homeserver.example/50-backup.yml.example
@@ -17,5 +17,10 @@ backup_nas_volume: "/volume1"                   # Synology Btrfs volume root
 ### Defaults — usually no need to change:
 backup_time: "21:00:00"                         # local time of the systemd timer
 
+# Master enable flag. Defaults to true. Set to false to pause nightly
+# backups without removing the role from platform_services (e.g. NAS
+# isn't on the LAN yet, or you're testing).
+# backup_enabled: true
+
 # Optional snapshot-trigger SSH config (sends a post-backup signal to
 # the NAS to take a Btrfs snapshot) goes in 20-extras.yml.

--- a/inventory/host_vars/homeserver.example/60-tailscale.yml.example
+++ b/inventory/host_vars/homeserver.example/60-tailscale.yml.example
@@ -11,3 +11,9 @@
 ### >>> YOU MUST SET:
 os_tailscale_auth_key: !vault |
   <ansible-vault-encrypted Tailscale auth key>
+
+###
+### Defaults — usually no need to change:
+# Master enable flag. Defaults to true. Set to false to keep the auth
+# key staged in inventory but skip joining the host to the tailnet.
+# tailscale_enabled: true

--- a/roles/platform/backup/README.md
+++ b/roles/platform/backup/README.md
@@ -23,6 +23,7 @@ rootless container volumes via `podman unshare`.
 
 | Variable                       | Default                | Purpose                                                            |
 |--------------------------------|------------------------|--------------------------------------------------------------------|
+| `backup_enabled`               | `true`                 | Master enable flag — site.yml skips the role if false even when `backup` is in `platform_services`. Per-service playbook bypasses this. |
 | `backup_time`                  | `02:00:00`             | systemd `OnCalendar` time-of-day (HH:MM:SS).                       |
 | `backup_nas_hostname`          | `nas`                  | Short hostname pinned in `/etc/hosts`.                             |
 | `backup_nas_ip`                | `192.168.x.x`          | NAS IP — pinned in `/etc/hosts` so backups don't depend on DNS.    |

--- a/roles/platform/backup/defaults/main.yml
+++ b/roles/platform/backup/defaults/main.yml
@@ -1,4 +1,17 @@
 ---
+# Master enable flag for the backup role.
+#
+# site.yml gates the role's inclusion on BOTH `backup in platform_services`
+# AND `backup_enabled | default(true)`. Set this to `false` in host_vars
+# to keep backup in the inventory list but skip its deployment on the
+# next `homeserver.sh install` / `ansible-playbook site.yml` run — useful
+# for hosts where you've staged the NAS coords but aren't ready to enable
+# nightly backups yet (e.g. NAS isn't on the LAN, or you're testing).
+#
+# Per-service playbooks (`ansible-playbook playbooks/backup.yml`) bypass
+# this flag — they're explicit operator intent.
+backup_enabled: true
+
 # NAS target for the NFS backup. Override ALL of these per-host in your
 # inventory (typically in host_vars/<host>.yml).
 #

--- a/roles/platform/os-tailscale/README.md
+++ b/roles/platform/os-tailscale/README.md
@@ -44,6 +44,7 @@ See `defaults/main.yml`. Common knobs:
 
 | Variable | Default | Purpose |
 |---|---|---|
+| `tailscale_enabled` | `true` | Master enable flag — site.yml skips the role if false even when `os-tailscale` is in `platform_services`. Per-service playbook bypasses this. |
 | `os_tailscale_auth_key` | `""` | Vault-encrypted reusable / single-use auth key from the admin console. Empty = manual login. |
 | `os_tailscale_hostname` | `inventory_hostname` | The label that appears in the admin console. |
 | `os_tailscale_advertise_routes` | `[]` | List of CIDRs to advertise as subnet routes (e.g. `["192.168.1.0/24"]`). Routes also need approval in the admin console. |

--- a/roles/platform/os-tailscale/defaults/main.yml
+++ b/roles/platform/os-tailscale/defaults/main.yml
@@ -1,4 +1,17 @@
 ---
+# Master enable flag for the os-tailscale role.
+#
+# site.yml gates the role's inclusion on BOTH `os-tailscale in
+# platform_services` AND `tailscale_enabled | default(true)`. Set this
+# to `false` in host_vars to keep os-tailscale in the inventory list but
+# skip its deployment on the next `homeserver.sh install` /
+# `ansible-playbook site.yml` run — useful for staging the auth key in
+# inventory before you're ready to join the host to the tailnet.
+#
+# Per-service playbooks (`ansible-playbook playbooks/os-tailscale.yml`)
+# bypass this flag — they're explicit operator intent.
+tailscale_enabled: true
+
 # Authentication key for unattended `tailscale up`. When set (typically
 # from vault), the role will run `tailscale up --auth-key=...` once if
 # the host isn't already logged in. When empty, complete login

--- a/roles/platform/pihole/README.md
+++ b/roles/platform/pihole/README.md
@@ -26,6 +26,7 @@ Pi-hole is mirrored on GHCR to sidestep Docker Hub's anonymous-pull rate limit. 
 
 | Variable                   | Default                              | Purpose                                                                |
 |----------------------------|--------------------------------------|------------------------------------------------------------------------|
+| `pihole_enabled`           | `true`                               | Master enable flag — site.yml skips the role if false even when `pihole` is in `platform_services`. Per-service playbook bypasses this. |
 | `pihole_web_port_https`    | `8443`                               | HTTPS port for the admin UI.                                           |
 | `pihole_image`             | `ghcr.io/pi-hole/pihole:latest`      | Pi-hole container image.                                               |
 | `pihole_unbound_image`     | `docker.io/klutchell/unbound:latest` | Unbound container image (pulled only when `pihole_enable_unbound`).    |

--- a/roles/platform/pihole/defaults/main.yml
+++ b/roles/platform/pihole/defaults/main.yml
@@ -1,3 +1,16 @@
+# Master enable flag for the pihole role.
+#
+# site.yml gates the role's inclusion on BOTH `pihole in platform_services`
+# AND `pihole_enabled | default(true)`. Set this to `false` in host_vars to
+# keep pihole in the inventory list but skip its deployment on the next
+# `homeserver.sh install` / `ansible-playbook site.yml` run — useful for
+# pausing the role temporarily without losing the rest of its config
+# (admin password, custom DNS records in 20-extras.yml, etc.).
+#
+# Per-service playbooks (`ansible-playbook playbooks/pihole.yml`) bypass
+# this flag — they're explicit operator intent.
+pihole_enabled: true
+
 pihole_web_port_https: 8443
 
 # Pi-hole container image. Defaults to the official GHCR mirror to avoid


### PR DESCRIPTION
## Summary

site.yml already gates pihole / backup / os-tailscale on a master \`<svc>_enabled | default(true)\` flag (added before v2.7.0), but the flag was undocumented anywhere — not in the role defaults, not in the example files, not in any README. New operators had no way to discover it short of grep'ing site.yml.

## Changes (docs only — no behavior change)

- Declare \`pihole_enabled: true\` / \`backup_enabled: true\` / \`tailscale_enabled: true\` in each role's \`defaults/main.yml\` with a block comment explaining the flag's purpose and the per-service-playbook bypass semantics.
- Add a row to each role's README variables table.
- Mention the flag in the \`platform_services\` comment of \`inventory/host_vars/homeserver.example/00-services.yml.example\`.
- Mention the flag (as a commented-out default) in \`40-pihole.yml.example\`, \`50-backup.yml.example\`, \`60-tailscale.yml.example\`.

## Design note

Per-service playbooks (e.g. \`ansible-playbook playbooks/pihole.yml\`) deliberately *ignore* the flag — they're explicit operator intent and shouldn't be silently skipped. The flag is a site.yml-orchestration concept: \"this host has the role staged in inventory but I'm pausing automated deployment.\"

Closes the documentation half of the original install-refactor plan's PR 4 (the functional half — site.yml gating — was already in place).

## Test plan

- [x] Lint clean (existing Jinja-in-name warnings in pihole/verify.yml are pre-existing).
- [x] Comments match the actual gate semantics in site.yml (\`<svc>_enabled | default(true)\` AND list membership).
- [ ] Reviewer: spot-check that \`ansible-inventory --host <host>\` now shows the new defaults for any host that doesn't override them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)