### PR TITLE
fix(install): detect local overlay, drop -i requirement for -y rebuild

### DIFF
--- a/homeserver.sh
+++ b/homeserver.sh
@@ -1517,12 +1517,32 @@ OVERLAY_DIR="$HOME/home-server-private"
 OVERLAY_URL=""
 USE_EXISTING_INVENTORY=false
 
+# Rebuild path — if the overlay is already in place locally (.git +
+# vault.pw + inventory for this hostname), use it as-is. No network
+# round-trip, no operator having to remember the overlay URL after a
+# `homeserver.sh uninstall + reinstall` cycle. Same detection logic
+# used downstream (host_vars_dir_has_content), just hoisted up so -y
+# can short-circuit the "must pass -i" requirement.
+SERVER_HOSTNAME_TENTATIVE="${HOSTNAME_FLAG:-$(hostname -s 2>/dev/null)}"
+if [[ -z "$OVERLAY_URL_FLAG" \
+   && -d "$OVERLAY_DIR/.git" \
+   && -r "$OVERLAY_DIR/vault.pw" ]] \
+   && host_vars_dir_has_content "$OVERLAY_DIR/inventory/host_vars/$SERVER_HOSTNAME_TENTATIVE"; then
+    OVERLAY_URL_LOCAL=true
+    # Synthesise an OVERLAY_URL so downstream `[[ -n "$OVERLAY_URL" ]]`
+    # branches still run (we want the vault.pw + symlink wiring; we
+    # just don't want to clone or pull). The pull step is gated below.
+    OVERLAY_URL="(local: $OVERLAY_DIR)"
+    ok "Overlay already in place at $OVERLAY_DIR — reusing without clone."
+fi
+
 # Overlay repo URL: CLI flag wins, else interactive prompt (silent in
-# -y mode — empty is a valid "no overlay" answer).
+# -y mode — empty is a valid "no overlay" answer; the rebuild-detection
+# above can also have set OVERLAY_URL).
 if [[ -n "$OVERLAY_URL_FLAG" ]]; then
     OVERLAY_URL="$OVERLAY_URL_FLAG"
     ok "Overlay repo: $OVERLAY_URL (from -i)"
-elif [[ "$YES_FLAG" != "true" ]]; then
+elif [[ -z "$OVERLAY_URL" && "$YES_FLAG" != "true" ]]; then
     echo
     echo -e "${BOLD}--- Private overlay repo (optional) ---${NC}"
     echo
@@ -1565,7 +1585,12 @@ if [[ -n "$OVERLAY_URL" ]]; then
         exit 1
     fi
 
-    if [[ ! -d "$OVERLAY_DIR/.git" ]]; then
+    if [[ "${OVERLAY_URL_LOCAL:-}" == "true" ]]; then
+        # Rebuild-detection path — overlay was already in place when we
+        # started. Skip both clone and pull; the operator's local tree
+        # is authoritative.
+        ok "Using overlay tree at $OVERLAY_DIR as-is (no clone, no pull)."
+    elif [[ ! -d "$OVERLAY_DIR/.git" ]]; then
         info "Cloning overlay into $OVERLAY_DIR ..."
         git clone "$OVERLAY_URL" "$OVERLAY_DIR"
     else


### PR DESCRIPTION
Hit while wiring up the E2E test runner (#295). Same issue is also a real UX bug for any operator running \`uninstall + install -y\` to rebuild against state that's already on disk — they shouldn't need to remember the overlay URL.

## Repro

\`\`\`bash
ssh homeserver2
cd ~/home-server
./homeserver.sh install -y -h homeserver2
# ==> ERROR: -y mode requires an inventory source (-i <overlay-url> or pre-staged inventory).
\`\`\`

…even though \`~/home-server-private/\` is fully populated.

## Fix

Add a "local overlay already in place" detection branch BEFORE the \`-y\` guard. If \`-i\` wasn't passed AND \`$HOME/home-server-private\` has \`.git\` + \`vault.pw\` + inventory for the current hostname, treat that as the source of truth: synthesise a non-empty \`OVERLAY_URL\` so the downstream symlink wiring still fires, but **skip both clone and pull** (the local tree is authoritative).

Reuses \`host_vars_dir_has_content\` from #266 — same helper the downstream code uses.

## Verified on homeserver2

\`\`\`
==> Step 3/7: Installing Ansible Galaxy dependencies...
==> Overlay already in place at /home/ansible/home-server-private — reusing without clone.
==> Using overlay tree at /home/ansible/home-server-private as-is (no clone, no pull).
==> Overlay has existing inventory for 'homeserver2' — will reuse as defaults.
==> Step 4/7: Setting up Ansible Vault...
\`\`\`

Detection fires; install proceeds normally.

## Why this matters for the E2E runner

The orchestrator's Phase 5 calls \`./homeserver.sh install -y -h homeserver2\` after renaming the test overlay into place. Without this fix Phase 5 would always fail. With this fix, the test runner becomes reliable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)