### PR TITLE
fix: keep state-paired secrets on non-purge remove (inventory_vars_to_clear_on_purge)

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -1293,8 +1293,12 @@ print(' '.join(on_remove.get('volumes_to_preserve_unless_purge') or []))
         UPDATE_JSON=$(mktemp --suffix=.json)
         # shellcheck disable=SC2064
         trap "rm -f $UPDATE_JSON" EXIT
-        if ! python3 scripts/build_remove_update.py \
-                --meta "$META" --service "$SERVICE" --output "$UPDATE_JSON"; then
+        BUILD_REMOVE_ARGS=(--meta "$META" --service "$SERVICE" --output "$UPDATE_JSON")
+        # Pass --purge through so state-paired secrets get cleared only
+        # when the paired volume is also being deleted (avoids the
+        # "regenerate password into preserved DB → can't log in" trap).
+        [[ "$PURGE" == "true" ]] && BUILD_REMOVE_ARGS+=(--purge)
+        if ! python3 scripts/build_remove_update.py "${BUILD_REMOVE_ARGS[@]}"; then
             err "Failed to build remove spec for $SERVICE."
             exit 1
         fi

--- a/roles/apps/entephoto-export/meta/install.yml
+++ b/roles/apps/entephoto-export/meta/install.yml
@@ -37,7 +37,16 @@ playbooks:
   - playbooks/entephoto-export.yml
 
 on_remove:
-  inventory_vars_to_clear:
+  inventory_vars_to_clear: []
+  # Paired with entephoto-export-state (preserved by default), which
+  # holds the CLI's persisted auth tied to this specific Ente account
+  # plus the sync cursor. Clearing the inventory creds without --purge
+  # forces the next `add` to re-prompt the operator (these are
+  # `secret_prompt` type), but the state volume still references the
+  # old account — `ente account add` would also need to re-run by
+  # hand. Keeping the creds in inventory across a non-purge remove
+  # lets re-add resume incremental exports cleanly.
+  inventory_vars_to_clear_on_purge:
     - entephoto_export_account_email
     - entephoto_export_account_password
   # The state volume holds CLI auth + sync cursor. Keep it on remove

--- a/roles/apps/entephoto/meta/install.yml
+++ b/roles/apps/entephoto/meta/install.yml
@@ -68,17 +68,30 @@ playbooks:
 
 on_remove:
   inventory_vars_to_clear:
+    # Derived URLs / endpoint values — safely re-rendered from
+    # caddy_domain on the next add.
+    - entephoto_api_url
+    - entephoto_photos_url
+    - entephoto_s3_endpoint
+    - entephoto_s3_host
+    - entephoto_s3_local_buckets
+  # Paired with preserved-by-default state:
+  #   db_password          ↔ entephoto-postgres-data (postgres role)
+  #   garage_rpc_secret    ↔ entephoto-garage-meta (cluster identity)
+  #   garage_admin_token   ↔ Garage admin auth-list (set on first init)
+  #   encryption/hash/jwt  ↔ entephoto-postgres-data — these sign and
+  #                          decrypt rows already written to the museum
+  #                          DB; rotating without --purge silently
+  #                          breaks every existing user.
+  # All only safe to regenerate when the matching volumes are also
+  # being purged.
+  inventory_vars_to_clear_on_purge:
     - entephoto_db_password
     - entephoto_garage_rpc_secret
     - entephoto_garage_admin_token
     - entephoto_encryption_key
     - entephoto_hash_key
     - entephoto_jwt_secret
-    - entephoto_api_url
-    - entephoto_photos_url
-    - entephoto_s3_endpoint
-    - entephoto_s3_host
-    - entephoto_s3_local_buckets
   volumes_to_preserve_unless_purge:
     - entephoto-postgres-data
     - entephoto-garage-data

--- a/roles/apps/jellyfin/meta/install.yml
+++ b/roles/apps/jellyfin/meta/install.yml
@@ -23,7 +23,13 @@ playbooks:
   - playbooks/dashboard.yml
 
 on_remove:
-  inventory_vars_to_clear:
+  inventory_vars_to_clear: []
+  # Paired with systemd-jellyfin-config (preserved by default), which
+  # holds jellyfin.db — the SQLite with the admin user row. Regenerating
+  # this without --purge would lock the operator out of the UI on the
+  # next add. --purge nukes the config volume, at which point a fresh
+  # password makes sense.
+  inventory_vars_to_clear_on_purge:
     - jellyfin_admin_password
   volumes_to_preserve_unless_purge:
     - systemd-jellyfin-config

--- a/roles/apps/nextcloud/meta/install.yml
+++ b/roles/apps/nextcloud/meta/install.yml
@@ -27,7 +27,15 @@ playbooks:
   - playbooks/dashboard.yml
 
 on_remove:
-  inventory_vars_to_clear:
+  inventory_vars_to_clear: []
+  # Both passwords are paired with preserved-by-default state:
+  # nextcloud-postgres-data holds the postgres role for the DB
+  # password and the user record (where the admin password hash
+  # lives). Regenerating these on the next `add` while the volume
+  # survives causes DB-auth failure on nextcloud ↔ postgres and
+  # locks the operator out of the admin UI. --purge nukes the
+  # volume, at which point regenerating is correct.
+  inventory_vars_to_clear_on_purge:
     - nextcloud_admin_password
     - nextcloud_db_password
   volumes_to_preserve_unless_purge:

--- a/roles/apps/paperless-ngx/meta/install.yml
+++ b/roles/apps/paperless-ngx/meta/install.yml
@@ -36,13 +36,22 @@ playbooks:
 on_remove:
   inventory_vars_to_clear:
     - paperless_url
+    # paperless_secret_key only signs Django session cookies — rotating
+    # it invalidates browser sessions but doesn't touch DB state.
     - paperless_secret_key
-    - paperless_db_password
-    - paperless_admin_password
     # paperless_oidc_* deliberately not listed — if the operator has
     # wired SSO via the SSO-Bootstrap walkthrough, removing Paperless
     # leaves the (now-orphaned) OIDC client in Nextcloud and the
     # inventory keys for it. Operator removes those manually.
+  inventory_vars_to_clear_on_purge:
+    # Paired with paperless-db-data (postgres role + admin user record).
+    # Without --purge the DB volume survives the remove, so the OLD
+    # passwords are still baked into postgres and into the admin row.
+    # Regenerating these on the next `add` would lock the operator
+    # out of both DB-auth and the admin UI. --purge nukes the volume,
+    # at which point regenerating is correct.
+    - paperless_db_password
+    - paperless_admin_password
   volumes_to_preserve_unless_purge:
     - paperless-data
     - paperless-db-data

--- a/roles/platform/pihole/meta/install.yml
+++ b/roles/platform/pihole/meta/install.yml
@@ -48,12 +48,20 @@ playbooks:
 # `homeserver.sh remove` cleanup. Volumes preserved by default; --purge
 # also deletes them.
 on_remove:
-  inventory_vars_to_clear:
+  inventory_vars_to_clear: []
+  # pihole_local_network and pihole_local_router stay — they're
+  # host-config (LAN subnet + gateway), not pihole-owned secrets.
+  # An operator removing pihole probably wants them remembered so
+  # re-adding pihole later picks them up without re-prompting.
+  #
+  # pihole_api_password is paired with systemd-pihole-etc (preserved
+  # by default), which holds setupVars.conf with the WEBPASSWORD hash
+  # baked in. Regenerating it without --purge produces a fresh hash
+  # that doesn't match what pihole has on disk → operator locked out
+  # of the admin UI on the next add. --purge nukes the volume, at
+  # which point a fresh password is correct.
+  inventory_vars_to_clear_on_purge:
     - pihole_api_password
-    # pihole_local_network and pihole_local_router stay — they're
-    # host-config (LAN subnet + gateway), not pihole-owned secrets.
-    # An operator removing pihole probably wants them remembered so
-    # re-adding pihole later picks them up without re-prompting.
   volumes_to_preserve_unless_purge:
     - systemd-pihole-etc
     - systemd-pihole-dnsmasq

--- a/scripts/build_remove_update.py
+++ b/scripts/build_remove_update.py
@@ -6,7 +6,14 @@ remove mode.
 
 Mirror of build_add_update.py for the remove direction. Pulls from
 the `on_remove` block of the meta file:
-  - inventory_vars_to_clear  → scalars to delete from inventory
+  - inventory_vars_to_clear           → always cleared on remove
+  - inventory_vars_to_clear_on_purge  → cleared only when --purge is
+    passed. Use for secrets PAIRED with a preserved-by-default volume
+    (DB passwords, admin passwords, API tokens baked into state) —
+    clearing them while the volume survives makes the next `add`
+    regenerate a fresh value that won't match what's already baked
+    into the preserved DB/SQLite/config, locking the operator out.
+    With --purge, the volume goes too, so the secret must follow.
   - side_effect_reversals=auto → remove side_effects entries from
     caddy_reverse_proxy_services + my_linux_users that this role added
 
@@ -15,6 +22,7 @@ Always also removes the service name from deploy_services.
 Usage:
     build_remove_update.py --meta roles/nextcloud/meta/install.yml
                            --service nextcloud
+                           [--purge]
                            --output /tmp/update.json
 """
 
@@ -27,6 +35,10 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--meta", required=True)
     p.add_argument("--service", required=True)
+    p.add_argument("--purge", action="store_true",
+                   help="Also clear `inventory_vars_to_clear_on_purge` "
+                        "secrets (paired with state volumes that --purge "
+                        "is deleting).")
     p.add_argument("--output", required=True)
     args = p.parse_args()
 
@@ -42,8 +54,13 @@ def main():
     side_effects = meta.get("side_effects") or {}
 
     # scalars to remove (the merge helper ignores `value` in remove mode,
-    # so a placeholder is fine — we just need the keys)
-    scalars = {k: {"value": "_"} for k in on_remove.get("inventory_vars_to_clear", []) or []}
+    # so a placeholder is fine — we just need the keys).
+    # `inventory_vars_to_clear` always fires; the on_purge bucket only
+    # fires with --purge (state-paired secrets — see module docstring).
+    clear_keys = list(on_remove.get("inventory_vars_to_clear", []) or [])
+    if args.purge:
+        clear_keys += list(on_remove.get("inventory_vars_to_clear_on_purge", []) or [])
+    scalars = {k: {"value": "_"} for k in clear_keys}
 
     # lists — remove the items this role added (platform_services/apps + caddy entries)
     _PLATFORM = {"caddy", "dashboard", "pihole", "backup", "os-tailscale"}

--- a/scripts/test_inventory_merge.sh
+++ b/scripts/test_inventory_merge.sh
@@ -220,6 +220,58 @@ python3 "$MERGE" --host-vars-dir "$WORK/test7" --service nextcloud \
     || report "remove drops cloud by subdomain (label-field mismatch)" FAIL
 
 echo
+echo "Test 8: build_remove_update.py respects inventory_vars_to_clear_on_purge"
+# Bug class: secret declared as something to regenerate, but the
+# matching state volume is preserved-by-default. Clearing the secret
+# without --purge desyncs inventory from the live DB / config, and
+# the operator gets locked out on the next add. The fix: split into
+# two buckets — always-clear, and on-purge-only.
+BR="$SCRIPT_DIR/build_remove_update.py"
+cat > "$WORK/meta_split.yml" << 'EOF'
+display_name: "Test"
+description: "synthetic role for buckets test"
+inventory_vars: []
+side_effects: {}
+playbooks: []
+on_remove:
+  inventory_vars_to_clear:
+    - safe_to_rotate
+  inventory_vars_to_clear_on_purge:
+    - paired_with_volume
+EOF
+
+python3 "$BR" --meta "$WORK/meta_split.yml" --service testsvc --output "$WORK/r_nopurge.json"
+python3 "$BR" --meta "$WORK/meta_split.yml" --service testsvc --purge --output "$WORK/r_purge.json"
+
+python3 -c "
+import json, sys
+nop = set((json.load(open('$WORK/r_nopurge.json')).get('scalars') or {}).keys())
+pur = set((json.load(open('$WORK/r_purge.json')).get('scalars') or {}).keys())
+assert nop == {'safe_to_rotate'}, f'no-purge cleared {nop}'
+assert pur == {'safe_to_rotate', 'paired_with_volume'}, f'purge cleared {pur}'
+" \
+    && report "no-purge clears only always-bucket; --purge adds on-purge bucket" PASS \
+    || report "no-purge clears only always-bucket; --purge adds on-purge bucket" FAIL
+
+# Also confirm that --purge is purely additive: a role with no on-purge
+# bucket behaves identically with and without --purge.
+cat > "$WORK/meta_legacy.yml" << 'EOF'
+display_name: "Legacy"
+description: "no on-purge bucket"
+inventory_vars: []
+side_effects: {}
+playbooks: []
+on_remove:
+  inventory_vars_to_clear:
+    - some_var
+EOF
+python3 "$BR" --meta "$WORK/meta_legacy.yml" --service legacysvc --output "$WORK/l_nopurge.json"
+python3 "$BR" --meta "$WORK/meta_legacy.yml" --service legacysvc --purge --output "$WORK/l_purge.json"
+diff -q "$WORK/l_nopurge.json" "$WORK/l_purge.json" >/dev/null \
+    && report "missing on-purge bucket: --purge is a no-op (back-compat)" PASS \
+    || report "missing on-purge bucket: --purge is a no-op (back-compat)" FAIL
+
+echo
 echo "=========================================="
 echo "  $PASS passed, $FAIL failed"
 echo "=========================================="


### PR DESCRIPTION
## Symptom

On homeserver2:

```
./homeserver.sh remove paperless-ngx     # vols preserved (no --purge)
./homeserver.sh add paperless-ngx        # add succeeds; paperless running
```

Admin login then fails. Also: the whole `apps/paperless-ngx.yml` split file disappears from inventory.

## Root cause

Same class as #289 (state ↔ inventory desync across remove + add).

`on_remove.inventory_vars_to_clear` fires unconditionally. `volumes_to_preserve_unless_purge` keeps the paired DB / SQLite / config alive by default. So a non-purge remove + add cycle:

1. Clears `paperless_admin_password` from inventory (file empties → gets deleted as a side-effect)
2. `add` regenerates a fresh password
3. Container starts with new value as `PAPERLESS_ADMIN_PASSWORD`, but paperless only honours that env on first DB init — the preserved `paperless-db-data` volume still has the admin row with the OLD hash → login fails

Audit shows this pattern across most roles — every secret listed in `inventory_vars_to_clear` whose paired data volume is in `volumes_to_preserve_unless_purge` is a future-bomb.

## Fix

New meta-schema key `inventory_vars_to_clear_on_purge`. Vars in that bucket only get cleared when `--purge` is passed — at which point the paired volume is being deleted anyway, so regenerating on the next `add` is correct.

### Code

- `scripts/build_remove_update.py`: `--purge` flag added. Without it, only clears `inventory_vars_to_clear`. With it, additionally clears `inventory_vars_to_clear_on_purge`. Back-compat: metas without the new key behave exactly as before.
- `homeserver.sh` `remove` verb (~L1296): passes `--purge` through to `build_remove_update.py`.

### Meta segregations

Every role with secrets paired to preserved state:

| Role | Moved to on-purge |
|---|---|
| paperless-ngx | `paperless_db_password`, `paperless_admin_password` |
| nextcloud | `nextcloud_admin_password`, `nextcloud_db_password` |
| entephoto | `entephoto_db_password`, `entephoto_garage_rpc_secret`, `entephoto_garage_admin_token`, `entephoto_encryption_key`, `entephoto_hash_key`, `entephoto_jwt_secret` |
| jellyfin | `jellyfin_admin_password` |
| pihole | `pihole_api_password` |
| entephoto-export | `entephoto_export_account_email`, `entephoto_export_account_password` |

Always-clear bucket retained for derived/safe-to-rotate vars (computed URLs, Django session signing key).

## Verification (live on homeserver2 against this branch)

- [x] `bash scripts/test_inventory_merge.sh` → 20/20 pass (+2 new tests for the bucketing)
- [x] `./homeserver.sh remove paperless-ngx` (no --purge) → `apps/paperless-ngx.yml` **survives** with `paperless_db_password` + `paperless_admin_password` intact (only `paperless_url` + `paperless_secret_key` cleared)
- [x] `./homeserver.sh add paperless-ngx` → `build_add_update.py` reuses the existing passwords (idempotency); the vault block for `paperless_admin_password` is byte-identical to before the remove. Container starts; no manual DB reset needed.
- [ ] (Operator step) `./homeserver.sh remove paperless-ngx --purge` → both buckets fire, volumes go, file removed; next `add` regenerates — correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)