### PR TITLE
feat: classify user-facing bootstrap secrets and warn on read/restore

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -233,13 +233,13 @@ if [[ -t 1 ]]; then
 else
     RED=''; GREEN=''; YELLOW=''; CYAN=''; BOLD=''; NC=''
 fi
-# err() goes to stderr; pick its colors based on stderr's TTY-ness
-# independently so e.g. `homeserver.sh foo 2>err.log` writes plain text
-# into err.log even when stdout is still a terminal.
+# err() and other stderr-bound output pick their colors based on
+# stderr's TTY-ness independently so e.g. `homeserver.sh foo 2>err.log`
+# writes plain text into err.log even when stdout is still a terminal.
 if [[ -t 2 ]]; then
-    ERR_RED='\033[0;31m'; ERR_NC='\033[0m'
+    ERR_RED='\033[0;31m'; ERR_YELLOW='\033[1;33m'; ERR_NC='\033[0m'
 else
-    ERR_RED=''; ERR_NC=''
+    ERR_RED=''; ERR_YELLOW=''; ERR_NC=''
 fi
 
 info()  { echo -e "${CYAN}==>${NC} $*"; }
@@ -726,10 +726,16 @@ for m in glob.glob(os.path.join(repo, "roles/platform/*/meta/install.yml")) \
 PY
         )
         if [[ -n "$meta_lookup" ]]; then
-            warn "$KEY is a user-facing bootstrap secret for '$meta_lookup'."
-            warn "The value below is what the tool generated at install time."
-            warn "If you (or anyone) changed it via the app's web UI since"
-            warn "then, that newer value is NOT reflected here."
+            # Warning goes to stderr explicitly (warn() emits to stdout
+            # by project convention; the value MUST be the only thing
+            # on stdout so `PW=$(homeserver.sh secret X)` captures it
+            # cleanly without the warning bytes leaking in).
+            {
+                echo -e "${ERR_YELLOW}==> WARNING:${ERR_NC} $KEY is a user-facing bootstrap secret for '$meta_lookup'."
+                echo -e "${ERR_YELLOW}==> WARNING:${ERR_NC} The value below is what the tool generated at install time."
+                echo -e "${ERR_YELLOW}==> WARNING:${ERR_NC} If you (or anyone) changed it via the app's web UI since"
+                echo -e "${ERR_YELLOW}==> WARNING:${ERR_NC} then, that newer value is NOT reflected here."
+            } >&2
         fi
         # Plain stdout so the value pipes cleanly into other tools.
         printf '%s\n' "$value"

--- a/homeserver.sh
+++ b/homeserver.sh
@@ -702,6 +702,35 @@ PY
             err "Key '$KEY' not found in inventory for $TARGET (or empty)."
             exit 1
         fi
+        # Surface drift risk for user-facing bootstrap secrets (admin
+        # passwords the user owns via the app's web UI). Inventory may
+        # be the value the tool generated at install time, NOT what
+        # the user is currently typing. Warning goes to stderr so the
+        # value-on-stdout pipe stays clean.
+        meta_lookup=$(python3 - "$KEY" "$INSTALL_DIR" <<'PY' 2>/dev/null || true
+import sys, glob, os
+key, repo = sys.argv[1], sys.argv[2]
+try:
+    import yaml
+except ImportError:
+    sys.exit(0)
+for m in glob.glob(os.path.join(repo, "roles/platform/*/meta/install.yml")) \
+       + glob.glob(os.path.join(repo, "roles/apps/*/meta/install.yml")):
+    with open(m) as f:
+        doc = yaml.safe_load(f) or {}
+    for v in (doc.get("inventory_vars") or []):
+        if v.get("name") == key and v.get("user_facing"):
+            role = m.split("/")[-3]
+            print(role)
+            sys.exit(0)
+PY
+        )
+        if [[ -n "$meta_lookup" ]]; then
+            warn "$KEY is a user-facing bootstrap secret for '$meta_lookup'."
+            warn "The value below is what the tool generated at install time."
+            warn "If you (or anyone) changed it via the app's web UI since"
+            warn "then, that newer value is NOT reflected here."
+        fi
         # Plain stdout so the value pipes cleanly into other tools.
         printf '%s\n' "$value"
         exit 0

--- a/playbooks/tasks/restore_generic.yml
+++ b/playbooks/tasks/restore_generic.yml
@@ -202,6 +202,46 @@
     file: "{{ playbook_dir }}/../roles/{{ svc._role_name }}/tasks/{{ svc.post_restore_tasks }}"
   when: svc.post_restore_tasks is defined
 
+# --- User-facing secret drift warning ---
+# Restore brings back an older volume. If the user changed their admin
+# password (or other user-facing secret) via the app UI between the
+# snapshot time and the restore, the restored DB has the OLDER value.
+# The password they remember no longer works; inventory's bootstrap
+# value might match the restored DB, but only if the user never changed
+# it post-install. Flag this so the operator knows to verify before
+# declaring the restore successful.
+- name: "{{ svc._role_name | upper }}: load role meta for user-facing scan"
+  ansible.builtin.include_vars:
+    file: "{{ lookup('ansible.builtin.first_found', [
+                playbook_dir + '/../roles/platform/' + svc._role_name + '/meta/install.yml',
+                playbook_dir + '/../roles/apps/'     + svc._role_name + '/meta/install.yml']) }}"
+    name: "_meta_{{ svc._role_name | replace('-', '_') }}"
+  failed_when: false
+
+- name: "{{ svc._role_name | upper }}: identify user-facing secrets"
+  ansible.builtin.set_fact:
+    _user_facing_secrets: >-
+      {{ (lookup('vars', '_meta_' + (svc._role_name | replace('-', '_')), default={})
+          .get('inventory_vars') or [])
+         | selectattr('user_facing', 'defined') | selectattr('user_facing')
+         | map(attribute='name') | list }}
+
+- name: "{{ svc._role_name | upper }}: warn about user-facing secret drift"
+  ansible.builtin.debug:
+    msg: |
+      Restore brought back an older {{ svc._role_name }} volume. Heads-up —
+      the restored DB / config still carries whatever value these
+      user-facing secrets had at snapshot time:
+        {{ _user_facing_secrets | join(', ') }}
+      If the user changed any of those via the app UI between then
+      and now, the password they currently remember will NOT work.
+      Either log in with the snapshot-time value, or reset via the
+      app's password-reset mechanism (e.g. `manage.py changepassword`,
+      `occ user:resetpassword`, `pihole -a -p`).
+      Inventory was not modified; `homeserver.sh secret <var>` still
+      returns the install-time bootstrap value.
+  when: _user_facing_secrets | default([]) | length > 0
+
 # --- Unmount the host's NAS share ---
 - name: "{{ svc._role_name | upper }}: unmount NAS host share"
   ansible.posix.mount:

--- a/roles/apps/jellyfin/meta/install.yml
+++ b/roles/apps/jellyfin/meta/install.yml
@@ -8,6 +8,10 @@ inventory_vars:
     type: secret
     generator: "openssl rand -base64 24"
     vault: true
+    # Bootstrap value used on first Jellyfin start (seeded via the
+    # role's postinstall). After that, the user owns the live password
+    # via the Jellyfin web UI. Inventory may drift out of sync.
+    user_facing: true
 
 side_effects:
   caddy_reverse_proxy_services:

--- a/roles/apps/nextcloud/meta/install.yml
+++ b/roles/apps/nextcloud/meta/install.yml
@@ -8,6 +8,10 @@ inventory_vars:
     type: secret
     generator: "openssl rand -base64 24"
     vault: true
+    # Bootstrap value used on first nextcloud occ install. After that,
+    # the user owns the live password via the nextcloud web UI (or
+    # `occ user:resetpassword admin`). Inventory may drift out of sync.
+    user_facing: true
   - name: nextcloud_db_password
     type: secret
     generator: "openssl rand -base64 24"

--- a/roles/apps/paperless-ngx/meta/install.yml
+++ b/roles/apps/paperless-ngx/meta/install.yml
@@ -19,6 +19,10 @@ inventory_vars:
     type: secret
     generator: "openssl rand -base64 24"
     vault: true
+    # Bootstrap value used on first DB init. After that, the user owns
+    # the live password via the paperless web UI (or `manage.py
+    # changepassword admin`). Inventory may drift out of sync.
+    user_facing: true
 
 side_effects:
   caddy_reverse_proxy_services:

--- a/roles/platform/pihole/meta/install.yml
+++ b/roles/platform/pihole/meta/install.yml
@@ -14,6 +14,16 @@ description: "DNS-level ad-blocker for every device on the LAN"
 #        config    → prompt with `default` (literal string or host-detect spec)
 #        computed  → render `template` (Jinja) against already-resolved values
 #        literal   → use `value` verbatim
+#
+# Optional `user_facing: true` flag — set on secrets that bootstrap an
+# app's admin login the user can later change via the app's web UI.
+# Inventory holds the value the tool generated at install time, but
+# the user owns the live value via the UI. `homeserver.sh secret`
+# warns when reading these so the operator knows the returned value
+# may be stale (latest bootstrap value, not what the user is actually
+# typing right now). Machine-internal secrets (DB passwords, signing
+# keys, encryption keys) leave the flag off — inventory IS the source
+# of truth there.
 inventory_vars:
   - name: pihole_local_network
     type: config
@@ -27,6 +37,7 @@ inventory_vars:
     type: secret
     generator: "openssl rand -base64 24"
     vault: true
+    user_facing: true  # operator can rotate via `pihole -a -p` in the admin UI
 
 # Side-effects on shared inventory keys when this role is added.
 # `homeserver.sh add` merges these in; `homeserver.sh remove` reverses them.


### PR DESCRIPTION
## Why

Yesterday's paperless admin-login fallout surfaced a real ownership ambiguity in the inventory model. Two distinct secret lifecycles get conflated today:

- **Machine-internal secrets** (DB passwords, signing keys, encryption keys, JWT secrets, RPC secrets) — only the app reads them, only via env var at startup. The user never touches them. Inventory is the source of truth. Restore moves volume + inventory as a pair, no ambiguity.
- **User-facing bootstrap secrets** (admin passwords) — inventory seeds the app on first init, then the user owns the live value via the app's web UI. Inventory becomes stale the first time the user changes the password. \`./homeserver.sh secret <var>\` keeps returning the install-time bootstrap as if it were current.

Same surface on restore: an older snapshot brings back an older password hash; the value the user currently remembers may not match the restored DB at all.

This is the lightweight "classify and warn" half of the design discussion. No behavior change — the operator gets a clear heads-up so they know the returned value may not be the right one. The heavier "push-into-app" verb (option B) is deliberately not in scope.

## Schema

New optional \`user_facing: true\` flag on \`inventory_vars\`. Documented in \`roles/platform/pihole/meta/install.yml\` (project's schema reference). Marked on every admin-password secret:

| Role | Var |
|---|---|
| paperless-ngx | \`paperless_admin_password\` |
| nextcloud | \`nextcloud_admin_password\` |
| jellyfin | \`jellyfin_admin_password\` |
| pihole | \`pihole_api_password\` |

Machine-internal secrets (DB / signing / encryption / JWT / garage RPC) leave the flag off — no drift risk there.

## Code

- **\`homeserver.sh\` \`secret\` verb**: walks every role's \`meta/install.yml\` looking for the requested var. If it's \`user_facing: true\`, emits a 4-line warning to **stderr** (using new \`ERR_YELLOW\`/\`ERR_NC\` for tty-aware color). Value still goes to stdout uncolored — \`PW=\$(./homeserver.sh secret X)\` and \`PW=\$(./homeserver.sh secret X 2>/dev/null)\` both capture exactly 32 clean bytes.
- **\`playbooks/tasks/restore_generic.yml\`**: after the post-restore hook, loads the matching role's meta, picks out user-facing var names, and emits a debug-task warning with concrete next steps (\`manage.py changepassword\`, \`occ user:resetpassword\`, \`pihole -a -p\`). Skipped when the list is empty.

## Verification (live on homeserver2)

- [x] \`./homeserver.sh secret paperless_admin_password\` shows warning lines on stderr, value on stdout
- [x] \`./homeserver.sh secret paperless_db_password\` (machine-internal) shows NO warning
- [x] \`PW=\$(./homeserver.sh secret paperless_admin_password 2>/dev/null)\` → \`len=32\`, clean ASCII
- [x] Even the legacy buggy capture \`\$(... 2>&1 | tail -1 | tr -d '[:space:]')\` returns the value cleanly because warning lines emit BEFORE the value
- [ ] (Operator step) \`ansible-playbook playbooks/restore.yml --limit homeserver2\` against a real backup — confirm the per-service warning appears for paperless/nextcloud/jellyfin/pihole and is skipped for others

## Out of scope

Option B from the design discussion (a \`reset-secret <var>\` verb that pushes inventory's value into the live app via per-role command — \`manage.py changepassword\`, \`occ user:resetpassword\`, etc.). Operator agreed this adds complexity that isn't worth it now; warn-and-document is enough to stop locking ourselves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)