### PR TITLE
feat(verify): add tasks/verify.yml for nextcloud and backup

### DIFF
--- a/roles/apps/nextcloud/defaults/main.yml
+++ b/roles/apps/nextcloud/defaults/main.yml
@@ -26,6 +26,15 @@ nextcloud_db_user: "ncuser"
 nextcloud_db_name: "nextcloud"
 nextcloud_db_password: ""
 
+# Run tasks/verify.yml at the end of deploy to assert that the
+# nextcloud-server container is healthy, /status.php returns
+# installed=true, the admin password in inventory still authenticates
+# against the DB (catches the inventory↔DB drift class of bug), and
+# `occ status` agrees. Hard-fails the play on regression. Override
+# to false to skip — useful for hosts running on a flaky upstream
+# where the WebDAV probe might timeout transiently.
+nextcloud_run_verification: true
+
 # Trusted domain Nextcloud will accept Host: headers for. Defaults to
 # cloud.<caddy_domain>; override only if you want a different
 # subdomain.

--- a/roles/apps/nextcloud/tasks/main.yml
+++ b/roles/apps/nextcloud/tasks/main.yml
@@ -69,6 +69,12 @@
 - name: Run postinstall (OIDC Provider app, Caddy trusted-proxy, etc.)
   ansible.builtin.include_tasks: postinstall.yml
 
+- name: Run post-install verification
+  ansible.builtin.import_tasks: verify.yml
+  when: nextcloud_run_verification | bool
+  tags:
+    - verify
+
 - name: Register backup manifest
   ansible.builtin.set_fact:
     _backup_manifests: >-

--- a/roles/apps/nextcloud/tasks/verify.yml
+++ b/roles/apps/nextcloud/tasks/verify.yml
@@ -1,0 +1,79 @@
+---
+# Post-install smoke tests. Hard-fails the playbook when Nextcloud is up
+# but not actually serving (container unhealthy, /status.php broken,
+# admin auth desynced from inventory, etc.). Re-runnable with
+# `--tags verify`. Skip with `--skip-tags verify` or set
+# `nextcloud_run_verification: false`.
+
+- name: Verify nextcloud-server container is healthy
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      su - nextcloud -c "podman inspect nextcloud-server
+      --format '{{ '{{' }}.State.Health.Status{{ '}}' }}'"
+  register: _nc_verify_health
+  changed_when: false
+  failed_when: _nc_verify_health.stdout | trim != "healthy"
+
+# /status.php is Nextcloud's lightweight readiness endpoint — JSON with
+# {installed, maintenance, version, ...}. Probing it via Caddy
+# exercises the whole reverse-proxy + TLS + nextcloud chain in one shot.
+- name: Probe /status.php through Caddy
+  ansible.builtin.uri:
+    url: "https://{{ nextcloud_subdomain }}.{{ caddy_domain }}/status.php"
+    return_content: true
+    timeout: 10
+    # Caddy serves a real LE cert in production but this play may run
+    # on a fresh deploy where the cert is still being issued. Accept the
+    # cert chain Caddy hands us either way — we're testing the app, not
+    # the CA pinning.
+    validate_certs: false
+  register: _nc_verify_status_php
+  failed_when: >-
+    _nc_verify_status_php.status != 200 or
+    not (_nc_verify_status_php.json.installed | default(false)) or
+    (_nc_verify_status_php.json.maintenance | default(false))
+
+# Live admin-auth roundtrip via WebDAV PROPFIND. Catches the exact
+# inventory↔DB drift that bit us on homeserver2 when the user changed
+# their password in the UI — Nextcloud's stored hash and inventory
+# fell out of sync, login failed silently, and there was no test
+# surfacing it. HTTP 207 (Multi-Status) means auth + WebDAV both
+# worked. 401 means inventory's `nextcloud_admin_password` doesn't
+# match the live DB.
+- name: Verify admin WebDAV auth roundtrip
+  ansible.builtin.uri:
+    url: "https://{{ nextcloud_subdomain }}.{{ caddy_domain }}/remote.php/dav/files/{{ nextcloud_admin_user }}/"
+    method: PROPFIND
+    headers:
+      Depth: "0"
+    user: "{{ nextcloud_admin_user }}"
+    password: "{{ nextcloud_admin_password }}"
+    force_basic_auth: true
+    status_code: [207]
+    validate_certs: false
+    timeout: 10
+  register: _nc_verify_webdav
+  failed_when: _nc_verify_webdav.status != 207
+
+# Final sanity from inside the app: `occ status` confirms Nextcloud
+# itself thinks it's installed and not in maintenance. Catches edge
+# cases where /status.php lies (e.g. cached behind Caddy) or where
+# the app DB is half-migrated.
+- name: Verify `occ status` reports installed
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      su - nextcloud -c "podman exec --user www-data nextcloud-server
+      php occ status --output=json"
+  register: _nc_verify_occ
+  changed_when: false
+
+- name: Assert occ reports installed + not in maintenance
+  ansible.builtin.assert:
+    that:
+      - (_nc_verify_occ.stdout | from_json).installed | bool
+      - not ((_nc_verify_occ.stdout | from_json).maintenance | bool)
+    fail_msg: >-
+      Nextcloud `occ status` returned unexpected state:
+      {{ _nc_verify_occ.stdout | trim }}

--- a/roles/apps/nextcloud/tasks/verify.yml
+++ b/roles/apps/nextcloud/tasks/verify.yml
@@ -5,15 +5,20 @@
 # `--tags verify`. Skip with `--skip-tags verify` or set
 # `nextcloud_run_verification: false`.
 
-- name: Verify nextcloud-server container is healthy
+# Container state — `.State.Status == "running"` rather than
+# `.State.Health.Status == "healthy"` because the upstream Nextcloud
+# image doesn't declare a HEALTHCHECK and our quadlet doesn't add
+# one. Running + responding-on-port is what we actually care about;
+# the /status.php probe below validates the latter.
+- name: Verify nextcloud-server container is running
   become: true
   ansible.builtin.command:
     cmd: >-
       su - nextcloud -c "podman inspect nextcloud-server
-      --format '{{ '{{' }}.State.Health.Status{{ '}}' }}'"
-  register: _nc_verify_health
+      --format '{{ '{{' }}.State.Status{{ '}}' }}'"
+  register: _nc_verify_running
   changed_when: false
-  failed_when: _nc_verify_health.stdout | trim != "healthy"
+  failed_when: _nc_verify_running.stdout | trim != "running"
 
 # /status.php is Nextcloud's lightweight readiness endpoint — JSON with
 # {installed, maintenance, version, ...}. Probing it via Caddy

--- a/roles/platform/backup/defaults/main.yml
+++ b/roles/platform/backup/defaults/main.yml
@@ -52,3 +52,19 @@ backup_nas_snapshot_key_path: /root/.ssh/nas-snapshot
 # 22 reserved for other use). Override per-host if your NAS uses a
 # different port.
 backup_nas_snapshot_port: 22
+
+# --- Verification (run at end of deploy) -------------------------------
+# When true, runs tasks/verify.yml at the tail of the role: confirms
+# the timer is enabled+active, the NFS share mounts ro round-trip, and
+# the last completed run logged "0 errors". Hard-fails the play on any
+# regression. Skip with --skip-tags verify or set to false on hosts
+# where flaky upstream (NAS, NFS) would make the play unreliable.
+backup_run_verification: true
+
+# When true, the verify task additionally invokes the SSH-based
+# snapshot trigger end-to-end. This ACTUALLY CREATES a snapshot on
+# the NAS each time — the authorized_keys forced command is the
+# snapshot-create call and there's no dry-run mode. Off by default
+# so routine redeploys don't pollute the snapshot list; the E2E
+# test runner flips it on for a real round-trip check.
+backup_verify_snapshot_trigger: false

--- a/roles/platform/backup/tasks/main.yml
+++ b/roles/platform/backup/tasks/main.yml
@@ -46,3 +46,9 @@
     name: home-server-backup.timer
     enabled: true
     state: started
+
+- name: Run post-install verification
+  ansible.builtin.import_tasks: verify.yml
+  when: backup_run_verification | bool
+  tags:
+    - verify

--- a/roles/platform/backup/tasks/verify.yml
+++ b/roles/platform/backup/tasks/verify.yml
@@ -1,0 +1,128 @@
+---
+# Post-deploy smoke tests for the backup chain. Hard-fails the play
+# when any link in the chain (timer → script → NAS NFS mount → SSH
+# snapshot trigger) is broken. Re-runnable with `--tags verify`. Skip
+# with `--skip-tags verify` or set `backup_run_verification: false`.
+
+- name: Verify home-server-backup.timer is enabled + active # noqa: command-instead-of-module
+  become: true
+  ansible.builtin.command:
+    cmd: systemctl is-enabled home-server-backup.timer
+  register: _bk_verify_timer_enabled
+  changed_when: false
+  failed_when: _bk_verify_timer_enabled.stdout | trim != "enabled"
+
+- name: Verify home-server-backup.timer is active # noqa: command-instead-of-module
+  become: true
+  ansible.builtin.command:
+    cmd: systemctl is-active home-server-backup.timer
+  register: _bk_verify_timer_active
+  changed_when: false
+  failed_when: _bk_verify_timer_active.stdout | trim != "active"
+
+# The NFS mount is the most common silent breakage point — a stale
+# DHCP-driven NAS IP, a Synology share rename, an NFS perms tweak.
+# Try a read-only mount + unmount round-trip via a dedicated test path
+# so we don't disturb /mnt/backup-tar that the live backup uses.
+- name: Verify NAS NFS share mounts read-only
+  become: true
+  block:
+    - name: Create temp mount dir
+      ansible.builtin.file:
+        path: /mnt/_backup-verify
+        state: directory
+        mode: "0755"
+
+    - name: Try ro mount of host's backup share # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: >-
+          mount -t nfs -o ro,noatime,vers=4
+          {{ backup_nas_hostname }}:{{ backup_nas_volume }}/backup-{{ inventory_hostname }}
+          /mnt/_backup-verify
+      changed_when: false
+      register: _bk_verify_mount
+
+    - name: List share contents (smoke — confirms the mount is actually live)
+      ansible.builtin.command: ls /mnt/_backup-verify
+      register: _bk_verify_ls
+      changed_when: false
+      failed_when: _bk_verify_ls.rc != 0
+  always:
+    - name: Unmount host's backup share # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: umount /mnt/_backup-verify
+      changed_when: false
+      failed_when: false
+
+    - name: Remove temp mount dir
+      ansible.builtin.file:
+        path: /mnt/_backup-verify
+        state: absent
+
+# Optional: verify the SSH-based snapshot trigger end-to-end. This
+# ACTUALLY CREATES A SNAPSHOT on the NAS every time it runs (the
+# authorized_keys forced command is the snapshot create call — we
+# can't dry-run it). Off by default so every routine deploy doesn't
+# pollute the snapshot list. The E2E test runner flips this on; for
+# day-to-day deploys the post-backup snapshot logged in the nightly
+# log gives the same signal at no extra cost.
+- name: Verify SSH-based snapshot trigger reaches the NAS (creates a real snapshot)
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      ssh -o BatchMode=yes -o ConnectTimeout=10
+      -i {{ backup_nas_snapshot_key_path }}
+      -p {{ backup_nas_snapshot_port }}
+      {{ backup_nas_snapshot_user }}@{{ backup_nas_hostname }}
+  register: _bk_verify_snapshot_trigger
+  changed_when: false
+  # Exit 0 + "was created from share" in the output = healthy.
+  # Common failure modes: shell got reset to /sbin/nologin on the
+  # NAS (DSM auto-resets after user-edit ops — see docs/NAS-Setup.md),
+  # sudoers drop-in was wiped on DSM update, SSH key not in
+  # authorized_keys yet.
+  failed_when: >-
+    _bk_verify_snapshot_trigger.rc != 0 or
+    "was created from share" not in (_bk_verify_snapshot_trigger.stdout
+                                     + _bk_verify_snapshot_trigger.stderr)
+  when:
+    - backup_verify_snapshot_trigger | default(false) | bool
+    - backup_nas_snapshot_user | default('') | length > 0
+    - backup_nas_snapshot_key_path | default('') | length > 0
+
+# Last-run health: parse the script's own log. Only meaningful AFTER
+# the first scheduled run has happened — on a brand-new install the
+# log won't exist yet, which is fine (skip with a notice, not a fail).
+- name: Check whether a backup log exists yet
+  become: true
+  ansible.builtin.stat:
+    path: /var/log/home-server-backup.log
+  register: _bk_verify_log_stat
+
+- name: Read tail of the backup log (last run summary)
+  become: true
+  ansible.builtin.command:
+    cmd: tail -n 50 /var/log/home-server-backup.log
+  register: _bk_verify_log_tail
+  changed_when: false
+  when: _bk_verify_log_stat.stat.exists
+
+- name: Assert most recent backup completed with 0 errors
+  ansible.builtin.assert:
+    that:
+      - _bk_verify_log_tail.stdout is search('=== Backup finished \\(0 errors\\) ===')
+    fail_msg: >-
+      Latest backup did not finish cleanly. Tail of
+      /var/log/home-server-backup.log:
+      {{ _bk_verify_log_tail.stdout | default('(empty)') }}
+  when: _bk_verify_log_stat.stat.exists
+
+- name: Note that no backup has run yet
+  ansible.builtin.debug:
+    msg: >-
+      /var/log/home-server-backup.log not present yet — backup hasn't
+      run for the first time. Either wait for the next 02:00 timer
+      fire, or trigger manually:
+        sudo systemctl start home-server-backup.service
+      Then re-run with `--tags verify`.
+  when: not _bk_verify_log_stat.stat.exists


### PR DESCRIPTION
First step of the E2E regression test plan (full plan in `/home/ds/.claude/plans/`). Brings two roles into the project's documented "verify is part of deploy" convention that today only pihole follows.

## Why now

Two recent debug sessions on homeserver2 — admin login broken after \`remove+add nextcloud\`, snapshot trigger broken after the DSM password change — would both have been caught at deploy time by these tasks. Manual testing after every PR is consuming too much time; building the verify-on-deploy layer is the prerequisite for an E2E driver that just runs \`--tags verify\`.

## What's in this PR

### \`roles/apps/nextcloud/tasks/verify.yml\` (new)

Four hard-fail assertions:

| Probe | What it catches |
|---|---|
| \`podman inspect nextcloud-server .State.Status == running\` | Container stopped / crashed |
| \`GET /status.php\` returns 200 + \`installed:true\` + \`maintenance:false\` | Caddy proxy broken, TLS issue, Nextcloud in upgrade-locked state |
| \`PROPFIND /remote.php/dav/files/{user}/\` with admin creds → 207 | **Inventory↔DB password drift** (the exact admin-login issue we hit on homeserver2) |
| \`occ status\` reports installed + not in maintenance | App-internal disagreement with the surface probe |

Gated by \`nextcloud_run_verification: true\` (default), tagged \`verify\`.

### \`roles/platform/backup/tasks/verify.yml\` (new)

Five assertions:

| Probe | What it catches |
|---|---|
| \`systemctl is-enabled\` + \`is-active\` home-server-backup.timer | Timer disabled / failed to start |
| Read-only NFS mount of the host's backup share, round-trip | NAS unreachable, share renamed, NFS perms regression, DHCP'd NAS IP drift |
| Last log entry shows \`=== Backup finished (0 errors) ===\` | Silent partial failures since last deploy |
| (Optional, off-by-default) SSH-based snapshot trigger end-to-end | Sudoers / shell / authorized_keys regression on the NAS — the exact issue from PR #293 |

The snapshot-trigger check is gated by \`backup_verify_snapshot_trigger: false\` by default because **it actually creates a snapshot every time it runs** (no dry-run mode on \`synosharesnapshot\`). The E2E driver flips it on; routine redeploys skip it to avoid polluting the snapshot list.

Gated by \`backup_run_verification: true\` (default), tagged \`verify\`.

## Test plan (executed on homeserver2 against this branch)

- [x] \`ansible-lint roles/.../verify.yml\` → \`production\` profile clean
- [x] \`ansible-playbook playbooks/nextcloud.yml --limit homeserver2 --tags verify\` → all 4 probes pass green
- [x] \`ansible-playbook playbooks/backup.yml --limit homeserver2 --tags verify\` → all 5 active probes pass; snapshot-trigger correctly skipped
- [x] Caught a real bug pre-merge: first draft of nextcloud verify asserted \`.State.Health.Status == healthy\`, but the nextcloud:apache image has no \`HEALTHCHECK\` → fixed to \`.State.Status == running\` after the live run showed nil-pointer

## Out of scope (follow-ups)

- Same shape for paperless-ngx, jellyfin, entephoto, syncthing, music-assistant (next PRs, one per role to keep diffs reviewable).
- The E2E orchestrator (\`scripts/test_e2e.sh\`) that drives uninstall→install→verify→backup→verify across a dedicated test overlay. Needs these verify tasks as building blocks; sequenced as the next PR after this lands.
- Restore round-trip verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)