### PR TITLE
fix(inventory-merge): dedup caddy_reverse_proxy_services by subdomain

### DIFF
--- a/scripts/inventory_merge.py
+++ b/scripts/inventory_merge.py
@@ -244,6 +244,39 @@ def _set_dict_entry_preserving_comments(mapping, key, value):
             mapping.ca.items[key] = saved
 
 
+# Lists of dicts that are logically keyed by one field, not by full-row
+# equality. Without this, an existing entry `{port: 8090, subdomain: cloud}`
+# in inventory looks "different" from a fresh meta entry like
+# `{subdomain: cloud, port: 8090, label: "Web UI"}` because the meta added
+# a `label` field over time. cmd_add's full-equality check then appends
+# the new entry alongside the old, producing duplicate Caddyfile blocks
+# and crashing Caddy at next reload; cmd_remove's `seq.index(item)` fails
+# for the same reason and silently leaves stale entries behind.
+#
+# Map each list-key to its identity field. Items matching by that field
+# are treated as the same logical entry for add (overwrite) and remove
+# (drop) semantics.
+LIST_IDENTITY_KEY = {
+    "caddy_reverse_proxy_services": "subdomain",
+}
+
+
+def _seq_find_by_identity(seq, item, identity_key):
+    """Return the index of the existing item in <seq> whose identity_key
+    matches <item>'s, or -1 if none. Used to dedup list-of-dicts entries
+    where two rows for the same logical thing may differ on cosmetic
+    fields the schema picked up later (e.g. dashboard `label` hint)."""
+    if not isinstance(item, (dict, CommentedMap)):
+        return -1
+    needle = item.get(identity_key)
+    if needle is None:
+        return -1
+    for i, existing in enumerate(seq):
+        if isinstance(existing, (dict, CommentedMap)) and existing.get(identity_key) == needle:
+            return i
+    return -1
+
+
 def cmd_add(data, update, vault_pw_file):
     # scalars (top-level)
     for key, spec in (update.get("scalars") or {}).items():
@@ -259,8 +292,20 @@ def cmd_add(data, update, vault_pw_file):
         if existing is None:
             existing = CommentedSeq()
             _set_dict_entry_preserving_comments(data, key, existing)
+        identity_key = LIST_IDENTITY_KEY.get(key)
         for item in spec.get("items", []):
             item = _to_commented(item)
+            # Identity-keyed lists: overwrite the existing row by index so
+            # cosmetic-field drift (e.g. caddy_reverse_proxy_services
+            # gaining a `label`) doesn't strand duplicates.
+            if identity_key is not None:
+                idx = _seq_find_by_identity(existing, item, identity_key)
+                if idx >= 0:
+                    existing[idx] = item
+                    continue
+                _append_seq_preserving_comments(existing, item)
+                continue
+            # Plain lists: dedup by full equality.
             if item not in existing:
                 _append_seq_preserving_comments(existing, item)
     # dicts — merge entries
@@ -349,7 +394,15 @@ def cmd_remove(data, update):
         existing = data.get(key)
         if existing is None:
             continue
+        identity_key = LIST_IDENTITY_KEY.get(key)
         for item in spec.get("items", []):
+            # Identity-keyed lists: drop by matching the identity field
+            # rather than full equality (see LIST_IDENTITY_KEY comment).
+            if identity_key is not None:
+                idx = _seq_find_by_identity(existing, _to_commented(item), identity_key)
+                if idx >= 0:
+                    _remove_seq_item_preserving_comments(existing, existing[idx])
+                continue
             _remove_seq_item_preserving_comments(existing, item)
     # dicts — remove entry keys
     for key, spec in (update.get("dicts") or {}).items():

--- a/scripts/test_inventory_merge.sh
+++ b/scripts/test_inventory_merge.sh
@@ -173,6 +173,53 @@ grep -q 'operator_custom_var' "$WORK/test5/20-extras.yml" \
     || report "operator_custom_var untouched" FAIL
 
 echo
+echo "Test 6: caddy_reverse_proxy_services dedup by subdomain (not full equality)"
+# Existing inventory carries an old-shape row for cloud (no `label`
+# hint); a meta-shape add of the same subdomain should REPLACE it,
+# not append a duplicate. Regression for the homeserver2 Caddyfile
+# bug where two `cloud.<domain>` blocks crashed Caddy.
+make_baseline "$WORK/test6"
+python3 - "$WORK/test6/10-caddy.yml" <<'PY'
+import sys
+from ruamel.yaml import YAML
+yaml = YAML(typ='rt'); yaml.indent(mapping=2, sequence=4, offset=2)
+with open(sys.argv[1]) as f: doc = yaml.load(f)
+doc["caddy_reverse_proxy_services"].append({"port": 8090, "subdomain": "cloud"})
+with open(sys.argv[1], "w") as f: yaml.dump(doc, f)
+PY
+cat > "$WORK/upd_cloud.json" << 'EOF'
+{"scalars": {}, "lists": {"caddy_reverse_proxy_services": {"items": [
+    {"subdomain": "cloud", "port": 8090, "label": "Web UI"}
+]}}, "dicts": {}}
+EOF
+python3 "$MERGE" --host-vars-dir "$WORK/test6" --service nextcloud \
+    --vault-password-file "$WORK/vault.pw" --update "$WORK/upd_cloud.json" --mode add
+n_cloud=$(grep -c "subdomain: cloud" "$WORK/test6/10-caddy.yml")
+[[ "$n_cloud" == "1" ]] \
+    && report "add dedupes cloud by subdomain (single entry)" PASS \
+    || report "add dedupes cloud by subdomain (got $n_cloud entries)" FAIL
+grep -q 'label: Web UI' "$WORK/test6/10-caddy.yml" \
+    && report "add overwrites with the meta-shape row (has label)" PASS \
+    || report "add overwrites with the meta-shape row (has label)" FAIL
+
+# `remove` with a meta-shape item should drop the inventory row even
+# when the inventory row lacks the cosmetic `label` field.
+make_baseline "$WORK/test7"
+python3 - "$WORK/test7/10-caddy.yml" <<'PY'
+import sys
+from ruamel.yaml import YAML
+yaml = YAML(typ='rt'); yaml.indent(mapping=2, sequence=4, offset=2)
+with open(sys.argv[1]) as f: doc = yaml.load(f)
+doc["caddy_reverse_proxy_services"].append({"port": 8090, "subdomain": "cloud"})
+with open(sys.argv[1], "w") as f: yaml.dump(doc, f)
+PY
+python3 "$MERGE" --host-vars-dir "$WORK/test7" --service nextcloud \
+    --vault-password-file "$WORK/vault.pw" --update "$WORK/upd_cloud.json" --mode remove
+! grep -q 'subdomain: cloud' "$WORK/test7/10-caddy.yml" \
+    && report "remove drops cloud by subdomain (label-field mismatch)" PASS \
+    || report "remove drops cloud by subdomain (label-field mismatch)" FAIL
+
+echo
 echo "=========================================="
 echo "  $PASS passed, $FAIL failed"
 echo "=========================================="


### PR DESCRIPTION
## Symptom

On homeserver2, `./homeserver.sh remove nextcloud && ./homeserver.sh add nextcloud` left the Caddyfile with two `cloud.<domain>` blocks. Caddy crashlooped past the systemd restart limit, dashboard went unreachable (\`Verbindung fehlgeschlagen\` in the browser).

## Root cause

`cmd_add`'s list-merge does \`if item not in existing\` and `cmd_remove`'s does \`seq.index(item)\` — both rely on **full-row equality**. The inventory carried an old-shape row for `cloud` from when nextcloud was first installed:

```yaml
- port: 8090
  subdomain: cloud
```

The meta later added a dashboard `label` hint, so meta items now look like:

```yaml
{ subdomain: cloud, port: 8090, label: "Web UI" }
```

One extra field on the meta side means the two rows aren't equal:

- `remove` couldn't find the inventory row → no-op (old row stayed)
- `add` saw the meta row as "missing" → appended a duplicate

Caddyfile rendering then emitted both rows, Caddy errored on the duplicate site address, exited 1, restart counter hit 5, systemd gave up. Port 443 idle. Dashboard down.

## Fix

Treat `caddy_reverse_proxy_services` as **identity-keyed by `subdomain`**:

- `cmd_add` overwrites the existing row in place when identity matches (so meta-side cosmetic-field drift takes effect on next add)
- `cmd_remove` drops by identity-key match, ignoring extra fields

Generalised via `LIST_IDENTITY_KEY` dict so future identity-keyed lists can opt in with one line.

## Verification

- Live recovery: dedup'd homeserver2's inventory by hand, re-ran `playbooks/caddy.yml`, caddy `active`, `curl https://simsons-t.dedyn.io/ → HTTP 200`. Dashboard back up.
- Test suite: 2 new regression tests (add-overwrite + remove-by-identity), 18/18 pass.

## Test plan

- [x] `bash scripts/test_inventory_merge.sh` → 18/18 pass
- [ ] On homeserver2: `./homeserver.sh remove nextcloud && ./homeserver.sh add nextcloud` → `caddy_reverse_proxy_services` has exactly one cloud entry; Caddyfile has one `cloud.<domain>` block; Caddy stays up

🤖 Generated with [Claude Code](https://claude.com/claude-code)