### PR TITLE
docs(nas): warn that DSM resets the SSH user's shell to nologin

### DIFF
--- a/docs/NAS-Setup.md
+++ b/docs/NAS-Setup.md
@@ -127,6 +127,38 @@ sudo chmod 0600 /var/services/homes/homeserver-backup/.ssh/authorized_keys
 (DSM may require enabling "User Home" service first — Control Panel →
 User & Group → Advanced → User Home.)
 
+### Login shell must be real (not `nologin`)
+
+DSM assigns `/sbin/nologin` to most non-DSM-admin user accounts by
+default, and **silently resets the shell back to `nologin` after any
+GUI-side change to the user** — including a password change, a group
+membership toggle, or a DSM update. With `nologin` set, the SSH forced
+command above never executes: sshd runs `$SHELL -c "<forced cmd>"`
+and `nologin -c …` just prints a refusal. You'll see:
+
+```
+$ sudo ssh -i /root/.ssh/nas-snapshot -p 1022 homeserver-backup@nas
+Permission denied, please try again.
+```
+
+(misleadingly identical to a sudo / SSH auth failure — but the cert
+auth succeeded; it's the shell rejecting the forced command at the
+other end).
+
+Set the shell to a real one **once at setup time and again any time
+you touch the user via the DSM GUI**:
+
+```bash
+sudo sed -i 's|^\(homeserver-backup:.*\):/sbin/nologin$|\1:/bin/sh|' /etc/passwd
+# Verify:
+grep ^homeserver-backup /etc/passwd   # last field should be /bin/sh
+```
+
+This is safe because the `command=...,no-pty,no-port-forwarding,no-X11-forwarding`
+directives in `authorized_keys` (above) still pin the connection to a
+single forced command — even with `/bin/sh` as the shell, the key
+can't be used for an interactive session.
+
 ## 8. Smoke test from the host
 
 ```bash
@@ -134,6 +166,19 @@ ssh -p <nas-ssh-port> -i /root/.ssh/nas-snapshot homeserver-backup@nas
 ```
 
 (`<nas-ssh-port>` defaults to 22; many Synology setups use 1022 — match what step 5 showed.)
+
+Expected output:
+
+```
+PTY allocation request failed on channel 0
+Snapshot [GMT+02-2026.06.12-09.44.58] was created from share [backup-homeserver]
+Connection to nas closed.
+```
+
+The `PTY allocation request failed` line is your `no-pty` directive
+doing its job — harmless. A `Snapshot [...] was created` line means
+the chain (SSH cert → forced command → sudo NOPASSWD → synosharesnapshot)
+is end-to-end healthy.
 
 Should print a `Snapshot created` line and exit 0. Snapshot Replication
 in DSM should immediately show one new snapshot in the share's history.


### PR DESCRIPTION
## Why

Today's snapshot-trigger debugging on homeserver — operator changed the NAS \`homeserver-backup\` user's password via the DSM GUI, and the next nightly backup logged:

\`\`\`
Triggering NAS snapshot of backup-homeserver
Permission denied, please try again.
ERROR: NAS snapshot trigger failed
\`\`\`

The error wording made it look like SSH or sudo auth. Both were fine:

- SSH cert auth succeeded (\`ssh -vv\` showed connection through to running the forced command)
- \`sudo -l -U homeserver-backup\` listed both NOPASSWD synosharesnapshot rules correctly
- Running \`sudo -u homeserver-backup sudo -n /usr/syno/sbin/synosharesnapshot ...\` directly on the NAS produced a snapshot

Root cause: DSM had silently flipped the user's login shell back to \`/sbin/nologin\` during the GUI password change. sshd ran \`\$SHELL -c \"<forced cmd>\"\`, \`nologin -c …\` just printed a refusal and exited 1. The misleading \"Permission denied\" was nologin's output, not sshd/sudo's.

## What this PR adds

A subsection in \`docs/NAS-Setup.md\` §7 that:
- documents DSM's auto-reset behaviour after any GUI-side user edit
- shows the misleading symptom verbatim so an operator searching for the error string lands here
- gives the busybox-safe \`sed\` one-liner to put \`/bin/sh\` back
- explains why \`/bin/sh\` is safe given the existing \`command=…,no-pty,no-port-forwarding,no-X11-forwarding\` lockdown

Also §8's smoke test now includes the expected good output (the \"PTY allocation request failed\" line is normal — \`no-pty\` doing its job).

## Test plan

- [x] sed one-liner verified on the live NAS — produces a working shell entry, snapshot trigger works end-to-end
- [x] Smoke test from homeserver \`sudo ssh -i /root/.ssh/nas-snapshot -p 1022 homeserver-backup@nas\` returns \`exit=0\` with a fresh snapshot timestamp
- [x] Documentation renders cleanly (no broken markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)