### PR TITLE
feat(restore): check image manifest + pin to backup-time digests

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -6,6 +6,16 @@
 # Special post-restore logic (pihole listsCache, entephoto DB restore) is
 # handled by per-role hooks in roles/<service>/tasks/restore.yml.
 #
+# Image-version pinning (PR #281 capture + PR #282 pin):
+#   The backup captures {container, image-tag, image-digest} alongside
+#   the volumes. At restore-time this playbook reads the latest manifest
+#   and re-pulls + re-tags each recorded digest so the restart picks up
+#   the image that wrote the data — avoids the "restore older volumes
+#   into a newer :latest image" trap. Default ON. To skip and use
+#   whatever image is currently tagged:
+#     ansible-playbook playbooks/restore.yml --limit homeserver \
+#       -e restore_pin_images=false
+#
 # Usage:
 #   ansible-playbook playbooks/restore.yml --limit homeserver
 #

--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -45,7 +45,74 @@
     label: "{{ item.container }}"
   changed_when: false
 
-# --- Stop the service ---
+# ===================================================================
+# Image-version manifest check + pin
+# -------------------------------------------------------------------
+# The backup script captured {name, image-tag, image-digest} for each
+# container running at backup time. Restoring volumes into a newer
+# auto-pulled :latest image risks DB-schema-vs-binary mismatches.
+#
+# Default behaviour: pull the recorded digests and re-tag them as the
+# current image name so the post-restore start picks up the
+# backup-time version. Override with `-e restore_pin_images=false`
+# (e.g. for a deliberate "restore into the newer version" path,
+# accepting upgrade-on-first-start migrations).
+# ===================================================================
+
+- name: "{{ svc._role_name | upper }}: find latest image manifest"
+  ansible.builtin.shell: >-
+    ls -t {{ restore_root }}/{{ svc._role_name }}/images/*.json 2>/dev/null | head -1
+  register: _manifest_path
+  changed_when: false
+  failed_when: false
+
+- name: "{{ svc._role_name | upper }}: read image manifest"
+  ansible.builtin.slurp:
+    src: "{{ _manifest_path.stdout }}"
+  register: _manifest_raw
+  when: _manifest_path.stdout | length > 0
+
+- name: "{{ svc._role_name | upper }}: parse image manifest"
+  ansible.builtin.set_fact:
+    _image_manifest: "{{ (_manifest_raw.content | b64decode | from_json).containers }}"
+    _image_manifest_ts: "{{ (_manifest_raw.content | b64decode | from_json).timestamp }}"
+  when: _manifest_path.stdout | length > 0
+
+- name: "{{ svc._role_name | upper }}: warn when no manifest found"
+  ansible.builtin.debug:
+    msg: >-
+      No image manifest found at
+      {{ restore_root }}/{{ svc._role_name }}/images/.
+      Backups predate PR #281 (capture step). Restore proceeds with
+      whatever image is currently running — verify the data is
+      compatible.
+  when: _manifest_path.stdout | length == 0
+
+- name: "{{ svc._role_name | upper }}: query current image digests for comparison"
+  ansible.builtin.shell: |
+    sudo -u {{ svc.service_user }} \
+      XDG_RUNTIME_DIR=/run/user/{{ my_linux_users[svc.service_user].uid }} \
+      podman inspect {{ item.name }} \
+      --format '{% raw %}{{.ImageDigest}}{% endraw %}' 2>/dev/null
+  loop: "{{ _image_manifest | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: _current_digests
+  changed_when: false
+  failed_when: false
+
+- name: "{{ svc._role_name | upper }}: image manifest comparison"
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.0.name }}: backup={{ item.0.image_digest }} ·
+      current={{ item.1.stdout if item.1.stdout else '(missing)' }} ·
+      {{ 'MATCH' if item.1.stdout == item.0.image_digest else 'MISMATCH' }}
+  loop: "{{ _image_manifest | default([]) | zip(_current_digests.results | default([])) | list }}"
+  loop_control:
+    label: "{{ item.0.name }}"
+  when: _image_manifest is defined
+
+# --- Stop the service (before pulling/tagging so nothing races) ---
 - name: "{{ svc._role_name | upper }}: stop service"
   ansible.builtin.command:
     cmd: >
@@ -54,6 +121,40 @@
       DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ my_linux_users[svc.service_user].uid }}/bus
       systemctl --user stop {{ svc.service_unit }}
   changed_when: false
+  failed_when: false
+
+# Pin: pull each recorded digest + retag as the current image name.
+# Iterate every manifest entry — the shell short-circuits when the
+# digest already matches (a no-op match logs "already pinned" and
+# moves on). Pulling an already-cached digest is fast and idempotent.
+#
+# `podman tag` overwrites the existing tag in local storage; the next
+# container start uses the now-tagged digest. Auto-update will re-bump
+# to :latest at its next tick — operator should pause auto-update if
+# they want the pin to persist beyond the immediate restart.
+- name: "{{ svc._role_name | upper }}: pin images to backup-time digests"
+  ansible.builtin.shell: |
+    set -eu
+    REPO='{{ item.image | regex_replace(":[^:/]+$", "") }}'
+    DIGEST='{{ item.image_digest }}'
+    TAGGED='{{ item.image }}'
+    SUDO='sudo -u {{ svc.service_user }} XDG_RUNTIME_DIR=/run/user/{{ my_linux_users[svc.service_user].uid }}'
+    CURRENT=$($SUDO podman inspect {{ item.name }} --format '{% raw %}{{.ImageDigest}}{% endraw %}' 2>/dev/null || echo '')
+    if [ "$CURRENT" = "$DIGEST" ]; then
+        echo "already pinned ({{ item.name }} @ $DIGEST)"
+        exit 0
+    fi
+    echo "pinning {{ item.name }}: $CURRENT -> $DIGEST"
+    $SUDO podman pull "${REPO}@${DIGEST}"
+    $SUDO podman tag  "${REPO}@${DIGEST}" "${TAGGED}"
+  loop: "{{ _image_manifest | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - restore_pin_images | default(true)
+    - _image_manifest is defined
+  register: _pin_result
+  changed_when: '"pinning" in _pin_result.stdout'
   failed_when: false
 
 # --- Restore tar volumes ---

--- a/roles/platform/backup/README.md
+++ b/roles/platform/backup/README.md
@@ -154,9 +154,13 @@ backups from that run.
   }
   ```
 - **Retention**: same 7-day window as the rest.
-- **Restore-side usage**: pin the role's image to the recorded digest
-  before re-deploy, so the restored volumes meet the version that
-  produced them. (Manual today; auto-pin is a planned follow-up.)
+- **Restore-side usage** (PR #282): `playbooks/restore.yml` reads the
+  latest manifest per role, compares each container's current
+  `ImageDigest` against the recorded one, and (default ON) pulls +
+  re-tags the recorded digest so the post-restore start uses the
+  exact image that wrote the data. Skip with
+  `-e restore_pin_images=false` to deliberately restore into the
+  current (newer) image.
 - **Non-fatal**: a capture failure logs an error but does not abort
   the run — volume backups still proceed.
 


### PR DESCRIPTION
## Summary

Companion to #281 (backup-time image manifest capture). The restore playbook now reads the latest \`images-*.json\` per role and:

1. **Logs a compare line per container**: \`<name>: backup=<digest> · current=<digest> · MATCH|MISMATCH\`
2. **Default ON**: pulls each recorded digest and re-tags it as the current image name, so the post-restore start picks up the image that wrote the data. Iteration short-circuits when the digest already matches (logged as \"already pinned\").
3. **Override**: \`-e restore_pin_images=false\` for the deliberate \"restore older data into the newer :latest, accept first-start upgrade migrations\" path.

## Order

Inside \`restore_generic.yml\`:

\`\`\`
mount → find tar/pgdump → READ MANIFEST + COMPARE →
stop service → PIN → restore tar → restore rsync →
start service → role hook → unmount
\`\`\`

Pin is sandwiched between stop + restore so the service comes back up on the pinned image, immediately serving the restored data.

## Behaviour

- **No manifest found** (backups predate #281): log a warning and proceed with the current image — matches pre-PR behaviour.
- **\`restore_pin_images: true\`** (default): pin every container whose digest differs.
- **\`restore_pin_images: false\`**: read + compare + log only; no pull/tag.

## Auto-update interaction

After restore, \`podman-auto-update.timer\` will re-bump \`:latest\` to current at its next tick (default daily). To pause the pin: \`sudo -u <user> systemctl --user stop podman-auto-update.timer\` before restore + decide later when to resume.

## Test plan

- [x] \`ansible-playbook --syntax-check playbooks/restore.yml\` clean
- [x] ansible-lint warnings on this PR are existing-pattern Jinja-in-name warnings, not introduced here
- [ ] Reviewer: on a host with manifests captured (any host post-#281), run \`ansible-playbook playbooks/restore.yml --limit <host> --tags <small-role> -e restore_pin_images=false\` first to validate the compare-only path. Then full restore with pin on a non-prod host (e.g. homeserver2) to validate the pull+tag path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)