### PR TITLE
feat(add): interactive prompts for config vars; route on kind

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -763,7 +763,7 @@ USAGE
     add)
         SERVICE="${1:-}"
         if [[ -z "$SERVICE" ]]; then
-            err "Usage: homeserver.sh add <service>"
+            err "Usage: homeserver.sh add <service> [--overrides k=v ...] [-y]"
             err "Available services:"
             for m in "$INSTALL_DIR"/roles/platform/*/meta/install.yml "$INSTALL_DIR"/roles/apps/*/meta/install.yml; do
                 [[ -f "$m" ]] || continue
@@ -773,6 +773,30 @@ USAGE
             done
             exit 2
         fi
+        shift || true
+        # Per-verb flag parsing. Mirrors `remove`'s loop so flags can
+        # follow the positional service name, e.g.
+        # `homeserver.sh add backup -h homeserver2 --overrides backup_nas_ip=192.168.1.184`.
+        # OVERRIDE_ARGS feeds `--overrides` to build_add_update.py and
+        # also short-circuits the interactive prompt for matching vars.
+        OVERRIDE_ARGS=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --overrides)
+                    shift
+                    while [[ $# -gt 0 && "$1" != -* ]]; do
+                        OVERRIDE_ARGS+=("$1")
+                        shift
+                    done
+                    continue
+                    ;;
+                -h) shift; HOSTNAME_FLAG="${1:-}" ;;
+                -v) shift; VAULT_PW_FLAG_FILE="${1:-}" ;;
+                -y|--yes) YES_FLAG=true ;;
+                *) err "Unknown add flag: $1"; exit 2 ;;
+            esac
+            shift
+        done
         ensure_install_dir
         ensure_ansible_on_path
         if ! META=$(resolve_meta_install "$INSTALL_DIR" "$SERVICE"); then
@@ -819,28 +843,45 @@ USAGE
         # shellcheck disable=SC2064
         trap "rm -f $UPDATE_JSON $PROMPTS_TXT" EXIT
         PROMPTED_ARGS=()
+        # Build the base build_add_update.py argv. --overrides may carry
+        # values the operator pre-supplied on the CLI; the same flag
+        # gets extended below with anything the interactive prompt
+        # collects for `config`-type vars.
+        BUILD_ARGS=(--meta "$META" --service "$SERVICE"
+                    --vault-password-file "$VAULT_PW_FILE"
+                    --target-host "$TARGET"
+                    --inventory-dir "$INSTALL_DIR/inventory")
+        if (( ${#OVERRIDE_ARGS[@]} > 0 )); then
+            BUILD_ARGS+=(--overrides "${OVERRIDE_ARGS[@]}")
+        fi
         # Discovery pass: build_add_update.py exits 3 with PROMPTS_NEEDED
-        # on stdout if the role declares `secret_prompt` vars. We collect
-        # operator-supplied values and re-invoke with --prompted-secrets.
+        # on stdout when the role declares vars the wrapper must collect
+        # (secret_prompt vars, or config vars with no resolvable default
+        # and no pre-supplied --overrides). Each line carries a `kind`
+        # column that tells us whether the captured value gets routed
+        # through --prompted-secrets (kind=secret) or --overrides
+        # (kind=config) on the re-invoke.
         if ! python3 scripts/build_add_update.py \
-                --meta "$META" \
-                --service "$SERVICE" \
-                --vault-password-file "$VAULT_PW_FILE" \
-                --target-host "$TARGET" \
-                --inventory-dir "$INSTALL_DIR/inventory" \
+                "${BUILD_ARGS[@]}" \
                 --output "$UPDATE_JSON" > "$PROMPTS_TXT" 2>&1; then
             if grep -q '^PROMPTS_NEEDED$' "$PROMPTS_TXT"; then
-                info "Role needs operator-supplied secret(s):"
+                if [[ "$YES_FLAG" == "true" ]]; then
+                    err "Role needs operator-supplied values but -y was passed."
+                    err "Pre-supply them with --overrides key=val ... and retry."
+                    grep -v '^PROMPTS_NEEDED$' "$PROMPTS_TXT" | \
+                        awk -F'\t' 'NF>=2 { printf "  - %s  (%s)\n", $1, $2 }' >&2
+                    exit 1
+                fi
+                info "Role needs operator-supplied value(s):"
                 # Inner `read` MUST come from /dev/tty — the while loop's
                 # stdin is the file we're iterating over, so a bare
                 # `read pval` would silently consume the next line of
                 # PROMPTS_TXT (the password's own metadata) as the user's
                 # input. /dev/tty bypasses the redirect.
-                while IFS=$'\t' read -r pkey ptext pconfirm pmask; do
+                while IFS=$'\t' read -r pkey ptext pconfirm pmask pkind; do
                     [[ "$pkey" == "PROMPTS_NEEDED" || -z "$pkey" ]] && continue
-                    # Default mask=true if the older build_add_update.py
-                    # didn't emit the field (back-compat).
                     pmask="${pmask:-true}"
+                    pkind="${pkind:-secret}"
                     read_flags="-r"
                     [[ "$pmask" == "true" ]] && read_flags="-rs"
                     echo
@@ -858,16 +899,24 @@ USAGE
                             exit 1
                         fi
                     fi
-                    PROMPTED_ARGS+=("$pkey=$pval")
+                    if [[ "$pkind" == "config" ]]; then
+                        OVERRIDE_ARGS+=("$pkey=$pval")
+                    else
+                        PROMPTED_ARGS+=("$pkey=$pval")
+                    fi
                 done < "$PROMPTS_TXT"
+                REINVOKE=(--meta "$META" --service "$SERVICE"
+                          --vault-password-file "$VAULT_PW_FILE"
+                          --target-host "$TARGET"
+                          --inventory-dir "$INSTALL_DIR/inventory")
+                if (( ${#OVERRIDE_ARGS[@]} > 0 )); then
+                    REINVOKE+=(--overrides "${OVERRIDE_ARGS[@]}")
+                fi
+                if (( ${#PROMPTED_ARGS[@]} > 0 )); then
+                    REINVOKE+=(--prompted-secrets "${PROMPTED_ARGS[@]}")
+                fi
                 if ! python3 scripts/build_add_update.py \
-                        --meta "$META" \
-                        --service "$SERVICE" \
-                        --vault-password-file "$VAULT_PW_FILE" \
-                        --target-host "$TARGET" \
-                        --inventory-dir "$INSTALL_DIR/inventory" \
-                        --prompted-secrets "${PROMPTED_ARGS[@]}" \
-                        --output "$UPDATE_JSON"; then
+                        "${REINVOKE[@]}" --output "$UPDATE_JSON"; then
                     err "Failed to build update spec after collecting prompts."
                     exit 1
                 fi

--- a/roles/platform/backup/meta/install.yml
+++ b/roles/platform/backup/meta/install.yml
@@ -30,7 +30,11 @@ inventory_vars:
 side_effects: {}
 
 playbooks:
-  - playbooks/backup.yml
+  # backup-only-deploy.yml pre-aggregates each role's backup_manifest
+  # into _backup_manifests via pre_tasks; playbooks/backup.yml expects
+  # that fact to already be set and fails with `_backup_manifests
+  # undefined` when invoked standalone (i.e. from `homeserver.sh add`).
+  - playbooks/backup-only-deploy.yml
   - playbooks/dashboard.yml  # refresh tile (if backup adds one)
 
 on_remove:

--- a/scripts/build_add_update.py
+++ b/scripts/build_add_update.py
@@ -11,9 +11,11 @@ Resolves each declared inventory_var:
                     the list of needed prompts on stdout (machine
                     readable) so the wrapper can collect them and
                     re-invoke.
-  - config        → leave for setup.sh's interactive prompt (skipped
-                    here; caller supplies via --extra-overrides if
-                    non-interactive)
+  - config        → use literal `default` or `host_detect:<key>` if
+                    one resolves. Otherwise treated like secret_prompt
+                    (exit 3 with PROMPTS_NEEDED, kind=config) so the
+                    wrapper can collect the value interactively. Pre-
+                    supplied values can be passed via --overrides.
   - computed      → render `template` Jinja against existing inventory
   - literal       → emit value verbatim
 
@@ -188,8 +190,11 @@ def main():
 
     # Resolve inventory_vars
     scalars = {}
-    config_needed = []  # config-type vars not in inventory or overrides
-    prompt_needed = []  # secret_prompt vars not in inventory or --prompted-secrets
+    # Vars the wrapper must collect interactively. Each entry is
+    # (kind, var); kind in {"secret", "config"} so the wrapper knows
+    # whether to route the answer through --prompted-secrets (vault)
+    # or --overrides (plaintext).
+    prompt_needed = []
     for var in meta.get("inventory_vars", []) or []:
         name = var["name"]
         vtype = var["type"]
@@ -205,7 +210,7 @@ def main():
             value = resolve_secret(var["generator"])
             scalars[name] = {"value": value, "vault": var.get("vault", True)}
         elif vtype == "secret_prompt":
-            prompt_needed.append(var)
+            prompt_needed.append(("secret", var))
         elif vtype == "computed":
             value = render_template(var["template"], existing)
             scalars[name] = {"value": value, "vault": False}
@@ -213,39 +218,38 @@ def main():
             scalars[name] = {"value": var["value"], "vault": False}
         elif vtype == "config":
             # Auto-resolve via host_detect or literal default. Only
-            # fall through to config_needed if there's no default to
-            # work with (operator must supply via --overrides).
+            # fall through to prompt_needed if there's no default to
+            # work with — wrapper collects the value interactively (or
+            # operator pre-supplies it via --overrides on the CLI).
             resolved = resolve_config_default(var.get("default"))
             if resolved:
                 scalars[name] = {"value": resolved, "vault": False}
             else:
-                config_needed.append(var)
+                prompt_needed.append(("config", var))
         else:
             print(f"ERROR: unknown var type {vtype!r} for {name!r}", file=sys.stderr)
             sys.exit(1)
 
-    if config_needed:
-        print("ERROR: the following `config`-type vars need values but"
-              " weren't found in inventory or --overrides:", file=sys.stderr)
-        for var in config_needed:
-            prompt = var.get("prompt", var["name"])
-            print(f"  --overrides {var['name']}=<...>  ({prompt})", file=sys.stderr)
-        sys.exit(2)
-
     if prompt_needed:
-        # Machine-readable on stdout, human-readable on stderr.
-        # Wrapper (setup.sh add) reads stdout to know which prompts
-        # to ask the operator for, then re-invokes with --prompted-secrets.
+        # Machine-readable on stdout. Wrapper (homeserver.sh add) reads
+        # this to know which prompts to ask the operator for, then
+        # re-invokes — routing each captured value into the right
+        # bucket based on `kind`:
+        #   secret → --prompted-secrets  (vault-encrypted scalar)
+        #   config → --overrides         (plaintext scalar)
         print("PROMPTS_NEEDED")
-        for var in prompt_needed:
+        for kind, var in prompt_needed:
             prompt_text = var.get("prompt", var["name"])
             confirm = "true" if var.get("confirm", False) else "false"
             # `mask` controls echo: true = hide input (passwords).
-            # Default true since `secret_prompt` is intended for secrets;
-            # roles set `mask: false` on visible fields like email.
-            mask = "true" if var.get("mask", True) else "false"
-            # name<TAB>prompt_text<TAB>confirm<TAB>mask
-            print(f"{var['name']}\t{prompt_text}\t{confirm}\t{mask}")
+            # secret_prompt defaults to mask=true; config vars are
+            # plaintext (subnets, hostnames, IPs) — never masked.
+            if kind == "config":
+                mask = "false"
+            else:
+                mask = "true" if var.get("mask", True) else "false"
+            # name<TAB>prompt_text<TAB>confirm<TAB>mask<TAB>kind
+            print(f"{var['name']}\t{prompt_text}\t{confirm}\t{mask}\t{kind}")
         sys.exit(3)
 
     # Side effects → lists + dicts


### PR DESCRIPTION
> Re-opened after auto-close when #283's branch was deleted on merge.
> Original PR: #284.

## Summary

Previously `./homeserver.sh add <svc>` failed hard when a `config`-type inventory_var had no usable default and the operator hadn't pre-supplied a value: `build_add_update.py` exited with `--overrides <name>=<...>` — but the `add` verb didn't even parse `--overrides` on the CLI, so the only path forward was to abandon and use `install`. This was the trigger case for the failed `add backup` against homeserver2 (`backup_nas_ip` has no default).

Make `add` walk those vars the same way it already walks `secret_prompt` vars: the discovery pass exits 3 with `PROMPTS_NEEDED` on stdout, and the wrapper collects each missing value from `/dev/tty` and re-invokes with the answers routed into the right bucket (`--overrides` for config, `--prompted-secrets` for secrets).

## Changes

- `scripts/build_add_update.py`: drop the `config_needed` exit-2 branch. Config vars without a resolvable default now join the secret_prompt vars on the `PROMPTS_NEEDED` path. Each line gains a 5th column `kind` (`secret` | `config`).
- `homeserver.sh add` verb: accept `--overrides k=v ...` and `-y/--yes` flags after the positional service name. With `-y` set, missing-value `PROMPTS_NEEDED` fails fast with a list of vars that still need values.
- `roles/platform/backup/meta/install.yml`: switch the playbook from `playbooks/backup.yml` → `playbooks/backup-only-deploy.yml` (the latter aggregates `_backup_manifests` via pre_tasks; `backup.yml` standalone fails with `_backup_manifests undefined`).

## Test plan (executed against homeserver2)

- [x] `./homeserver.sh add backup -y --overrides backup_nas_ip=192.168.1.184` → deploys cleanly, all 4 vars in `50-backup.yml`, backup appended to `platform_services`, dashboard refreshed
- [x] Re-run `./homeserver.sh add backup` → idempotency trips ("already deployed")
- [x] `./homeserver.sh add backup -y` (with `backup_nas_ip` absent + no overrides) → fast-fails with explicit "Pre-supply with --overrides backup_nas_ip" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)