### PR TITLE
fix(install): union caddy_reverse_proxy_services with selected-role meta

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -1979,36 +1979,65 @@ echo ""
 vault_encrypt "$DESEC_TOKEN" "caddy_acme_token"
 echo ""
 
-# caddy_reverse_proxy_services: prefer existing inventory block if
-# present (preserves operator port overrides / hand-added services);
-# otherwise aggregate canonical entries from each selected service's
-# roles/{platform,apps}/<svc>/meta/install.yml — single source of truth.
-existing_rps=$(inv_get caddy_reverse_proxy_services)
-if [[ -n "$existing_rps" ]]; then
-    echo "$existing_rps" | python3 -c "
-import json, sys, yaml
-d = json.load(sys.stdin)
-print(yaml.safe_dump({'caddy_reverse_proxy_services': d}, default_flow_style=False, sort_keys=False).rstrip())
-"
-else
-    META_PATHS=()
-    for svc in "${SELECTED_SERVICES[@]}"; do
-        if m=$(resolve_meta_install "$INSTALL_DIR" "$svc"); then
-            META_PATHS+=("$m")
-        fi
-    done
-    INSTALL_DIR="$INSTALL_DIR" python3 - "${META_PATHS[@]}" <<'PY'
-import sys, yaml
-entries = []
+# caddy_reverse_proxy_services: union of (each selected role's meta
+# side_effects.caddy_reverse_proxy_services) + the existing inventory's
+# list, keyed by subdomain. Existing entries win per-key — preserves
+# operator port overrides and hand-added subdomains. Missing entries
+# for newly-selected services get filled in from meta.
+#
+# (Bug class fixed previously for my_linux_users in PR #272: the old
+# "if existing present, copy verbatim" branch silently dropped any
+# newly-selected service's subdomain because the existing inventory
+# was preserved with no union.)
+existing_rps_json=$(inv_get caddy_reverse_proxy_services)
+META_PATHS=()
+for svc in "${SELECTED_SERVICES[@]}"; do
+    if m=$(resolve_meta_install "$INSTALL_DIR" "$svc"); then
+        META_PATHS+=("$m")
+    fi
+done
+
+EXISTING="$existing_rps_json" \
+    python3 - "${META_PATHS[@]}" <<'PY'
+import json, os, sys, yaml
+
+# Layer 1: aggregate from each selected role's meta/install.yml.
+merged = {}
 for path in sys.argv[1:]:
-    with open(path) as fh:
-        meta = yaml.safe_load(fh) or {}
+    try:
+        with open(path) as fh:
+            meta = yaml.safe_load(fh) or {}
+    except Exception:
+        continue
     for entry in ((meta.get('side_effects') or {}).get('caddy_reverse_proxy_services') or []):
-        entries.append(entry)
-print(yaml.safe_dump({'caddy_reverse_proxy_services': entries},
+        sub = entry.get('subdomain')
+        if sub:
+            merged[sub] = dict(entry)
+
+# Layer 2: existing inventory wins per-subdomain (preserves operator
+# port overrides + any hand-added subdomains that don't come from
+# meta — e.g. an extra Caddy route in 20-extras.yml that's been
+# duplicated into the main reverse_proxy list).
+existing_raw = (os.environ.get('EXISTING') or '').strip()
+if existing_raw:
+    try:
+        existing = json.loads(existing_raw)
+        if isinstance(existing, list):
+            for entry in existing:
+                if isinstance(entry, dict):
+                    sub = entry.get('subdomain')
+                    if sub:
+                        merged[sub] = dict(entry)
+    except json.JSONDecodeError:
+        pass
+
+# Stable order: alphabetical by subdomain. Matches `ls` output for
+# anyone diffing the file by hand.
+ordered = [merged[k] for k in sorted(merged.keys())]
+
+print(yaml.safe_dump({'caddy_reverse_proxy_services': ordered},
                      default_flow_style=False, sort_keys=False).rstrip())
 PY
-fi
 } > "$HOST_VARS_DIR/10-caddy.yml"
 
 # --- 30-smtp.yml: SMTP relay (whole block optional) ---


### PR DESCRIPTION
## Summary

Install's \`10-caddy.yml\` write used to either copy the existing \`caddy_reverse_proxy_services\` list verbatim OR fall back to aggregating from selected roles' meta. If the existing list was missing an entry for a newly-selected service (e.g. operator added \`nextcloud\` to apps but had never deployed it before), the install preserved the old list and silently skipped nextcloud — its \`cloud\` subdomain never got a Caddy block.

**Symptom on prod after the v2.7.x upgrade**: \`https://cloud.simsons.dedyn.io/\` served the dashboard fallthrough instead of Nextcloud, because the Caddyfile's \`host @cloud\` matcher was never rendered (no \`cloud\` entry in \`caddy_reverse_proxy_services\`).

This is the same bug class as \`my_linux_users\` (fixed in PR #272). Apply the same fix shape:

1. Aggregate \`{subdomain → entry}\` from each selected role's \`meta/install.yml\` \`side_effects.caddy_reverse_proxy_services\`.
2. Layer the existing inventory list on top, keyed by subdomain — operator port overrides and hand-added subdomains win per-key.
3. Emit alphabetically by subdomain for stable diffs.

## Test plan

- [x] Local unit-test the merge logic with three scenarios:
  - Fresh install (no existing) → aggregates all selected roles
  - Prod bug repro (existing missing nextcloud, role selected) → meta fills the gap
  - Operator override (existing pihole has custom port 9443 + path: /custom) → existing wins per-subdomain
- [x] \`bash -n homeserver.sh\` clean
- [x] Manual repro + recovery on prod (added the nextcloud entry via \`config caddy\`-style hand-edit, ran caddy playbook; cloud.simsons.dedyn.io now serves nextcloud)
- [ ] Reviewer: re-run \`homeserver.sh install\` on prod (or any v2.7.x host); confirm the regenerated \`10-caddy.yml\` matches what's already there + any newly-selected services get added without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)