### PR TITLE
feat(e2e): test orchestrator + WebDAV/backup-content helpers + docs

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,172 @@
+# Automated regression testing on `homeserver2`
+
+The project ships an automated E2E regression test that exercises the
+full deploy → app → backup chain on a dedicated test host. It catches
+the kinds of bugs that previously needed an hour of manual testing
+after every PR — silent admin-password drift, broken backup snapshot
+triggers, partial deploys that fail at first user contact.
+
+This doc covers:
+
+1. One-time operator setup on `homeserver2`
+2. Running the test
+3. Reading the output
+4. Extending coverage to more apps
+
+## What the test does
+
+`scripts/test_e2e.sh` orchestrates 12 phases against `homeserver2`:
+
+| Phase | What runs | What it proves |
+|---|---|---|
+| 0 | Pre-flight checks | The host is `homeserver2`, the test overlay exists, the prod overlay is clean, no backup is mid-flight |
+| 1 | Stage helpers + fixtures to `/tmp` | (so they survive the uninstall in phase 3) |
+| 2 | Park prod overlay aside, swap test overlay into its place | The test runs against a known-clean curated inventory; the prod overlay is untouched |
+| 3 | `homeserver.sh uninstall` | The host returns to a known-empty state — exercises `clean-host.sh` for regressions |
+| 4 | `git clone` a fresh repo | Bootstrap path |
+| 5 | `homeserver.sh install -y -h homeserver2` (platform only) | Install flow's non-interactive mode against the test overlay's curated services list |
+| 6 | `curl https://<caddy_domain>/` | Caddy serving + LE cert issued |
+| 7 | `homeserver.sh add nextcloud -y` | `add` workflow + role's `tasks/verify.yml` (container running, /status.php, WebDAV PROPFIND, occ status) |
+| 8 | Upload 5 fixture files via WebDAV | Real app traffic — the auth path the user takes |
+| 9 | `homeserver.sh add backup -y` | `add` workflow + backup role's `tasks/verify.yml` (timer enabled+active, NFS mount round-trip, last log clean) |
+| 10 | `systemctl start home-server-backup.service`, wait | A real backup run end-to-end |
+| 11 | Assert log shows `0 errors` | The backup script completed every per-app step |
+| 12 | Mount NAS share read-only, assert all 5 fixtures present in the nextcloud-data tarball | **End-to-end data flow**: user-uploaded files survived the backup pipeline |
+
+On exit (success or failure), an `EXIT` trap always:
+- Swaps the prod overlay back into place.
+- Removes the staging directory under `/tmp`.
+
+Total wall time: 30-40 min.
+
+## One-time operator setup
+
+You only need to do this once per machine. After this, the test is
+`./scripts/test_e2e.sh -y`.
+
+### 1. Create `~/home-server-test-overlay/` on `homeserver2`
+
+This is a separate operator-owned tree with the same layout as your
+production overlay (`~/home-server-private/`). The test runner
+**parks the prod overlay aside** and renames this one into its place
+for the duration of the run.
+
+The cleanest seed is to copy your prod overlay and trim it:
+
+```bash
+# On homeserver2
+cp -a ~/home-server-private ~/home-server-test-overlay
+
+# Strip the apps so the test starts from "platform only":
+cd ~/home-server-test-overlay/inventory/host_vars/homeserver2
+
+# Edit 00-services.yml — leave caddy + dashboard, drop nextcloud/paperless/etc.
+# Final state should look like:
+#   platform_services: [caddy, dashboard]
+#   apps: []
+
+# Remove the per-app files (the runner re-generates them via `add`):
+rm -rf apps/
+
+# Set up a backup file with NAS coords but no other app-specific bits.
+# (50-backup.yml will be re-created by `add backup` during the run, but
+# pre-seeding the NAS IP avoids the prompt under -y.)
+```
+
+The test overlay reuses:
+- The same `caddy_domain` (e.g. `simsons-t.dedyn.io`) — `homeserver2`
+  IS the system under test, no other service needs the domain during
+  a test run.
+- The same SMTP credentials (sending mail is a real dependency).
+- The same NAS coords + NFS share (`backup-homeserver2`).
+- The same `vault.pw`.
+
+### 2. Confirm prerequisites
+
+```bash
+# Prod overlay clean (no uncommitted changes)
+cd ~/home-server-private && git status -sb
+
+# Test overlay exists at the expected path
+ls -la ~/home-server-test-overlay/inventory/host_vars/homeserver2/
+
+# Optional but recommended: temporarily stop the prod backup timer so
+# the next nightly backup doesn't race the test.
+sudo systemctl stop home-server-backup.timer
+```
+
+The runner re-enables the timer on exit if you used the trap (which is
+default), but stopping it explicitly avoids any surprise interaction.
+
+## Running
+
+```bash
+# Interactive (gates with a confirmation prompt)
+ssh homeserver2 'cd ~/home-server && ./scripts/test_e2e.sh'
+
+# Non-interactive (for cron)
+ssh homeserver2 'cd ~/home-server && ./scripts/test_e2e.sh -y'
+```
+
+Or from `homeserver2` directly:
+
+```bash
+cd ~/home-server
+./scripts/test_e2e.sh
+```
+
+Exit code 0 = green. Any other exit = a phase failed; the last log
+lines name which one.
+
+## Reading the output
+
+Phases print a heading and tick marks for each sub-step:
+
+```
+=== Phase 6: assert caddy + dashboard reachable ===
+[09:14:22] caddy_domain: simsons-t.dedyn.io
+  ✓ Caddy serves apex: HTTP 200
+
+=== Phase 7: ./homeserver.sh add nextcloud -y ===
+... (ansible play output) ...
+  ✓ nextcloud added (role verify passed inline)
+```
+
+On failure, the trap names the failed phase before cleanup runs:
+
+```
+  ✗ Failed in phase: 11/log-check (exit 1)
+
+=== Cleanup (always runs) ===
+[09:42:05] [[ -d '/home/ds/home-server-private' ]] && mv ... || true
+[09:42:05] [[ -d '/home/ds/home-server-private.parked-by-e2e' ]] && mv ... || true
+[09:42:05] rm -rf '/tmp/home-server-e2e-staging-12345'
+```
+
+If the runner crashes mid-flight (e.g. SIGKILL'd), you may find
+`~/home-server-private.parked-by-e2e/` left over. The pre-flight check
+detects this on the next run and tells you how to restore.
+
+## Extending coverage
+
+The current MVP is platform + nextcloud + backup. Adding another app
+is mechanical — two pieces of code:
+
+1. Add `tasks/verify.yml` to the role (see `roles/apps/nextcloud/tasks/verify.yml`
+   for the shape and `roles/platform/pihole/tasks/verify.yml` as the
+   schema reference).
+2. Add three phases to `scripts/test_e2e.sh` between phases 11 and 12:
+   - `homeserver.sh add <svc> -y`
+   - Upload a small fixture (PDF for paperless, video for jellyfin,
+     etc.)
+   - Extend the phase-12 backup-content check to include the
+     new tarball + fixture names.
+
+The `tasks/verify.yml` change is the higher-value deliverable — it
+runs at every deploy, not just E2E test runs.
+
+Out of scope today (next PRs):
+- paperless-ngx, jellyfin, entephoto, syncthing, music-assistant verify + E2E phases.
+- Restore round-trip verification (boot a restored snapshot, confirm fixtures come back).
+- GitHub Actions matrix run on PRs with a `needs-e2e` label.
+- Nightly cron + mail-on-failure.

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+# ============================================================================
+# scripts/test_e2e.sh — E2E regression test for the home-server project.
+#
+# Runs on homeserver2 (the test host). Drives a full lifecycle:
+#
+#   uninstall → install platform (caddy + dashboard) → add nextcloud
+#   → upload fixtures via WebDAV → add backup → trigger backup → assert
+#   the fixtures are present inside the NAS tarball
+#
+# Designed to be cheap to repeat. The verify steps inside each role
+# (tasks/verify.yml — see PR #294) do the per-service health checks;
+# this driver is the orchestrator that wires uninstall + install +
+# data-load + backup verification.
+#
+# ----------------------------------------------------------------------------
+# ONE-TIME OPERATOR SETUP (see docs/Testing.md for full how-to)
+# ----------------------------------------------------------------------------
+#
+#   1. Create ~/home-server-test-overlay/ on homeserver2 with the same
+#      shape as ~/home-server-private/ but with a curated inventory
+#      (platform_services: [caddy, dashboard], apps: []).
+#   2. Make sure ~/home-server-private/ has no uncommitted changes (the
+#      runner refuses to start otherwise — protects operator state).
+#   3. Disable the prod backup timer for the duration of the run
+#      (the runner does this automatically and re-enables on exit).
+#
+# ----------------------------------------------------------------------------
+# RUNNING
+# ----------------------------------------------------------------------------
+#
+#   On homeserver2:
+#     ./scripts/test_e2e.sh             # interactive — gates with a prompt
+#     ./scripts/test_e2e.sh -y          # non-interactive (for cron)
+#
+#   From the laptop:
+#     ssh homeserver2 'cd ~/home-server && ./scripts/test_e2e.sh -y'
+#
+# Total wall time: 30-40 min. Exit code 0 = green; non-zero = the phase
+# that failed is named in the last log line + via the EXIT trap summary.
+# ============================================================================
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Config — overrides via env vars
+# -----------------------------------------------------------------------------
+TEST_HOSTNAME=${TEST_HOSTNAME:-homeserver2}
+PROD_OVERLAY=${PROD_OVERLAY:-$HOME/home-server-private}
+TEST_OVERLAY=${TEST_OVERLAY:-$HOME/home-server-test-overlay}
+PROD_OVERLAY_PARK=${PROD_OVERLAY_PARK:-$HOME/home-server-private.parked-by-e2e}
+REPO_URL=${REPO_URL:-https://github.com/luckynrslevin/home-server.git}
+REPO_DIR=${REPO_DIR:-$HOME/home-server}
+STAGING_DIR=${STAGING_DIR:-/tmp/home-server-e2e-staging-$$}
+BACKUP_WAIT_TIMEOUT=${BACKUP_WAIT_TIMEOUT:-1800}   # 30 min ceiling for a single backup run
+
+# CLI
+YES_FLAG=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -y|--yes) YES_FLAG=true ;;
+        -h|--help)
+            sed -n '/^# ====/,/^# ====/p' "$0" | sed 's/^# //;s/^#$//'
+            exit 0
+            ;;
+        *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# -----------------------------------------------------------------------------
+# Colors (TTY-aware, mirrors homeserver.sh PR #291)
+# -----------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+    R='\033[0;31m'; G='\033[0;32m'; Y='\033[1;33m'; C='\033[0;36m'; B='\033[1m'; N='\033[0m'
+else
+    R=''; G=''; Y=''; C=''; B=''; N=''
+fi
+log()    { printf '%s[%s] %s%s\n' "${C}" "$(date +%H:%M:%S)" "$*" "${N}"; }
+phase()  { printf '\n%s=== %s ===%s\n' "${B}" "$*" "${N}"; }
+ok()     { printf '%s  ✓ %s%s\n' "${G}" "$*" "${N}"; }
+fail()   { printf '%s  ✗ %s%s\n' "${R}" "$*" "${N}"; }
+warn()   { printf '%s  ! %s%s\n' "${Y}" "$*" "${N}"; }
+
+# -----------------------------------------------------------------------------
+# Phase tracking + cleanup trap
+# -----------------------------------------------------------------------------
+CURRENT_PHASE=""
+CLEANUP_ACTIONS=()
+register_cleanup() { CLEANUP_ACTIONS+=("$1"); }
+
+on_exit() {
+    local rc=$?
+    echo
+    if [[ $rc -ne 0 ]]; then
+        fail "Failed in phase: ${CURRENT_PHASE:-(setup)} (exit $rc)"
+    fi
+    if [[ ${#CLEANUP_ACTIONS[@]} -gt 0 ]]; then
+        phase "Cleanup (always runs)"
+        # Run cleanup actions in reverse order (LIFO — match setup order).
+        for ((i=${#CLEANUP_ACTIONS[@]}-1; i>=0; i--)); do
+            log "${CLEANUP_ACTIONS[$i]}"
+            eval "${CLEANUP_ACTIONS[$i]}" || warn "cleanup action returned non-zero: ${CLEANUP_ACTIONS[$i]}"
+        done
+    fi
+    exit $rc
+}
+trap on_exit EXIT
+
+# =============================================================================
+# PHASE 0: pre-flight
+# =============================================================================
+CURRENT_PHASE="0/pre-flight"
+phase "Phase 0: pre-flight checks"
+
+# Hostname guard — refuses to run anywhere except the configured test host.
+# Protects against accidental invocation on a production homeserver.
+if [[ "$(hostname -s)" != "$TEST_HOSTNAME" ]]; then
+    fail "Refusing to run: \$(hostname -s)=$(hostname -s), expected $TEST_HOSTNAME"
+    fail "Override with: TEST_HOSTNAME=$(hostname -s) ./scripts/test_e2e.sh"
+    exit 1
+fi
+ok "Hostname is $TEST_HOSTNAME"
+
+[[ -d "$TEST_OVERLAY" ]] || { fail "Test overlay missing: $TEST_OVERLAY (see docs/Testing.md)"; exit 1; }
+ok "Test overlay present: $TEST_OVERLAY"
+
+if [[ -d "$PROD_OVERLAY" ]]; then
+    if ! (cd "$PROD_OVERLAY" && git diff --quiet && git diff --cached --quiet); then
+        fail "Prod overlay has uncommitted changes — won't risk losing them."
+        fail "Commit + push, or stash them, then re-run."
+        exit 1
+    fi
+    ok "Prod overlay working tree clean"
+fi
+
+if [[ -d "$PROD_OVERLAY_PARK" ]]; then
+    fail "Found leftover $PROD_OVERLAY_PARK from a previous failed run."
+    fail "Inspect + restore manually, then remove the park dir:"
+    fail "  mv $PROD_OVERLAY_PARK $PROD_OVERLAY"
+    exit 1
+fi
+
+# Refuse if a backup is mid-flight — the swap would tear its NFS mount.
+if systemctl is-active --quiet home-server-backup.service 2>/dev/null; then
+    fail "home-server-backup.service is currently running. Wait or kill it before retrying."
+    exit 1
+fi
+ok "No backup currently running"
+
+if [[ "$YES_FLAG" != "true" ]]; then
+    echo
+    warn "About to FULLY WIPE $TEST_HOSTNAME and rebuild from scratch."
+    warn "Estimated wall time: 30-40 min."
+    read -r -p "Type YES to continue, anything else aborts: " confirm
+    [[ "$confirm" == "YES" ]] || { warn "Aborted by operator."; exit 1; }
+fi
+
+# =============================================================================
+# PHASE 1: stage helpers + fixtures outside ~/home-server (uninstall wipes that)
+# =============================================================================
+CURRENT_PHASE="1/staging"
+phase "Phase 1: stage helpers + fixtures to $STAGING_DIR"
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+cp -a "$REPO_DIR/scripts/test_e2e/." "$STAGING_DIR/test_e2e/"
+cp -a "$REPO_DIR/tests/fixtures/." "$STAGING_DIR/fixtures/"
+helpers_n=$(find "$STAGING_DIR/test_e2e" -maxdepth 1 -type f | wc -l)
+fixtures_n=$(find "$STAGING_DIR/fixtures" -maxdepth 1 -type f | wc -l)
+ok "Staged $helpers_n helper(s), $fixtures_n fixture(s)"
+
+register_cleanup "rm -rf '$STAGING_DIR'"
+
+# =============================================================================
+# PHASE 2: swap prod overlay aside, expose test overlay at the canonical path
+# =============================================================================
+CURRENT_PHASE="2/overlay-swap"
+phase "Phase 2: park prod overlay; expose test overlay as $PROD_OVERLAY"
+
+# The test overlay must live where homeserver.sh expects an overlay (so
+# ensure_overlay_symlink_intact + install's overlay logic both Just Work
+# against the test inventory). We rename the prod overlay aside for the
+# duration of the test and rename the test overlay into place.
+if [[ -d "$PROD_OVERLAY" ]]; then
+    mv "$PROD_OVERLAY" "$PROD_OVERLAY_PARK"
+    ok "Parked prod overlay → $PROD_OVERLAY_PARK"
+fi
+mv "$TEST_OVERLAY" "$PROD_OVERLAY"
+ok "Test overlay is now at $PROD_OVERLAY"
+
+# Reverse swap on exit, regardless of test outcome. Park dir was already
+# moved aside, so this is symmetric.
+register_cleanup "[[ -d '$PROD_OVERLAY' ]] && mv '$PROD_OVERLAY' '$TEST_OVERLAY' || true"
+register_cleanup "[[ -d '$PROD_OVERLAY_PARK' ]] && mv '$PROD_OVERLAY_PARK' '$PROD_OVERLAY' || true"
+
+# =============================================================================
+# PHASE 3: uninstall (wipes ~/home-server + ~/.vaultpw + all service users etc)
+# =============================================================================
+CURRENT_PHASE="3/uninstall"
+phase "Phase 3: ./homeserver.sh uninstall"
+
+if [[ -d "$REPO_DIR" ]]; then
+    bash "$REPO_DIR/scripts/clean-host.sh" 2>&1 | tail -20 || warn "clean-host returned non-zero (continuing)"
+fi
+ok "Uninstall complete"
+
+# =============================================================================
+# PHASE 4: fresh re-clone (uninstall removed $REPO_DIR)
+# =============================================================================
+CURRENT_PHASE="4/reclone"
+phase "Phase 4: clone $REPO_URL → $REPO_DIR"
+
+git clone --quiet "$REPO_URL" "$REPO_DIR"
+ok "Cloned $(cd "$REPO_DIR" && git log -1 --format='%h %s' main)"
+
+# =============================================================================
+# PHASE 5: install platform (caddy + dashboard only, per test overlay)
+# =============================================================================
+CURRENT_PHASE="5/install"
+phase "Phase 5: ./homeserver.sh install -y -h $TEST_HOSTNAME"
+
+# Test overlay has platform_services=[caddy,dashboard], apps=[], so -y
+# install rebuilds the base platform only. caddy_acme_token + smtp_*
+# come from the test overlay's vaulted inventory.
+cd "$REPO_DIR"
+./homeserver.sh install -y -h "$TEST_HOSTNAME" 2>&1 | tail -30
+ok "Platform installed"
+
+# =============================================================================
+# PHASE 6: probe caddy + dashboard
+# =============================================================================
+CURRENT_PHASE="6/caddy-probe"
+phase "Phase 6: assert caddy + dashboard reachable"
+
+CADDY_DOMAIN=$(./homeserver.sh secret caddy_domain 2>/dev/null || true)
+if [[ -z "$CADDY_DOMAIN" ]]; then
+    # Not stored as a secret — read directly from inventory.
+    CADDY_DOMAIN=$(python3 -c "
+import yaml
+with open('$PROD_OVERLAY/inventory/host_vars/$TEST_HOSTNAME/10-caddy.yml') as f:
+    print(yaml.safe_load(f).get('caddy_domain', '').strip('\"'))")
+fi
+[[ -n "$CADDY_DOMAIN" ]] || { fail "Could not resolve caddy_domain"; exit 1; }
+log "caddy_domain: $CADDY_DOMAIN"
+
+# Dashboard subdomain doesn't exist for an apps=[] install — caddy still
+# serves /dashboard on the apex. Probe both 200 and accept 200/302/204.
+status=$(curl -sk -o /dev/null -w "%{http_code}" "https://$CADDY_DOMAIN/" || true)
+if [[ "$status" =~ ^(200|301|302)$ ]]; then
+    ok "Caddy serves apex: HTTP $status"
+else
+    fail "Caddy apex returned HTTP $status"
+    exit 1
+fi
+
+# =============================================================================
+# PHASE 7: add nextcloud (role's tasks/verify.yml runs inside the playbook)
+# =============================================================================
+CURRENT_PHASE="7/add-nextcloud"
+phase "Phase 7: ./homeserver.sh add nextcloud -y"
+
+./homeserver.sh add nextcloud -y 2>&1 | tail -30
+ok "nextcloud added (role verify passed inline)"
+
+# =============================================================================
+# PHASE 8: upload fixture files via WebDAV
+# =============================================================================
+CURRENT_PHASE="8/upload-fixtures"
+phase "Phase 8: upload fixtures into Nextcloud"
+
+NEXTCLOUD_ADMIN_PASSWORD=$(./homeserver.sh secret nextcloud_admin_password 2>/dev/null | tail -1)
+export NEXTCLOUD_ADMIN_PASSWORD
+NEXTCLOUD_URL="https://cloud.$CADDY_DOMAIN"
+python3 "$STAGING_DIR/test_e2e/upload_nextcloud_files.py" \
+    --url "$NEXTCLOUD_URL" \
+    --user ncadmin \
+    --password-from-env NEXTCLOUD_ADMIN_PASSWORD \
+    --fixtures-dir "$STAGING_DIR/fixtures" \
+    || { fail "Upload failed"; exit 1; }
+unset NEXTCLOUD_ADMIN_PASSWORD
+ok "All fixtures uploaded"
+
+# =============================================================================
+# PHASE 9: add backup
+# =============================================================================
+CURRENT_PHASE="9/add-backup"
+phase "Phase 9: ./homeserver.sh add backup -y"
+
+# Test overlay should carry backup_nas_ip already; if not, the install
+# walker prompts. -y mode requires it to be in inventory.
+./homeserver.sh add backup -y 2>&1 | tail -30
+ok "backup added (role verify passed inline, snapshot-trigger probe was off)"
+
+# =============================================================================
+# PHASE 10: trigger backup now (don't wait until 02:00) and wait for completion
+# =============================================================================
+CURRENT_PHASE="10/run-backup"
+phase "Phase 10: trigger nightly backup immediately, wait for finish"
+
+sudo systemctl start home-server-backup.service
+log "backup service started; polling for completion (timeout ${BACKUP_WAIT_TIMEOUT}s)"
+elapsed=0
+while sudo systemctl is-active --quiet home-server-backup.service; do
+    sleep 15
+    elapsed=$((elapsed + 15))
+    if (( elapsed >= BACKUP_WAIT_TIMEOUT )); then
+        fail "Backup did not finish within ${BACKUP_WAIT_TIMEOUT}s"
+        sudo journalctl -u home-server-backup.service --no-pager -n 20
+        exit 1
+    fi
+    log "still running… (${elapsed}s)"
+done
+ok "Backup service finished after ${elapsed}s"
+
+# =============================================================================
+# PHASE 11: assert log shows clean run
+# =============================================================================
+CURRENT_PHASE="11/log-check"
+phase "Phase 11: assert backup log shows 0 errors"
+
+if sudo tail -50 /var/log/home-server-backup.log | grep -q "=== Backup finished (0 errors) ==="; then
+    ok "Log shows 0 errors"
+else
+    fail "Last backup did not finish cleanly. Log tail:"
+    sudo tail -30 /var/log/home-server-backup.log
+    exit 1
+fi
+
+# =============================================================================
+# PHASE 12: verify fixture files made it into the NAS tarball
+# =============================================================================
+CURRENT_PHASE="12/backup-contents"
+phase "Phase 12: assert fixtures landed in NAS tarball"
+
+# Read NAS coords from inventory.
+NAS_HOST=$(python3 -c "
+import yaml
+with open('$PROD_OVERLAY/inventory/host_vars/$TEST_HOSTNAME/50-backup.yml') as f:
+    print(yaml.safe_load(f)['backup_nas_hostname'])")
+NAS_VOLUME=$(python3 -c "
+import yaml
+with open('$PROD_OVERLAY/inventory/host_vars/$TEST_HOSTNAME/50-backup.yml') as f:
+    print(yaml.safe_load(f)['backup_nas_volume'])")
+log "Mounting $NAS_HOST:$NAS_VOLUME/backup-$TEST_HOSTNAME"
+
+FIXTURE_NAMES=()
+for f in "$STAGING_DIR/fixtures"/payload-*.txt; do
+    FIXTURE_NAMES+=("$(basename "$f")")
+done
+
+python3 "$STAGING_DIR/test_e2e/verify_backup_contents.py" \
+    --mount-and-check \
+    --nas-host "$NAS_HOST" \
+    --nas-volume "$NAS_VOLUME" \
+    --share-name "backup-$TEST_HOSTNAME" \
+    --role nextcloud \
+    --volume nextcloud-data \
+    --expect "${FIXTURE_NAMES[@]}" \
+    || { fail "Tarball did not contain every fixture"; exit 1; }
+ok "All ${#FIXTURE_NAMES[@]} fixture(s) present in backup tarball"
+
+# =============================================================================
+# All phases passed
+# =============================================================================
+CURRENT_PHASE="(done)"
+phase "E2E PASSED"
+log "All 12 phases green. Total wall time: $SECONDS s"

--- a/scripts/test_e2e/upload_nextcloud_files.py
+++ b/scripts/test_e2e/upload_nextcloud_files.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+scripts/test_e2e/upload_nextcloud_files.py — upload fixture files
+into Nextcloud via WebDAV.
+
+Used by scripts/test_e2e.sh to populate the running Nextcloud instance
+with deterministic test data before triggering a backup. The same
+filenames are looked up in the backup tarball by
+verify_backup_contents.py, so any mid-pipeline data loss is caught.
+
+Auth is HTTP Basic with the admin user from inventory. The runner
+fetches the password via `homeserver.sh secret nextcloud_admin_password`
+(ASCII-clean since PR #291) and passes it as --password-from-env.
+
+Exit code: 0 on every PUT returning 201/204/207; non-zero otherwise.
+"""
+
+import argparse
+import os
+import sys
+import urllib.parse
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    sys.exit("ERROR: python-requests not installed.")
+try:
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except ImportError:
+    pass
+
+
+def upload(base_url, user, password, src_path):
+    """PUT src_path into Nextcloud at /remote.php/dav/files/{user}/{name}."""
+    dest_url = (f"{base_url.rstrip('/')}/remote.php/dav/files/"
+                f"{urllib.parse.quote(user)}/{urllib.parse.quote(src_path.name)}")
+    with open(src_path, "rb") as fh:
+        r = requests.put(
+            dest_url, data=fh,
+            auth=(user, password),
+            verify=False,           # caddy may still be issuing the cert
+            timeout=30,
+        )
+    return r.status_code, dest_url
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", required=True,
+                   help="Nextcloud base URL, e.g. https://cloud.simsons-t.dedyn.io")
+    p.add_argument("--user", default="ncadmin",
+                   help="Admin username (default: ncadmin)")
+    p.add_argument("--password-from-env", default="NEXTCLOUD_ADMIN_PASSWORD",
+                   help="Read admin password from this env var "
+                        "(default: NEXTCLOUD_ADMIN_PASSWORD)")
+    p.add_argument("--fixtures-dir", required=True,
+                   help="Directory containing the fixture files to upload")
+    p.add_argument("--glob", default="payload-*.txt",
+                   help="Fixture filename glob (default: payload-*.txt)")
+    args = p.parse_args()
+
+    password = os.environ.get(args.password_from_env)
+    if not password:
+        sys.exit(f"ERROR: env var {args.password_from_env} is empty or unset.")
+
+    fixtures = sorted(Path(args.fixtures_dir).glob(args.glob))
+    if not fixtures:
+        sys.exit(f"ERROR: no fixtures matched {args.glob} under {args.fixtures_dir}")
+
+    print(f"Uploading {len(fixtures)} fixture(s) to {args.url} as {args.user}")
+    failures = []
+    for src in fixtures:
+        status, url = upload(args.url, args.user, password, src)
+        marker = "OK " if status in (201, 204, 207) else "FAIL"
+        print(f"  [{marker}] {status} {url}")
+        if status not in (201, 204, 207):
+            failures.append((src.name, status))
+
+    if failures:
+        print(f"\n{len(failures)} upload(s) failed:")
+        for name, status in failures:
+            print(f"  - {name}: HTTP {status}")
+        sys.exit(1)
+    print(f"\nAll {len(fixtures)} fixture(s) uploaded successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_e2e/verify_backup_contents.py
+++ b/scripts/test_e2e/verify_backup_contents.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+scripts/test_e2e/verify_backup_contents.py — confirm a backup tarball
+contains the expected fixture files.
+
+Used by scripts/test_e2e.sh after a backup run to assert end-to-end
+data flow: the fixture filenames uploaded into Nextcloud via WebDAV
+should appear inside the nextcloud-data tarball on the NAS share. Any
+mid-pipeline data loss (rsync misconfig, tar exclude pattern, wrong
+volume) shows up as a missing file here.
+
+Two operating modes:
+
+  --mount-and-check        mount the NAS share read-only, find the
+                           latest tarball for the named role+volume,
+                           grep for expected fixture filenames, then
+                           unmount. The pattern the backup script
+                           actually deploys to NAS.
+
+  --tarball <path>         skip the mount step and look at a tarball
+                           the caller already located. Useful for
+                           debugging without NFS access.
+
+Exit 0 if every expected filename is present; non-zero otherwise.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def latest_tarball(share_root: Path, role: str, volume: str) -> Path:
+    """Return the most recent .tar.gz under share_root/<role>/<volume>/."""
+    candidates = sorted((share_root / role / volume).glob("*.tar.gz"),
+                        key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        sys.exit(f"ERROR: no *.tar.gz under {share_root / role / volume}")
+    return candidates[0]
+
+
+def names_in_tar(tar_path: Path) -> set:
+    """Return the set of basename(member) for every file in the tarball."""
+    names = set()
+    with tarfile.open(tar_path, "r:gz") as tf:
+        for m in tf.getmembers():
+            if m.isfile():
+                names.add(os.path.basename(m.name))
+    return names
+
+
+def check(tar_path: Path, expected: list[str]) -> int:
+    """Assert every name in `expected` is present inside `tar_path`."""
+    present = names_in_tar(tar_path)
+    print(f"Tarball: {tar_path} ({len(present)} files)")
+    missing = [n for n in expected if n not in present]
+    if missing:
+        print(f"MISSING: {len(missing)} fixture(s) not in tarball:")
+        for n in missing:
+            print(f"  - {n}")
+        return 1
+    print(f"OK: all {len(expected)} expected fixture(s) present.")
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--expect", nargs="+", required=True,
+                   help="Filename(s) that MUST be present in the tarball.")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--tarball", help="Path to an already-extracted tarball.")
+    g.add_argument("--mount-and-check", action="store_true",
+                   help="Mount the NAS share, find the latest tarball, check, unmount.")
+    p.add_argument("--nas-host", help="NAS hostname (with --mount-and-check)")
+    p.add_argument("--nas-volume", help="NAS volume root (with --mount-and-check)")
+    p.add_argument("--share-name", help="Share basename, e.g. backup-homeserver2")
+    p.add_argument("--role", help="Role subdir inside the share, e.g. nextcloud")
+    p.add_argument("--volume", help="Volume subdir inside the role, e.g. nextcloud-data")
+    args = p.parse_args()
+
+    if args.tarball:
+        sys.exit(check(Path(args.tarball), args.expect))
+
+    # --mount-and-check path
+    for needed in ("nas_host", "nas_volume", "share_name", "role", "volume"):
+        if not getattr(args, needed):
+            sys.exit(f"ERROR: --mount-and-check requires --{needed.replace('_', '-')}")
+
+    with tempfile.TemporaryDirectory(prefix="e2e-backup-mount-") as mnt:
+        nfs_src = f"{args.nas_host}:{args.nas_volume}/{args.share_name}"
+        try:
+            subprocess.run(
+                ["sudo", "mount", "-t", "nfs", "-o", "ro,noatime,vers=4",
+                 nfs_src, mnt],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            sys.exit(f"ERROR: NFS mount {nfs_src} → {mnt} failed: {exc}")
+        try:
+            tar_path = latest_tarball(Path(mnt), args.role, args.volume)
+            rc = check(tar_path, args.expect)
+        finally:
+            subprocess.run(["sudo", "umount", mnt], check=False)
+        sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/payload-1.txt
+++ b/tests/fixtures/payload-1.txt
@@ -1,0 +1,5 @@
+home-server E2E fixture file #1
+Reference token: HSE2E-PAYLOAD-1-2026
+This file is uploaded by scripts/test_e2e/upload_nextcloud_files.py
+and verified by scripts/test_e2e/verify_backup_contents.py.
+If you see these files outside an E2E test run, something went wrong.

--- a/tests/fixtures/payload-2.txt
+++ b/tests/fixtures/payload-2.txt
@@ -1,0 +1,5 @@
+home-server E2E fixture file #2
+Reference token: HSE2E-PAYLOAD-2-2026
+This file is uploaded by scripts/test_e2e/upload_nextcloud_files.py
+and verified by scripts/test_e2e/verify_backup_contents.py.
+If you see these files outside an E2E test run, something went wrong.

--- a/tests/fixtures/payload-3.txt
+++ b/tests/fixtures/payload-3.txt
@@ -1,0 +1,5 @@
+home-server E2E fixture file #3
+Reference token: HSE2E-PAYLOAD-3-2026
+This file is uploaded by scripts/test_e2e/upload_nextcloud_files.py
+and verified by scripts/test_e2e/verify_backup_contents.py.
+If you see these files outside an E2E test run, something went wrong.

--- a/tests/fixtures/payload-4.txt
+++ b/tests/fixtures/payload-4.txt
@@ -1,0 +1,5 @@
+home-server E2E fixture file #4
+Reference token: HSE2E-PAYLOAD-4-2026
+This file is uploaded by scripts/test_e2e/upload_nextcloud_files.py
+and verified by scripts/test_e2e/verify_backup_contents.py.
+If you see these files outside an E2E test run, something went wrong.

--- a/tests/fixtures/payload-5.txt
+++ b/tests/fixtures/payload-5.txt
@@ -1,0 +1,5 @@
+home-server E2E fixture file #5
+Reference token: HSE2E-PAYLOAD-5-2026
+This file is uploaded by scripts/test_e2e/upload_nextcloud_files.py
+and verified by scripts/test_e2e/verify_backup_contents.py.
+If you see these files outside an E2E test run, something went wrong.


### PR DESCRIPTION
Sequel to PR #294. Adds the orchestrator that drives a full lifecycle end-to-end on homeserver2 — uninstall, install platform, add nextcloud, upload fixtures, add backup, run + verify backup, verify fixtures made it into the NAS tarball.

## What's in this PR

### `scripts/test_e2e.sh` — 12-phase driver

| Phase | What runs |
|---|---|
| 0 | Pre-flight: hostname guard, test overlay present, prod overlay clean, no backup mid-flight, confirmation prompt (skipped with -y) |
| 1 | Stage helpers + fixtures to `/tmp` (so they survive the uninstall) |
| 2 | Park prod overlay aside, rename test overlay into its canonical path |
| 3 | `./homeserver.sh uninstall` |
| 4 | Re-clone repo (uninstall wiped it) |
| 5 | `./homeserver.sh install -y -h homeserver2` (platform only) |
| 6 | Assert caddy serves apex with HTTP 200/301/302 |
| 7 | `./homeserver.sh add nextcloud -y` (role's verify.yml runs inline per #294) |
| 8 | Upload 5 fixture files via WebDAV |
| 9 | `./homeserver.sh add backup -y` (role's verify.yml runs inline) |
| 10 | `systemctl start home-server-backup.service`, poll until idle |
| 11 | Grep `/var/log/home-server-backup.log` for `0 errors` |
| 12 | Mount NAS share read-only, find latest `nextcloud-data` tarball, assert all 5 fixture filenames are inside |

EXIT trap always runs cleanup: park-swap-back, then staging cleanup. Pre-flight refuses to start if a previous run left `~/home-server-private.parked-by-e2e/` around (= last test crashed mid-flight; operator must inspect first).

### `scripts/test_e2e/upload_nextcloud_files.py`

WebDAV PUT of every `payload-*.txt` fixture into Nextcloud as `ncadmin`. Reads password from env (default `NEXTCLOUD_ADMIN_PASSWORD`) so the plaintext doesn't show up on the command line. Per-file PASS/FAIL summary on stdout.

### `scripts/test_e2e/verify_backup_contents.py`

Two modes:
- `--tarball <path>` — inspect a tarball you already located.
- `--mount-and-check` — mount the named NAS share read-only, find the newest `*.tar.gz`, grep for expected basenames, unmount.

### `tests/fixtures/payload-{1..5}.txt`

Small static fixtures with distinctive ASCII tokens (`HSE2E-PAYLOAD-N`) so finding them in a backup is unambiguous.

### `docs/Testing.md`

Operator how-to: one-time setup of `~/home-server-test-overlay/`, running the test, reading the output, extending coverage in follow-up PRs.

## Smoke-tested

- [x] `bash -n` clean, `shellcheck` default-profile clean.
- [x] Python helpers: `--help` renders, `py_compile` passes.
- [x] Pre-flight hostname guard fires correctly when run on the laptop (refuses with override hint).
- [x] Pre-flight test-overlay guard fires correctly on homeserver2 before the operator has seeded the test overlay (refuses with docs reference).

## Why no full E2E run in this PR

Phases 2-12 require the operator's one-time setup of `~/home-server-test-overlay/` per `docs/Testing.md`. That setup is operator-specific (their deSEC token, their SMTP creds, their NAS) — I can't seed it from a PR. Once the operator seeds the test overlay, the first `./scripts/test_e2e.sh -y` run will be the real validation. I expect some bumps on the first end-to-end run; will follow up with fix-up commits as they surface.

## Out of scope (next PRs)

- `roles/apps/paperless-ngx/tasks/verify.yml` + phases 13-15 of the orchestrator (add paperless, upload PDFs, verify backup includes them).
- Same shape for jellyfin, entephoto, syncthing, music-assistant.
- Restore round-trip verification.
- CI integration (GitHub Actions matrix run on PRs).
- Nightly cron + mail-on-failure wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)