### PR TITLE
docs: refresh operator docs for split host_vars + per-cert + apps split

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Work in progress — not ready for production use yet.**
 > The project is under active development and as of now it's not
 > exactly working as described. The architecture, role
-> contracts, inventory layout, and even the deploy_services list
+> contracts, inventory layout, and even the platform_services + apps lists
 > still change without warning between commits.
 
 ## Objective

--- a/docs/Install-CloudInit.md
+++ b/docs/Install-CloudInit.md
@@ -33,7 +33,7 @@ deployed*. No SSH session opened.
      for security).
    - Your vault password.
    - Hostname + chosen SSH port.
-   - Which `deploy_services` preset to use (e.g.
+   - Which `platform_services` + `apps` preset to use (e.g.
      `cloud-vserver-dns`, `cloud-vserver-files`, `cloud-vserver-full`).
 3. Click "Create VM".
 4. Wait 15–30 minutes.

--- a/docs/Install-VPS.md
+++ b/docs/Install-VPS.md
@@ -107,7 +107,7 @@ Continue with **[Quickstart](Quickstart.md)** → Step 2.
 
 ## Caveats for cloud deploys
 
-The default `deploy_services` list assumes a home-LAN context (NAS
-mounts, AirPlay, USB DAC, etc.). On a cloud VPS, you'll want to
-pare it down. The example `dnsvserver` host in the inventory is a
-good template for a small cloud-only deploy.
+The default `platform_services` + `apps` lists assume a home-LAN
+context (NAS mounts, AirPlay, USB DAC, etc.). On a cloud VPS,
+you'll want to pare them down. The example `dnsvserver` host in
+the inventory is a good template for a small cloud-only deploy.

--- a/docs/NAS-Setup.md
+++ b/docs/NAS-Setup.md
@@ -145,7 +145,8 @@ If it fails, check:
 
 ## 9. Inventory wiring
 
-In `inventory/host_vars/<host>/main.yml`:
+In `inventory/host_vars/<host>/20-extras.yml` (operator-managed,
+never touched by `homeserver.sh install`):
 
 ```yaml
 backup_nas_snapshot_user: homeserver-backup

--- a/docs/PLATFORM-CONTRACT.md
+++ b/docs/PLATFORM-CONTRACT.md
@@ -28,7 +28,7 @@ Caddy is **mandatory** — `playbooks/site.yml` asserts it.
 
 ### 3. Backup manifests (`roles/platform/backup`)
 
-Apps declare a `backup_manifest` in `defaults/main.yml`. The backup role reads manifests from any role in `deploy_services`. **App behavior is unchanged whether or not backup is deployed** — the manifest is free metadata.
+Apps declare a `backup_manifest` in `defaults/main.yml`. The backup role reads manifests from any role in `platform_services + apps` (the union exposed by `inventory/group_vars/all.yml` as `deploy_services` for back-compat). **App behavior is unchanged whether or not backup is deployed** — the manifest is free metadata.
 
 Schema: see `roles/META-SCHEMA.md`.
 
@@ -57,5 +57,5 @@ These rules are enforced by `scripts/check-role-boundaries.sh`.
 1. Default to `roles/apps/<name>/`.
 2. Declare a `backup_manifest` in `defaults/main.yml` if the role has state worth restoring.
 3. Add a `caddy_route` template if it has a web UI.
-4. Add `<name>` to your host's `deploy_services` list.
+4. Add `<name>` to your host's `apps:` list in `00-services.yml` (or `platform_services:` if it's foundational infra). The convenient way is `homeserver.sh add <name>` — that prompts for any required secrets, vaults them, updates `apps:` / `platform_services` / `caddy_reverse_proxy_services` / `my_linux_users`, and runs the role's playbook.
 5. Run `scripts/check-role-boundaries.sh` before opening a PR.

--- a/docs/SMTP-Setup.md
+++ b/docs/SMTP-Setup.md
@@ -66,8 +66,9 @@ the cleaner path is: turn on 2FA first, then generate an app password.
 
 ## Inventory configuration
 
-Add these vars to `inventory/host_vars/<host>/main.yml` (in your
-private overlay):
+Add these vars to `inventory/host_vars/<host>/30-smtp.yml` (in
+your private overlay — or use `homeserver.sh config smtp` to open
+it in your `$EDITOR` and auto-apply via `playbooks/site.yml`):
 
 ```yaml
 ##################################################################################################

--- a/docs/SSO-Bootstrap.md
+++ b/docs/SSO-Bootstrap.md
@@ -51,8 +51,8 @@ to any other app you add later.
 
 ## Step 2 — Add the credentials to inventory
 
-In your private overlay's `inventory/host_vars/<host>/main.yml`,
-under the Paperless block:
+In your private overlay's
+`inventory/host_vars/<host>/apps/paperless-ngx.yml`:
 
 ```yaml
 paperless_oidc_enabled: true

--- a/docs/Setup-Guide/01-deSEC-account.md
+++ b/docs/Setup-Guide/01-deSEC-account.md
@@ -44,8 +44,8 @@ After creating your account create your domain:
 
 You now own `mydomain.dedyn.io` and any subdomain under it
 (`pihole.mydomain.dedyn.io`, `paperless.mydomain.dedyn.io`,
-etc.) — Caddy will mint a wildcard cert covering all of them in
-Step 4.
+etc.) — Caddy will mint one Let's Encrypt cert per name (apex
++ each subdomain) via DNS-01 against deSEC in Step 4.
 
 (~1 min.)
 

--- a/docs/Setup-Guide/05-run-setup.md
+++ b/docs/Setup-Guide/05-run-setup.md
@@ -61,14 +61,22 @@ Roughly in order:
 - Writes the wildcard A record (`*.<sub>.dedyn.io → <server LAN
   IP>`) to deSEC via API. (One less manual step in the deSEC
   dashboard.)
-- Generates your inventory file under
-  `~/home-server/inventory/host_vars/homeserver/main.yml`,
-  including vault-encrypted secrets for every service.
-- Runs `ansible-playbook playbooks/site.yml --connection=local`
+- Generates your split-layout inventory under
+  `~/home-server/inventory/host_vars/<hostname>/` — one file per
+  section (`00-services.yml`, `10-caddy.yml`, `30-smtp.yml`,
+  `40-pihole.yml`, …, plus `apps/<svc>.yml` per deployed app),
+  with vault-encrypted secrets in the relevant files. See
+  `inventory/host_vars/homeserver.example/README.md` for the
+  layout contract.
+- If you provide a private overlay repo URL, the inventory is
+  written there and selective symlinks (`inventory/hosts.yml` and
+  `inventory/host_vars`) point the public clone at the overlay
+  — secrets stay out of the public repo.
+- Runs `ansible-playbook playbooks/site.yml --limit <hostname>`
   against your box, deploying every role you picked.
-- Caddy issues a wildcard Let's Encrypt cert for
-  `*.<sub>.dedyn.io` via DNS-01 against deSEC — no inbound port
-  forwarding needed.
+- Caddy issues one Let's Encrypt cert per site name (apex + each
+  reverse-proxied subdomain) via DNS-01 against deSEC — no
+  inbound port forwarding needed.
 - Pi-hole gets a wildcard local DNS record so LAN clients resolve
   the subdomain to your homeserver's IP.
 

--- a/docs/Setup-Guide/06-verify-and-explore.md
+++ b/docs/Setup-Guide/06-verify-and-explore.md
@@ -35,7 +35,7 @@ If you see a padlock — congratulations, you're done. 🎉
 |---|---|---|
 | **DNS doesn't resolve** the subdomain | Your laptop isn't using Pi-hole as DNS, OR you haven't picked Pi-hole in the service list | Set your laptop's DNS to the homeserver's IP, or add the homeserver to your router's DHCP DNS server. |
 | **Cert warning** | Caddy's first cert issuance hadn't completed yet when you opened the URL | Wait 1–2 min; reload. If still wrong, check `journalctl --user -u caddy -n 50` on the server for an ACME error. |
-| **Apex works, subdomains fail with `SSL_ERROR_INTERNAL_ERROR_ALERT`** | Apex cert issued; wildcard cert stuck in an ACME retry loop because the deSEC plugin left stale `_acme-challenge` TXT records. Rare since homeserver.sh pre-clears them, but possible if Caddy's apex + wildcard orders ever truly race. | `ssh <host> 'sudo -u webproxy XDG_RUNTIME_DIR=/run/user/1011 systemctl --user restart caddy'` then wait ~2 min. Background: [#170](https://github.com/luckynrslevin/home-server/issues/170). |
+| **Some subdomains work, others fail with `SSL_ERROR_INTERNAL_ERROR_ALERT`** | One subdomain's cert hasn't been issued yet — Caddy issues one cert per name (apex + each reverse-proxied subdomain) and they trickle in on first deploy. | Wait ~2 min and reload. If still failing, check `sudo -u webproxy XDG_RUNTIME_DIR=/run/user/1011 podman logs caddy` for the failed name. Closes the apex+wildcard race that was [#170](https://github.com/luckynrslevin/home-server/issues/170). |
 | **Connection refused** | Server's firewall not yet open on 443 | Re-run `homeserver.sh upgrade` on the server. |
 
 ## Explore

--- a/docs/Tailscale-DNS-Setup.md
+++ b/docs/Tailscale-DNS-Setup.md
@@ -9,8 +9,8 @@ This guide assumes:
 - You've completed the [Setup Guide](Setup-Guide/README.md) — the
   homeserver is deployed, dashboards are reachable on your LAN.
 - Tailscale is installed on the homeserver (the `os-tailscale` role
-  is in your `deploy_services`) and the box is logged into your
-  tailnet.
+  is in your `platform_services` list with `tailscale_enabled: true`)
+  and the box is logged into your tailnet.
 - You have at least one device (laptop, phone) on the same tailnet.
 
 ## What this fixes


### PR DESCRIPTION
## Summary

Eleven docs still talked about pre-v2.6 inventory shape and the single-wildcard cert model. Operators reading them while setting up would hit dead-end paths:
- \`host_vars/<host>/main.yml\` doesn't exist post-#260 (split into per-section files)
- \`deploy_services\` is now a computed group_var, not a settable inventory list (post-#262 it's the union of \`platform_services\` + \`apps\`)
- The wildcard cert is now per-subdomain certs as of #273 (closed #170)

## Files touched (1-line / one-paragraph fixes, no structural rewrites)

| File | Change |
|------|--------|
| \`Setup-Guide/01-deSEC-account.md\` | Drop \"wildcard cert\" |
| \`Setup-Guide/05-run-setup.md\` | Describe the split-layout inventory + per-name certs in \"What homeserver.sh does behind the scenes\" |
| \`Setup-Guide/06-verify-and-explore.md\` | Drop the issue-#170 wildcard-race troubleshoot row; replace with the per-cert trickle-in note |
| \`SMTP-Setup.md\` | \`main.yml\` → \`30-smtp.yml\` (+ point at \`homeserver.sh config smtp\`) |
| \`NAS-Setup.md\` | \`main.yml\` → \`20-extras.yml\` (operator-owned) |
| \`SSO-Bootstrap.md\` | \`main.yml\` → \`apps/paperless-ngx.yml\` |
| \`PLATFORM-CONTRACT.md\` | \`deploy_services\` → \`platform_services + apps\`; \"add to list\" instructions point at \`homeserver.sh add\` |
| \`Tailscale-DNS-Setup.md\` | \`deploy_services\` → \`platform_services\` + \`tailscale_enabled\` |
| \`Install-VPS.md\` | Same |
| \`Install-CloudInit.md\` | Same |
| \`README.md\` (top-level) | Same |

## Out of scope (separate PR — long planning docs that deserve a fuller pass)

- \`docs/DNS-vserver-plan.md\`
- \`docs/CloudInit-Self-Provision-Plan.md\`

## Test plan

- [x] \`grep -rE \"host_vars.*main\\.yml\" docs/Setup-Guide README.md\` returns nothing
- [x] All edits are 1-line replacements or short paragraphs; no semantic rewrites
- [ ] Reviewer: scan the 11 file changes; let me know if any wording should match a phrase you prefer

🤖 Generated with [Claude Code](https://claude.com/claude-code)