### PR TITLE
fix(e2e): emit real ESC bytes, not literal \\033[ strings

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -70,8 +70,13 @@ done
 # -----------------------------------------------------------------------------
 # Colors (TTY-aware, mirrors homeserver.sh PR #291)
 # -----------------------------------------------------------------------------
+# Use $'…' ANSI-C quoting so the strings hold the ACTUAL ESC byte, not
+# the literal backslash-zero-three-three sequence. Earlier we used
+# plain '…' quoting and `printf '%s'`, which printed the escape codes
+# verbatim — same class of bug as PR #291, different invocation.
 if [[ -t 1 ]]; then
-    R='\033[0;31m'; G='\033[0;32m'; Y='\033[1;33m'; C='\033[0;36m'; B='\033[1m'; N='\033[0m'
+    R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[1;33m'
+    C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
 else
     R=''; G=''; Y=''; C=''; B=''; N=''
 fi


### PR DESCRIPTION
First end-to-end run on homeserver2 surfaced the orchestrator was printing literal \`\033[0;31m  ✗ Failed...\` (visible backslash-zero-three-three) instead of red ✗. Same bug class as #291, different invocation pattern.

## Root cause

\`\`\`bash
R='\033[0;31m'                # single-quote = literal — R holds \\033[0;31m as 8 chars
printf '%s' "\$R"             # %s doesn't interpret escapes — prints \\033[0;31m verbatim
\`\`\`

Compare \`homeserver.sh\` which uses \`echo -e\` (interprets escapes) — that's why the homeserver.sh side renders colors correctly even though it defines colors the same way.

## Fix

Switch the color-var definitions to \$'…' ANSI-C quoting:

\`\`\`bash
R=$'\033[0;31m'               # ANSI-C quoting interprets escape at parse time
\`\`\`

R now holds the actual ESC byte. \`printf '%s' "\$R"\` then emits the real escape sequence and terminals render colors.

## Verified

Under a real PTY:
- \`\\x1b[\` (real ESC byte) present in output
- \`\\\\033[\` (literal backslash-zero-three-three) gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)